### PR TITLE
Exclude non-existent paths from classpath input

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -56,7 +56,7 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
     override fun toArgument() = if (!fileCollection.isEmpty) {
         listOf(
             CLASSPATH_PARAMETER,
-            fileCollection.joinToString(File.pathSeparator) { it.absolutePath }
+            fileCollection.files.filter(File::exists).joinToString(File.pathSeparator) { it.absolutePath }
         )
     } else {
         emptyList()


### PR DESCRIPTION
Avoids showing unnecessary warnings in debug output:
```
    warning: classpath entry points to a non-existent location
```
Matches behaviour of KotlinCompile task, see https://github.com/JetBrains/kotlin/blob/v2.0.0/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/tasks/KotlinCompile.kt#L262-L264