### PR TITLE
Don't automatically add reflect & stdlib to classpath via Gradle

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -175,6 +175,8 @@ abstract class Detekt @Inject constructor(
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.get()),
             FreeArgs(freeCompilerArgs.get()),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
+            .plus("-no-stdlib")
+            .plus("-no-reflect")
 
     @InputFiles
     @SkipWhenEmpty

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -148,6 +148,8 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             DisableDefaultRuleSetArgument(disableDefaultRuleSets.get()),
             FreeArgs(freeCompilerArgs.get()),
         ).flatMap(CliArgument::toArgument)
+            .plus("-no-stdlib")
+            .plus("-no-reflect")
 
     @InputFiles
     @SkipWhenEmpty


### PR DESCRIPTION
This matches the behaviour of the Kotlin Gradle plugin:
https://github.com/JetBrains/kotlin/blob/v2.0.0/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/dsl/KotlinJvmCompilerOptionsHelper.kt#L21-L22

Stacks on #7408

Required for #4465