### PR TITLE
Allow passing extra compiler arguments when configuring compiler

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -221,6 +221,9 @@ class CliArgs {
     )
     var showVersion: Boolean = false
 
+    @Parameter(description = "Options to pass to the Kotlin compiler.", hidden = true)
+    var freeCompilerArgs: List<String> = mutableListOf()
+
     val failurePolicy: RulesSpec.FailurePolicy
         get() {
             return when (val minSeverity = failOnSeverity) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -81,6 +81,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             apiVersion = args.apiVersion?.versionString
             classpath = args.classpath?.trim()
             jdkHome = args.jdkHome
+            freeCompilerArgs = args.freeCompilerArgs
         }
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -242,12 +242,6 @@ internal class CliArgsSpec {
             assertThatExceptionOfType(HelpRequest::class.java)
                 .isThrownBy { parseArguments(arrayOf("--help")) }
         }
-
-        @Test
-        fun `throws HandledArgumentViolation on wrong options`() {
-            assertThatExceptionOfType(HandledArgumentViolation::class.java)
-                .isThrownBy { parseArguments(arrayOf("--unknown-to-us-all")) }
-        }
     }
 
     @Test

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -297,6 +297,20 @@ internal class CliArgsSpec {
                 .isThrownBy { parseArguments(arrayOf("--language-version", "2")) }
                 .withMessageStartingWith("\"2\" passed to --language-version, expected one of [1.0, 1.1, 1.2, 1.3, ")
         }
+
+        @Test
+        fun `valid compiler args are accepted`() {
+            val args = arrayOf(
+                "-Xcontext-receivers",
+                "-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
+            )
+            val spec = parseArguments(args).toSpec()
+
+            assertThat(spec.compilerSpec.freeCompilerArgs).containsOnly(
+                "-Xcontext-receivers",
+                "-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
+            )
+        }
     }
 
     @Nested

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -319,9 +319,25 @@ class RunnerSpec {
         }
     }
 
-    @Test
-    fun `throws HandledArgumentViolation on wrong options`() {
-        assertThatIllegalStateException()
-            .isThrownBy { executeDetekt("--unknown-to-us-all") }
+    @Nested
+    inner class CompilerArgs {
+        @Test
+        fun `accepts valid compiler options that are not natively handed by detekt CLI`() {
+            val path = resourceAsPath("/cases/CleanPoko.kt")
+            assertThatCode {
+                executeDetekt(
+                    "--input",
+                    path.toString(),
+                    "-Xcontext-receivers",
+                    "-opt-in=org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi",
+                )
+            }.doesNotThrowAnyException()
+        }
+
+        @Test
+        fun `throws HandledArgumentViolation on wrong options`() {
+            assertThatIllegalStateException()
+                .isThrownBy { executeDetekt("--unknown-to-us-all") }
+        }
     }
 }

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.cli.executeDetekt
 import io.gitlab.arturbosch.detekt.cli.parseArguments
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -316,5 +317,11 @@ class RunnerSpec {
                 .contains("$modificationMessagePrefix${inputPath.absolutePathString()}$modificationMessageSuffix")
             assertThat(inputPath).content().isEqualTo("class Test {\r\n\r\n}\r\n")
         }
