### PR TITLE
Add alias `PropertyName` for `VariableNaming` rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -392,6 +392,7 @@ naming:
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
+    aliases: ['PropertyName']
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.Alias
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Configuration
@@ -19,6 +20,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  * Reports variable names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
+@Alias("PropertyName")
 class VariableNaming(config: Config) : Rule(
     config,
     "Variable names should follow the naming convention set in the projects configuration."


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/7401

This only add `PropertyName` for `VariableNaming` rule. Other alias like `PrivatePropertyName`, `ConstPropertyName` as these rules of Idea doesn't match one to one with detekt rules