### PR TITLE
Add `BigDecimal(kotlin.String)` to `ForbiddenMethodCall`

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -632,9 +632,9 @@ style:
         value: 'kotlin.io.print'
       - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.println'
-      - reason: 'using `BigDecimal(kotlin.Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
+      - reason: 'using `BigDecimal(Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
         value: 'java.math.BigDecimal.<init>(kotlin.Double)'
-      - reason: 'using `BigDecimal(kotlin.String)` can result in `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
+      - reason: 'using `BigDecimal(String)` can result in `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
         value: 'java.math.BigDecimal.<init>(kotlin.String)'
   ForbiddenSuppress:
     active: false

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -632,8 +632,10 @@ style:
         value: 'kotlin.io.print'
       - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.println'
-      - reason: 'using `BigDecimal.<init>(kotlin.Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(kotlin.Double)` or `BigDecimal.<init>(kotlin.String)` instead.'
+      - reason: 'using `BigDecimal(kotlin.Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
         value: 'java.math.BigDecimal.<init>(kotlin.Double)'
+      - reason: 'using `BigDecimal(kotlin.String)` can result in `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
+        value: 'java.math.BigDecimal.<init>(kotlin.String)'
   ForbiddenSuppress:
     active: false
     rules: []

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -632,9 +632,9 @@ style:
         value: 'kotlin.io.print'
       - reason: 'println does not allow you to configure the output stream. Use a logger instead.'
         value: 'kotlin.io.println'
-      - reason: 'using `BigDecimal(Double)` can result in unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
+      - reason: 'using `BigDecimal(Double)` can result in unexpected floating point precision behavior. Use `BigDecimal.valueOf(Double)` or `String.toBigDecimalOrNull()` instead.'
         value: 'java.math.BigDecimal.<init>(kotlin.Double)'
-      - reason: 'using `BigDecimal(String)` can result in `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
+      - reason: 'using `BigDecimal(String)` can result in a `NumberFormatException`. Use `String.toBigDecimalOrNull()`'
         value: 'java.math.BigDecimal.<init>(kotlin.String)'
   ForbiddenSuppress:
     active: false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -65,9 +65,11 @@ class ForbiddenMethodCall(config: Config) : Rule(
         valuesWithReason(
             "kotlin.io.print" to "print does not allow you to configure the output stream. Use a logger instead.",
             "kotlin.io.println" to "println does not allow you to configure the output stream. Use a logger instead.",
-            "java.math.BigDecimal.<init>(kotlin.Double)" to "using `BigDecimal.<init>(kotlin.Double)` can result in " +
-                "unexpected float point precision behavior. Use `BigDecimal.valueOf(kotlin.Double)` or " +
-                "`BigDecimal.<init>(kotlin.String)` instead.",
+            "java.math.BigDecimal.<init>(kotlin.Double)" to "using `BigDecimal(Double)` can result in " +
+                "unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or " +
+                "`String.toBigDecimalOrNull()` instead.",
+            "java.math.BigDecimal.<init>(kotlin.String)" to "using `BigDecimal(String)` can result in " +
+                "`NumberFormatException`. Use `String.toBigDecimalOrNull()`",
         )
     ) { list ->
         list.map { Forbidden(fromFunctionSignature(it.value), it.reason) }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -66,9 +66,9 @@ class ForbiddenMethodCall(config: Config) : Rule(
             "kotlin.io.print" to "print does not allow you to configure the output stream. Use a logger instead.",
             "kotlin.io.println" to "println does not allow you to configure the output stream. Use a logger instead.",
             "java.math.BigDecimal.<init>(kotlin.Double)" to "using `BigDecimal(Double)` can result in " +
-                "unexpected float point precision behavior. Use `BigDecimal.valueOf(Double)` or " +
+                "unexpected floating point precision behavior. Use `BigDecimal.valueOf(Double)` or " +
                 "`String.toBigDecimalOrNull()` instead.",
-            "java.math.BigDecimal.<init>(kotlin.String)" to "using `BigDecimal(String)` can result in " +
+            "java.math.BigDecimal.<init>(kotlin.String)" to "using `BigDecimal(String)` can result in a " +
                 "`NumberFormatException`. Use `String.toBigDecimalOrNull()`",
         )
     ) { list ->

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -754,7 +754,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should report when using BigDecimal string constructor`() {
+            fun `should not report when using BigDecimal string constructor`() {
                 val code = """
                     import java.math.BigDecimal
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -754,11 +754,25 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should report nothing when using BigDecimal string constructor`() {
+            fun `should report when using BigDecimal string constructor`() {
                 val code = """
                     import java.math.BigDecimal
 
                     val x = BigDecimal("3.14")
+                """.trimIndent()
+                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                assertThat(findings).hasSize(1)
+                assertThat(findings.first()).hasMessage(
+                    "The method `java.math.BigDecimal.<init>(kotlin.String)` has " +
+                        "been forbidden: using `BigDecimal(String)` can result in " +
+                        "`NumberFormatException`. Use `String.toBigDecimalOrNull()`"
+                )
+            }
+
+            @Test
+            fun `should not report when using toBigDecimalOrNull method`() {
+                val code = """
+                    val x = "3.14".toBigDecimalOrNull()
                 """.trimIndent()
                 val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
                 assertThat(findings).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -754,7 +754,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             }
 
             @Test
-            fun `should not report when using BigDecimal string constructor`() {
+            fun `should report when using BigDecimal string constructor`() {
                 val code = """
                     import java.math.BigDecimal
 
@@ -764,7 +764,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first()).hasMessage(
                     "The method `java.math.BigDecimal.<init>(kotlin.String)` has " +
-                        "been forbidden: using `BigDecimal(String)` can result in " +
+                        "been forbidden: using `BigDecimal(String)` can result in a " +
                         "`NumberFormatException`. Use `String.toBigDecimalOrNull()`"
                 )
             }


### PR DESCRIPTION
Currently, we already have one forbidden method related to BigDecimal

Fixes https://github.com/detekt/detekt/issues/5977