+    }
+
+    @Test
+    fun `throws HandledArgumentViolation on wrong options`() {
+        assertThatIllegalStateException()
+            .isThrownBy { executeDetekt("--unknown-to-us-all") }
     }
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -39,6 +39,7 @@ internal class EnvironmentFacade(
             compilerSpec.languageVersion,
             compilerSpec.jvmTarget,
             compilerSpec.jdkHome,
+            compilerSpec.freeCompilerArgs,
             printStream,
         )
         createKotlinCoreEnvironment(

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -55,6 +55,7 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFailOnSeverity ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFreeCompilerArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
@@ -80,6 +81,7 @@ public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
+	public abstract fun getFreeCompilerArgs ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -33,6 +33,7 @@ internal fun Project.registerJvmCompilationDetektTask(
         /* Note: jvmTarget convention is also set in setDetektTaskDefaults. There may be a race between setting it here
            as well, but they should both set the same value. This should possibly be revisited in the future. */
         detektTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
+        detektTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
 
         detektTask.baseline.convention(
             project.layout.file(
@@ -73,6 +74,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         /* Note: jvmTarget convention is also set in setCreateBaselineTaskDefaults. There may be a race between setting
            it here as well, but they should both set the same value. This should possibly be revisited in the future. */
         createBaselineTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
+        createBaselineTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
 
         createBaselineTask.baseline.convention(
             project.layout.file(

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -19,17 +19,20 @@ import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
 import io.gitlab.arturbosch.detekt.invoke.FailOnSeverityArgument
+import io.gitlab.arturbosch.detekt.invoke.FreeArgs
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.Action
+import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.CacheableTask
@@ -135,6 +138,10 @@ abstract class Detekt @Inject constructor(
 
     private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
 
+    @get:Input
+    @get:Incubating
+    abstract val freeCompilerArgs: ListProperty<String>
+
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
@@ -165,7 +172,8 @@ abstract class Detekt @Inject constructor(
                 minSeverity = failOnSeverity.get()
             ),
             BasePathArgument(basePath.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get())
+            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get()),
+            FreeArgs(freeCompilerArgs.get()),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
 
     @InputFiles

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -14,15 +14,18 @@ import io.gitlab.arturbosch.detekt.invoke.DebugArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
+import io.gitlab.arturbosch.detekt.invoke.FreeArgs
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
+import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.CacheableTask
@@ -120,6 +123,10 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     @get:Internal
     abstract val jdkHome: DirectoryProperty
 
+    @get:Input
+    @get:Incubating
+    abstract val freeCompilerArgs: ListProperty<String>
+
     @get:Internal
     internal val arguments
         get() = listOf(
@@ -138,7 +145,8 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             AutoCorrectArgument(autoCorrect.get()),
             AllRulesArgument(allRules.get()),
             BasePathArgument(basePath.orNull),
-            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get())
+            DisableDefaultRuleSetArgument(disableDefaultRuleSets.get()),
+            FreeArgs(freeCompilerArgs.get()),
         ).flatMap(CliArgument::toArgument)
 
     @InputFiles

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -97,6 +97,10 @@ internal data class CustomReportArgument(val reportId: String, val file: Regular
     override fun toArgument() = listOf(REPORT_PARAMETER, "$reportId:${file.asFile.absolutePath}")
 }
 
+internal data class FreeArgs(val args: List<String>) : CliArgument() {
+    override fun toArgument(): List<String> = args
+}
+
 internal data class BasePathArgument(val basePath: String?) : CliArgument() {
     override fun toArgument() = basePath?.let { listOf(BASE_PATH_PARAMETER, it) }.orEmpty()
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -13,6 +13,8 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
+import org.jetbrains.kotlin.cli.jvm.configureAdvancedJvmOptions
+import org.jetbrains.kotlin.cli.jvm.setupJvmSpecificArguments
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.Disposable
 import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
@@ -68,6 +70,7 @@ fun createCompilerConfiguration(
     languageVersion: String?,
     jvmTarget: String,
     jdkHome: Path?,
+    freeCompilerArgs: List<String>,
     printStream: PrintStream,
 ): CompilerConfiguration {
     val javaFiles = pathsToAnalyze.flatMap { path ->
@@ -98,6 +101,7 @@ fun createCompilerConfiguration(
         }
         add("-jvm-target")
         add(jvmTarget)
+        addAll(freeCompilerArgs)
     }
 
     parseCommandLineArguments(args, jvmCompilerArguments)
@@ -113,6 +117,8 @@ fun createCompilerConfiguration(
             PrintingMessageCollector(printStream, MessageRenderer.PLAIN_FULL_PATHS, false)
         )
         setupLanguageVersionSettings(jvmCompilerArguments)
+        setupJvmSpecificArguments(jvmCompilerArguments)
+        configureAdvancedJvmOptions(jvmCompilerArguments)
 
         if (jdkHome != null) {
             put(JVMConfigurationKeys.JDK_HOME, jdkHome.toFile())

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -100,6 +100,7 @@ public abstract interface class io/github/detekt/tooling/api/spec/BaselineSpec {
 public abstract interface class io/github/detekt/tooling/api/spec/CompilerSpec {
 	public abstract fun getApiVersion ()Ljava/lang/String;
 	public abstract fun getClasspath ()Ljava/lang/String;
+	public abstract fun getFreeCompilerArgs ()Ljava/util/List;
 	public abstract fun getJdkHome ()Ljava/nio/file/Path;
 	public abstract fun getJvmTarget ()Ljava/lang/String;
 	public abstract fun getLanguageVersion ()Ljava/lang/String;
@@ -237,11 +238,13 @@ public final class io/github/detekt/tooling/dsl/CompilerSpecBuilder : io/github/
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getApiVersion ()Ljava/lang/String;
 	public final fun getClasspath ()Ljava/lang/String;
+	public final fun getFreeCompilerArgs ()Ljava/util/List;
 	public final fun getJdkHome ()Ljava/nio/file/Path;
 	public final fun getJvmTarget ()Ljava/lang/String;
 	public final fun getLanguageVersion ()Ljava/lang/String;
 	public final fun setApiVersion (Ljava/lang/String;)V
 	public final fun setClasspath (Ljava/lang/String;)V
+	public final fun setFreeCompilerArgs (Ljava/util/List;)V
 	public final fun setJdkHome (Ljava/nio/file/Path;)V
 	public final fun setJvmTarget (Ljava/lang/String;)V
 	public final fun setLanguageVersion (Ljava/lang/String;)V

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/CompilerSpec.kt
@@ -32,4 +32,9 @@ interface CompilerSpec {
      * the JRE from the runtime environment.
      */
     val jdkHome: Path?
+
+    /**
+     * Options to pass to the Kotlin compiler.
+     */
+    val freeCompilerArgs: List<String>
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -11,8 +11,10 @@ class CompilerSpecBuilder : Builder<CompilerSpec> {
     var apiVersion: String? = null
     var classpath: String? = null
     var jdkHome: Path? = null
+    var freeCompilerArgs: List<String> = emptyList()
 
-    override fun build(): CompilerSpec = CompilerModel(jvmTarget, languageVersion, apiVersion, classpath, jdkHome)
+    override fun build(): CompilerSpec =
+        CompilerModel(jvmTarget, languageVersion, apiVersion, classpath, jdkHome, freeCompilerArgs)
 }
 
 private data class CompilerModel(
@@ -21,4 +23,5 @@ private data class CompilerModel(
     override val apiVersion: String?,
     override val classpath: String?,
     override val jdkHome: Path?,
+    override val freeCompilerArgs: List<String>,
 ) : CompilerSpec


### PR DESCRIPTION
Builds on #7403, adding support for parsing and applying non-standard compiler flags that configure language settings (e.g. `-Xcontext-receivers`, `-Xexplicit-api` and `-opt-in` via `setupLanguageVersionSettings`), setting other Kotlin/JVM arguments (e.g. `-Xfriend-paths` via `setupJvmSpecificArguments`) and advanced Kotlin/JVM options (e.g. `-Xjvm-enable-preview` via `configureAdvancedJvmOptions`).

Some flags require additional code before they're properly supported by the compiler configuration, e.g. friend paths, but that will be handled in follow up PRs.

Required for #4465