### PR TITLE
BracesOnIfStatements: fix false-positive when chained

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
@@ -1971,6 +1971,70 @@ class BracesOnIfStatementsSpec {
                     "if"(1)
                 ),
             )
+
+            @TestFactory
+            fun `no braces in chained expression are accepted`() = listOf(
+                flag(
+                    """
+                        if (true) {
+                            ""
+                        } else if (true) {
+                            ""
+                        } else {
+                            ""
+                        }.trim()
+                    """.trimIndent(),
+                    *NOTHING
+                ),
+                flag(
+                    """
+                        if (true) {
+                            ""
+                        } else if (true) {
+                            ""
+                        } else {
+                            ""
+                        }?.trim()
+                    """.trimIndent(),
+                    *NOTHING
+                ),
+                flag(
+                    """
+                        if (true) {
+                            ""
+                        } else if (true) {
+                            ""
+                        } else {
+                            ""
+                        } ?: ""
+                    """.trimIndent(),
+                    *NOTHING
+                ),
+                flag(
+                    """
+                        if (true) {
+                            true
+                        } else if (true) {
+                            true
+                        } else {
+                            true
+                        } && true
+                    """.trimIndent(),
+                    *NOTHING
+                ),
+                flag(
+                    """
+                        if (true) {
+                            1
+                        } else if (true) {
+                            1
+                        } else {
+                            1
+                        } or 1
+                    """.trimIndent(),
+                    *NOTHING
+                ),
+            )
         }
     }
 


### PR DESCRIPTION
`BracesOnIfStatements` configured with `multiLine=always/consistent` reports violation in case of if-else-if-else chained with other expressions. For example:
```
if (true) {
    ""
} else if (true) {
    ""
} else {
    ""
}.trim()
```

This MR fixes such issues