### PR TITLE
Automatically handle explicit API option in JVM compilation analysis tasks

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -1,5 +1,6 @@
 package dev.detekt.gradle.plugin
 
+import dev.detekt.gradle.plugin.internal.mapExplicitArgMode
 import io.gitlab.arturbosch.detekt.Detekt
 import io.gitlab.arturbosch.detekt.DetektCreateBaselineTask
 import io.gitlab.arturbosch.detekt.DetektPlugin
@@ -96,6 +97,9 @@ class DetektBasePlugin : Plugin<Project> {
                                 }
                             )
                         )
+                        if (sourceSet.name == "main") {
+                            detektTask.explicitApi.convention(mapExplicitArgMode())
+                        }
                         detektTask.description = "Run detekt analysis for ${sourceSet.name} source set"
                     }
 
@@ -111,6 +115,9 @@ class DetektBasePlugin : Plugin<Project> {
                             )
                         )
 
+                        if (sourceSet.name == "main") {
+                            createBaselineTask.explicitApi.convention(mapExplicitArgMode())
+                        }
                         createBaselineTask.description = "Creates detekt baseline for ${sourceSet.name} source set"
                     }
                 }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -7,8 +7,11 @@ import io.gitlab.arturbosch.detekt.extensions.DetektExtension
 import io.gitlab.arturbosch.detekt.internal.addVariantName
 import io.gitlab.arturbosch.detekt.internal.existingVariantOrBaseFile
 import org.gradle.api.Project
+import org.gradle.api.provider.Provider
 import org.gradle.util.GradleVersion
+import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonOptions
+import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -38,6 +41,9 @@ internal fun Project.registerJvmCompilationDetektTask(
         detektTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
         detektTask.optIn.convention(siblingTask.compilerOptions.optIn)
         detektTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
+        if (compilation.name == "main") {
+            detektTask.explicitApi.convention(mapExplicitArgMode())
+        }
 
         detektTask.baseline.convention(
             project.layout.file(
@@ -83,6 +89,9 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         createBaselineTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
         createBaselineTask.optIn.convention(siblingTask.compilerOptions.optIn)
         createBaselineTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
+        if (compilation.name == "main") {
+            createBaselineTask.explicitApi.convention(mapExplicitArgMode())
+        }
 
         createBaselineTask.baseline.convention(
             project.layout.file(
@@ -99,3 +108,12 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         }
     }
 }
+
+internal fun Project.mapExplicitArgMode(): Provider<String> =
+    provider {
+        when (kotlinExtension.explicitApi) {
+            ExplicitApiMode.Strict -> "strict"
+            ExplicitApiMode.Warning -> "warning"
+            else -> null
+        }
+    }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -18,6 +18,7 @@ import io.gitlab.arturbosch.detekt.invoke.DefaultReportArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
+import io.gitlab.arturbosch.detekt.invoke.ExplicitApiArgument
 import io.gitlab.arturbosch.detekt.invoke.FailOnSeverityArgument
 import io.gitlab.arturbosch.detekt.invoke.FreeArgs
 import io.gitlab.arturbosch.detekt.invoke.FriendPathArgs
@@ -154,6 +155,10 @@ abstract class Detekt @Inject constructor(
     @get:Incubating
     abstract val freeCompilerArgs: ListProperty<String>
 
+    @get:Input
+    @get:Optional
+    internal abstract val explicitApi: Property<String>
+
     init {
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
@@ -189,6 +194,7 @@ abstract class Detekt @Inject constructor(
             OptInArguments(optIn.get()),
             FriendPathArgs(friendPaths),
             NoJdkArgument(noJdk.get()),
+            ExplicitApiArgument(explicitApi.orNull),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
             .plus("-no-stdlib")
             .plus("-no-reflect")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -14,6 +14,7 @@ import io.gitlab.arturbosch.detekt.invoke.DebugArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.DisableDefaultRuleSetArgument
+import io.gitlab.arturbosch.detekt.invoke.ExplicitApiArgument
 import io.gitlab.arturbosch.detekt.invoke.FreeArgs
 import io.gitlab.arturbosch.detekt.invoke.FriendPathArgs
 import io.gitlab.arturbosch.detekt.invoke.InputArgument
@@ -139,6 +140,10 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     @get:Incubating
     abstract val freeCompilerArgs: ListProperty<String>
 
+    @get:Input
+    @get:Optional
+    internal abstract val explicitApi: Property<String>
+
     @get:Internal
     internal val arguments
         get() = listOf(
@@ -162,6 +167,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             OptInArguments(optIn.get()),
             FriendPathArgs(friendPaths),
             NoJdkArgument(noJdk.get()),
+            ExplicitApiArgument(explicitApi.orNull),
         ).flatMap(CliArgument::toArgument)
             .plus("-no-stdlib")
             .plus("-no-reflect")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -29,6 +29,7 @@ private const val JDK_HOME_PARAMETER = "--jdk-home"
 private const val BASE_PATH_PARAMETER = "--base-path"
 private const val OPT_IN_PARAMETER = "-opt-in"
 private const val NO_JDK_PARAMETER = "-no-jdk"
+private const val EXPLICIT_API_MODE = "-Xexplicit-api"
 
 /* parameters passed with single hyphen prefix must be passed at end of command line argument list so they get passed
    as freeCompilerArgs
@@ -172,3 +173,7 @@ internal data class OptInArguments(val list: List<String>) : CliArgument() {
 }
 
 internal data class NoJdkArgument(override val value: Boolean) : BoolCliArgument(value, NO_JDK_PARAMETER)
+
+internal data class ExplicitApiArgument(val mode: String?) : CliArgument() {
+    override fun toArgument() = mode?.let { listOf("$EXPLICIT_API_MODE=$it") }.orEmpty()
+}


### PR DESCRIPTION
Required for https://github.com/detekt/detekt/issues/4465, #3874 and https://github.com/detekt/detekt/issues/4647

This is a little different to the other options recently added to DGP for new compiler options. The option can only be set in Kotlin in the `kotlin` extension in Gradle scripts and cannot be set on individual Kotlin compilation tasks, so I've used the same convention for the detekt tasks - the compilation tasks will accept & pass the value to the compiler options used by detekt, so it's available for rules to use if they need to, but since it doesn't actually affect the compilation at all, and the Kotlin compilation tasks don't expose it either, I've kept it internal here too.