### PR TITLE
Make friendPaths an Input

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -85,7 +85,7 @@ abstract class Detekt @Inject constructor(
     @get:Optional
     abstract val classpath: ConfigurableFileCollection
 
-    @get:Internal
+    @get:Input
     abstract val friendPaths: ConfigurableFileCollection
 
     @get:Input

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -79,7 +79,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     @get:Optional
     abstract val classpath: ConfigurableFileCollection
 
-    @get:Internal
+    @get:Input
     abstract val friendPaths: ConfigurableFileCollection
 
     @get:Console


### PR DESCRIPTION
When friendPaths are updated the compilation needs to be rerun. Kotlin Gradle plugin has this as Internal, but they use another property annotated Input which is used to track changes to friend path inputs. Our plugin needs to make it Input otherwise changes in friend path classpaths won't trigger another analysis run.