### PR TITLE
Remove hash from class name in debug output

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -20,4 +20,9 @@ inline fun <reified T : Extension> loadExtensions(
             it.init(settings.config)
             it.init(settings)
         }
-        .also { settings.debug { "Loaded extensions: $LIST_ITEM_SPACING${it.joinToString(LIST_ITEM_SPACING)}" } }
+        .also {
+            settings.debug {
+                "Loaded extensions: $LIST_ITEM_SPACING" +
+                    it.joinToString(LIST_ITEM_SPACING) { it.javaClass.canonicalName }
+            }
+        }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -27,5 +27,10 @@ fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> {
             listOf(SingleRuleProvider(ruleName, realProvider))
         }
     }
-        .also { debug { "Registered rule sets: $LIST_ITEM_SPACING${it.joinToString(LIST_ITEM_SPACING)}" } }
+        .also {
+            debug {
+                "Registered rule sets: $LIST_ITEM_SPACING" +
+                    it.joinToString(LIST_ITEM_SPACING) { it.javaClass.canonicalName }
+            }
+        }
 }


### PR DESCRIPTION
New output:
```
Registered rule sets: 
    io.gitlab.arturbosch.detekt.rules.bugs.PotentialBugProvider
    io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider
    io.gitlab.arturbosch.detekt.rules.coroutines.CoroutinesProvider
    io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider
    io.gitlab.arturbosch.detekt.rules.empty.EmptyCodeProvider
    io.gitlab.arturbosch.detekt.rules.exceptions.ExceptionsProvider
    io.gitlab.arturbosch.detekt.rules.naming.NamingProvider
    io.gitlab.arturbosch.detekt.rules.performance.PerformanceProvider
    io.gitlab.arturbosch.detekt.rules.style.StyleGuideProvider
    io.gitlab.arturbosch.detekt.formatting.FormattingProvider
    io.gitlab.arturbosch.detekt.libraries.RuleLibrariesProvider
    io.gitlab.arturbosch.detekt.authors.RuleAuthorsProvider
```

Current output:
```
Registered rule sets: 	
    io.gitlab.arturbosch.detekt.rules.bugs.PotentialBugProvider@202f841c	
    io.gitlab.arturbosch.detekt.rules.complexity.ComplexityProvider@17eea70b	
    io.gitlab.arturbosch.detekt.rules.coroutines.CoroutinesProvider@26a36cea	
    io.gitlab.arturbosch.detekt.rules.documentation.CommentSmellProvider@362c3c60	
    io.gitlab.arturbosch.detekt.rules.empty.EmptyCodeProvider@6a7f41dd	
    io.gitlab.arturbosch.detekt.rules.exceptions.ExceptionsProvider@84b7566	
    io.gitlab.arturbosch.detekt.rules.naming.NamingProvider@35b28cb9	
    io.gitlab.arturbosch.detekt.rules.performance.PerformanceProvider@62aa7953	
    io.gitlab.arturbosch.detekt.rules.style.StyleGuideProvider@72cbbd72	
    io.gitlab.arturbosch.detekt.formatting.FormattingProvider@21780608
```


