### PR TITLE
Indroduce `Rule.Id`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -192,6 +192,10 @@ public final class io/gitlab/arturbosch/detekt/api/IssueKt {
 	public static final fun getSuppressed (Lio/gitlab/arturbosch/detekt/api/Issue;)Z
 }
 
+public final class io/gitlab/arturbosch/detekt/api/IssueKt {
+	public static final fun getName (Lio/gitlab/arturbosch/detekt/api/RuleInstance;)Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+}
+
 public final class io/gitlab/arturbosch/detekt/api/Location {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/nio/file/Path;)V
@@ -287,6 +291,15 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 }
 
+public final class io/gitlab/arturbosch/detekt/api/Rule$Id {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
@@ -297,8 +310,7 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/RuleInstance {
 	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun getId ()Ljava/lang/String;
-	public abstract fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+	public abstract fun getId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
 	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -192,10 +192,6 @@ public final class io/gitlab/arturbosch/detekt/api/IssueKt {
 	public static final fun getSuppressed (Lio/gitlab/arturbosch/detekt/api/Issue;)Z
 }
 
-public final class io/gitlab/arturbosch/detekt/api/IssueKt {
-	public static final fun getName (Lio/gitlab/arturbosch/detekt/api/RuleInstance;)Lio/gitlab/arturbosch/detekt/api/Rule$Name;
-}
-
 public final class io/gitlab/arturbosch/detekt/api/Location {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/nio/file/Path;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -39,8 +39,9 @@ val Issue.suppressed: Boolean
     get() = suppressReasons.isNotEmpty()
 
 interface RuleInstance {
-    val id: String
-    val name: Rule.Name
+    val id: Rule.Id
     val ruleSetId: RuleSet.Id
     val description: String
 }
+
+val RuleInstance.name: Rule.Name get() = id.ruleName

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -43,5 +43,3 @@ interface RuleInstance {
     val ruleSetId: RuleSet.Id
     val description: String
 }
-
-val RuleInstance.name: Rule.Name get() = id.ruleName

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
-import io.gitlab.arturbosch.detekt.api.internal.identifierRegex
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -91,7 +90,7 @@ open class Rule(
     @Poko
     class Name(val value: String) {
         init {
-            require(value.matches(identifierRegex)) { "Name '$value' must match ${identifierRegex.pattern}" }
+            require(value.matches(nameRegex)) { "Name '$value' must match ${nameRegex.pattern}}" }
         }
 
         override fun toString(): String = value
@@ -100,7 +99,7 @@ open class Rule(
     @Poko
     class Id(val value: String) {
         init {
-            require(value.matches(ruleIdPattern)) { "Id '$value' must match ${identifierRegex.pattern}" }
+            require(value.matches(idRegex)) { "Id '$value' must match ${idRegex.pattern}" }
         }
 
         val ruleName: Name get() = Name(value.split("/", limit = 2).first())
@@ -109,4 +108,5 @@ open class Rule(
     }
 }
 
-private val ruleIdPattern = Regex("${identifierRegex.pattern}(/${identifierRegex.pattern})?")
+private val nameRegex = Regex("[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")
+private val idRegex = Regex("${nameRegex.pattern}(/${nameRegex.pattern})?")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -99,8 +99,14 @@ open class Rule(
 
     @Poko
     class Id(val value: String) {
+        init {
+            require(value.matches(ruleIdPattern)) { "Id '$value' must match ${identifierRegex.pattern}" }
+        }
+
         val ruleName: Name get() = Name(value.split("/", limit = 2).first())
 
         override fun toString(): String = value
     }
 }
+
+private val ruleIdPattern = Regex("${identifierRegex.pattern}(/${identifierRegex.pattern})?")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
-import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
+import io.gitlab.arturbosch.detekt.api.internal.identifierRegex
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -91,7 +91,7 @@ open class Rule(
     @Poko
     class Name(val value: String) {
         init {
-            validateIdentifier(value)
+            require(value.matches(identifierRegex)) { "Name '$value' must match ${identifierRegex.pattern}" }
         }
 
         override fun toString(): String = value

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -96,4 +96,11 @@ open class Rule(
 
         override fun toString(): String = value
     }
+
+    @Poko
+    class Id(val value: String) {
+        val ruleName: Name get() = Name(value.split("/", limit = 2).first())
+
+        override fun toString(): String = value
+    }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -90,7 +90,7 @@ open class Rule(
     @Poko
     class Name(val value: String) {
         init {
-            require(value.matches(nameRegex)) { "Name '$value' must match ${nameRegex.pattern}}" }
+            require(value.matches(nameRegex)) { "Name '$value' must match $nameRegex" }
         }
 
         override fun toString(): String = value
@@ -99,7 +99,7 @@ open class Rule(
     @Poko
     class Id(val value: String) {
         init {
-            require(value.matches(idRegex)) { "Id '$value' must match ${idRegex.pattern}" }
+            require(value.matches(idRegex)) { "Id '$value' must match $idRegex" }
         }
 
         val ruleName: Name = Name(value.split("/", limit = 2).first())

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -102,7 +102,7 @@ open class Rule(
             require(value.matches(idRegex)) { "Id '$value' must match $idRegex" }
         }
 
-        val ruleName: Name = Name(value.split("/", limit = 2).first())
+        val ruleName: Name = Name(value.substringBefore("/"))
 
         override fun toString(): String = value
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -102,7 +102,7 @@ open class Rule(
             require(value.matches(idRegex)) { "Id '$value' must match ${idRegex.pattern}" }
         }
 
-        val ruleName: Name get() = Name(value.split("/", limit = 2).first())
+        val ruleName: Name = Name(value.split("/", limit = 2).first())
 
         override fun toString(): String = value
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
-import io.gitlab.arturbosch.detekt.api.internal.identifierRegex
 
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
@@ -15,9 +14,11 @@ class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
     @Poko
     class Id(val value: String) {
         init {
-            require(value.matches(identifierRegex)) { "Id '$value' must match ${identifierRegex.pattern}" }
+            require(value.matches(idRegex)) { "Id '$value' must match ${idRegex.pattern}" }
         }
 
         override fun toString(): String = value
     }
 }
+
+private val idRegex = Regex("[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
-import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
+import io.gitlab.arturbosch.detekt.api.internal.identifierRegex
 
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
@@ -15,7 +15,7 @@ class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
     @Poko
     class Id(val value: String) {
         init {
-            validateIdentifier(value)
+            require(value.matches(identifierRegex)) { "Id '$value' must match ${identifierRegex.pattern}" }
         }
 
         override fun toString(): String = value

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -14,7 +14,7 @@ class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
     @Poko
     class Id(val value: String) {
         init {
-            require(value.matches(idRegex)) { "Id '$value' must match ${idRegex.pattern}" }
+            require(value.matches(idRegex)) { "Id '$value' must match $idRegex" }
         }
 
         override fun toString(): String = value

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
@@ -1,3 +1,0 @@
-package io.gitlab.arturbosch.detekt.api.internal
-
-internal val identifierRegex = Regex("[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Validation.kt
@@ -1,12 +1,3 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
-private val identifierRegex = Regex("[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")
-
-/**
- * Checks if given string matches the criteria of an id - [aA-zZ]+([-][aA-zZ]+)* .
- */
-internal fun validateIdentifier(id: String) {
-    require(id.matches(identifierRegex)) {
-        "id '$id' must match ${identifierRegex.pattern}"
-    }
-}
+internal val identifierRegex = Regex("[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
@@ -20,7 +20,7 @@ class RuleSetSpec {
                 RuleSet.Id(ruleSetId),
                 emptyList()
             )
-        }.withMessageStartingWith("id '$ruleSetId' must match")
+        }.withMessageStartingWith("Id '$ruleSetId' must match")
     }
 
     companion object {

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
@@ -1,53 +1,43 @@
 package io.gitlab.arturbosch.detekt.api
 
 import org.assertj.core.api.Assertions.assertThatCode
-import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 
 class RuleSetSpec {
-    @ParameterizedTest(name = "should allow RuleSet with name {0}")
-    @MethodSource("getValidNames")
-    fun shouldAllowValidNames(ruleSetId: String) {
-        assertThatCode { RuleSet(RuleSet.Id(ruleSetId), emptyList()) }.doesNotThrowAnyException()
-    }
-
-    @ParameterizedTest(name = "should not allow RuleSet with name {0}")
-    @MethodSource("getInvalidNames")
-    fun shouldNotAllowInvalidNames(ruleSetId: String) {
-        assertThatExceptionOfType(IllegalArgumentException::class.java).isThrownBy {
-            RuleSet(
-                RuleSet.Id(ruleSetId),
-                emptyList()
-            )
-        }.withMessageStartingWith("Id '$ruleSetId' must match")
-    }
-
-    companion object {
-        @JvmStatic
-        fun getValidNames() = listOf(
-            "abc-def",
-            "abc-def",
-            "abc1-def",
-            "ab1c-def",
-            "abc1",
-            "abc-1",
-            "abc-def1",
-            "abc-de1f",
-            "abcDef",
-            "abcDef1",
+    @Nested
+    inner class Id {
+        @ParameterizedTest(name = "should allow RuleSet with id {0}")
+        @ValueSource(
+            strings = [
+                "abc-def",
+                "abc1-def",
+                "abc-1",
+                "abc-def1",
+                "abc-de1f",
+                "abcDef",
+                "abcDef1",
+            ]
         )
+        fun shouldAllowValidIds(ruleSetId: String) {
+            assertThatCode { RuleSet.Id(ruleSetId) }
+                .doesNotThrowAnyException()
+        }
 
-        @JvmStatic
-        fun getInvalidNames() = listOf(
-            "abc def",
-            "abc1 def",
-            "ab1c def",
-            "abc 1",
-            "abc-",
-            "abc-def-",
-            "-abcDef",
-            "1abcDef",
+        @ParameterizedTest(name = "should not allow RuleSet with id {0}")
+        @ValueSource(
+            strings = [
+                "abc def",
+                "abc-",
+                "-abcDef",
+                "1abcDef",
+            ]
         )
+        fun shouldNotAllowInvalidIds(ruleSetId: String) {
+            assertThatCode { RuleSet.Id(ruleSetId) }
+                .hasMessageStartingWith("Id '$ruleSetId' must match")
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
     }
 }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSetSpec.kt
@@ -36,7 +36,7 @@ class RuleSetSpec {
         )
         fun shouldNotAllowInvalidIds(ruleSetId: String) {
             assertThatCode { RuleSet.Id(ruleSetId) }
-                .hasMessageStartingWith("Id '$ruleSetId' must match")
+                .hasMessage("Id '$ruleSetId' must match [aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
@@ -1,0 +1,101 @@
+package io.gitlab.arturbosch.detekt.api
+
+import org.assertj.core.api.Assertions.assertThatCode
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class RuleSpec {
+    @Nested
+    inner class Id {
+        @ParameterizedTest(name = "should allow Rule with id {0}")
+        @ValueSource(
+            strings = [
+                "abc-def",
+                "abc1-def",
+                "abc-1",
+                "abc-def1",
+                "abc-de1f",
+                "abcDef",
+                "abcDef1",
+
+                "abc-def/abcDef1",
+                "abc1-def/abc-def",
+                "abc-1/abc1-def",
+                "abc-def1/abc-1",
+                "abc-de1f/abc-def1",
+                "abcDef/abc-de1f",
+                "abcDef1/abcDef",
+            ]
+        )
+        fun shouldAllowValidIds(ruleName: String) {
+            assertThatCode { Rule.Id(ruleName) }
+                .doesNotThrowAnyException()
+        }
+
+        @ParameterizedTest(name = "should not allow Rule with id {0}")
+        @ValueSource(
+            strings = [
+                "abc def",
+                "abc1 def",
+                "ab1c def",
+                "abc 1",
+                "abc-",
+                "abc-def-",
+                "-abcDef",
+                "1abcDef",
+
+                "abc-def/abc def",
+                "abc1-def/abc1 def",
+                "abc-1/ab1c def",
+                "abc-def1/abc 1",
+                "abc-de1f/abc-",
+                "abcDef/abc-def-",
+
+                "abcDef1/abc/def",
+                "abcDef1/abc/",
+                "abcDef1/",
+            ]
+        )
+        fun shouldNotAllowInvalidIds(ruleName: String) {
+            assertThatCode { Rule.Id(ruleName) }
+                .hasMessageStartingWith("Id '$ruleName' must match")
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    inner class Name {
+        @ParameterizedTest(name = "should allow Rule with name {0}")
+        @ValueSource(
+            strings = [
+                "abc-def",
+                "abc1-def",
+                "abc-1",
+                "abc-def1",
+                "abc-de1f",
+                "abcDef",
+                "abcDef1",
+            ]
+        )
+        fun shouldAllowValidNames(ruleName: String) {
+            assertThatCode { Rule.Name(ruleName) }
+                .doesNotThrowAnyException()
+        }
+
+        @ParameterizedTest(name = "should not allow Rule with name {0}")
+        @ValueSource(
+            strings = [
+                "abc def",
+                "abc-",
+                "-abcDef",
+                "1abcDef",
+            ]
+        )
+        fun shouldNotAllowInvalidNames(ruleName: String) {
+            assertThatCode { Rule.Name(ruleName) }
+                .hasMessageStartingWith("Name '$ruleName' must match")
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+}

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
@@ -59,7 +59,9 @@ class RuleSpec {
         )
         fun shouldNotAllowInvalidIds(ruleName: String) {
             assertThatCode { Rule.Id(ruleName) }
-                .hasMessage("Id '$ruleName' must match [aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9](/[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9])?")
+                .hasMessage(
+                    "Id '$ruleName' must match [aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9](/[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9])?"
+                )
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
     }

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/RuleSpec.kt
@@ -59,7 +59,7 @@ class RuleSpec {
         )
         fun shouldNotAllowInvalidIds(ruleName: String) {
             assertThatCode { Rule.Id(ruleName) }
-                .hasMessageStartingWith("Id '$ruleName' must match")
+                .hasMessage("Id '$ruleName' must match [aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9](/[aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9])?")
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
     }
@@ -94,7 +94,7 @@ class RuleSpec {
         )
         fun shouldNotAllowInvalidNames(ruleName: String) {
             assertThatCode { Rule.Name(ruleName) }
-                .hasMessageStartingWith("Name '$ruleName' must match")
+                .hasMessage("Name '$ruleName' must match [aA-zZ]+(?:[aA-zZ0-9-]+)*[aA-zZ0-9]")
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
     }

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -58,15 +58,11 @@ fun createRuleInstance(
     id: String = "TestSmell/id",
     ruleSetId: String = "RuleSet${id.split("/", limit = 2).first()}",
     description: String = "Description ${id.split("/", limit = 2).first()}",
-): RuleInstance {
-    val split = id.split("/", limit = 2)
-    return RuleInstanceImpl(
-        id = id,
-        name = Rule.Name(split.first()),
-        ruleSetId = RuleSet.Id(ruleSetId),
-        description = description
-    )
-}
+): RuleInstance = RuleInstanceImpl(
+    id = Rule.Id(id),
+    ruleSetId = RuleSet.Id(ruleSetId),
+    description = description
+)
 
 fun createEntity(
     signature: String = "TestEntitySignature",
@@ -122,8 +118,7 @@ private data class IssueImpl(
 }
 
 private data class RuleInstanceImpl(
-    override val id: String,
-    override val name: Rule.Name,
+    override val id: Rule.Id,
     override val ruleSetId: RuleSet.Id,
     override val description: String,
 ) : RuleInstance

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -5,6 +5,7 @@ import io.github.detekt.tooling.api.spec.RulesSpec
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.NoRestrictions
 import io.github.detekt.utils.PathFilters
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import java.nio.file.Path
 import kotlin.io.path.ExperimentalPathApi
@@ -102,5 +103,5 @@ private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":")
         ?: return if (disableDefaultRuleSets) DisableDefaultRuleSets else NoRestrictions
     require(parts.size == 2) { "Pattern 'RuleSetId:RuleName' expected." }
-    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), parts[1])
+    return RulesSpec.RunPolicy.RestrictToSingleRule(RuleSet.Id(parts[0]), Rule.Id(parts[1]))
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.config.validation
 
 import io.gitlab.arturbosch.detekt.api.Notification
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
-import io.gitlab.arturbosch.detekt.core.extractRuleName
 import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 internal class InvalidPropertiesConfigValidator(
@@ -55,7 +55,7 @@ internal class InvalidPropertiesConfigValidator(
         baseline: Map<String, Any>
     ): List<Notification> {
         if (!baseline.contains(propertyName)) {
-            val ruleName = extractRuleName(propertyName)
+            val ruleName = runCatching { Rule.Id(propertyName).ruleName }.getOrNull()
             if (ruleName == null || !baseline.contains(ruleName.value)) {
                 return listOf(propertyDoesNotExists(propertyPath))
             }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSets.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.extensions.LIST_ITEM_SPACING
-import io.gitlab.arturbosch.detekt.core.extractRuleName
 import java.util.ServiceLoader
 
 fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> {
@@ -21,14 +20,10 @@ fun ProcessingSettings.createRuleProviders(): List<RuleSetProvider> {
 
         is RulesSpec.RunPolicy.RestrictToSingleRule -> {
             val ruleSetId = runPolicy.ruleSetId
-            val ruleId = runPolicy.ruleId
             val realProvider = requireNotNull(ruleSetProviders.find { it.ruleSetId == ruleSetId }) {
                 "There was no rule set with id '$ruleSetId'."
             }
-            val ruleName = requireNotNull(extractRuleName(ruleId)) {
-                "There was not rule '$ruleId' in rule set '$ruleSetId'."
-            }
-            listOf(SingleRuleProvider(ruleName, realProvider))
+            listOf(SingleRuleProvider(runPolicy.ruleId.ruleName, realProvider))
         }
     }
         .also {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -11,8 +12,8 @@ import kotlin.text.RegexOption.IGNORE_CASE
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.
  * If this element cannot have annotations, the first annotative parent is searched.
  */
-fun KtElement.isSuppressedBy(id: String, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
-    val acceptedSuppressionIds = mutableSetOf(id, "ALL", "all", "All")
+fun KtElement.isSuppressedBy(id: Rule.Id, aliases: Set<String>, ruleSetId: RuleSet.Id? = null): Boolean {
+    val acceptedSuppressionIds = mutableSetOf(id.value, "ALL", "all", "All")
     if (ruleSetId != null) {
         acceptedSuppressionIds.addAll(listOf(ruleSetId.value, "$ruleSetId.$id", "$ruleSetId:$id"))
     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
@@ -51,7 +51,7 @@ class RuleSetsSpec {
     @ValueSource(strings = ["MagicNumber", "MagicNumber/id"])
     fun `only loads the provider with the selected rule`(ruleId: String) {
         val providers = createNullLoggingSpec {
-            rules { runPolicy = RestrictToSingleRule(RuleSet.Id("style"), ruleId) }
+            rules { runPolicy = RestrictToSingleRule(RuleSet.Id("style"), Rule.Id(ruleId)) }
         }
             .withSettings { createRuleProviders() }
 
@@ -66,7 +66,7 @@ class RuleSetsSpec {
     fun `throws when rule set doesn't exist`(ruleId: String) {
         assertThatThrownBy {
             createNullLoggingSpec {
-                rules { runPolicy = RestrictToSingleRule(RuleSet.Id("foo"), ruleId) }
+                rules { runPolicy = RestrictToSingleRule(RuleSet.Id("foo"), Rule.Id(ruleId)) }
             }
                 .withSettings { createRuleProviders() }
         }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/SuppressionsSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
 import io.github.detekt.test.utils.compileContentForTest
+import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
@@ -17,7 +18,7 @@ import org.junit.jupiter.params.provider.ValueSource
 class SuppressionsSpec {
 
     private fun KtElement.isSuppressedBy(): Boolean =
-        isSuppressedBy("RuleName", setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
+        isSuppressedBy(Rule.Id("RuleName"), setOf("alias1", "alias2"), RuleSet.Id("RuleSetId"))
 
     @Nested
     inner class DifferentSuppressLocation {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -12,6 +12,7 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
+import io.gitlab.arturbosch.detekt.api.name
 import io.gitlab.arturbosch.detekt.api.suppressed
 import kotlinx.html.CommonAttributeGroupFacadeFlowInteractiveContent
 import kotlinx.html.FlowContent
@@ -115,7 +116,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         issues
             .groupBy { it.ruleInstance }
             .toList()
-            .sortedBy { (ruleInstance, _) -> ruleInstance.id }
+            .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
             .forEach { (ruleInstance, ruleIssues) ->
                 renderRule(ruleInstance, ruleIssues)
             }
@@ -126,7 +127,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val ruleName = ruleInstance.name.value
         val ruleSetId = ruleInstance.ruleSetId.value
         details {
-            id = ruleId
+            id = ruleId.value
             open = true
 
             summary("rule-container") {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -12,7 +12,6 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import io.gitlab.arturbosch.detekt.api.name
 import io.gitlab.arturbosch.detekt.api.suppressed
 import kotlinx.html.CommonAttributeGroupFacadeFlowInteractiveContent
 import kotlinx.html.FlowContent
@@ -124,7 +123,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
 
     private fun FlowContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>) {
         val ruleId = ruleInstance.id
-        val ruleName = ruleInstance.name.value
+        val ruleName = ruleInstance.id.ruleName.value
         val ruleSetId = ruleInstance.ruleSetId.value
         details {
             id = ruleId.value
@@ -172,7 +171,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val absoluteFile = basePath.resolve(issue.location.path).toFile()
         if (absoluteFile.exists()) {
             absoluteFile.useLines {
-                snippetCode(issue.ruleInstance.name, it, issue.location.source, issue.location.text.length())
+                snippetCode(issue.ruleInstance.id.ruleName, it, issue.location.source, issue.location.text.length())
             }
         }
     }

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -20,7 +20,6 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import io.gitlab.arturbosch.detekt.api.name
 import io.gitlab.arturbosch.detekt.api.suppressed
 import java.nio.file.Path
 import java.time.OffsetDateTime
@@ -102,7 +101,7 @@ private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path) {
 
 private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>, basePath: Path) {
     val ruleId = ruleInstance.id
-    val ruleName = ruleInstance.name.value
+    val ruleName = ruleInstance.id.ruleName.value
     val ruleSetId = ruleInstance.ruleSetId.value
     h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
     paragraph { ruleInstance.description }

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -20,6 +20,7 @@ import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
+import io.gitlab.arturbosch.detekt.api.name
 import io.gitlab.arturbosch.detekt.api.suppressed
 import java.nio.file.Path
 import java.time.OffsetDateTime
@@ -93,7 +94,7 @@ private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path) {
     issues
         .groupBy { it.ruleInstance }
         .toList()
-        .sortedBy { (ruleInstance, _) -> ruleInstance.id }
+        .sortedBy { (ruleInstance, _) -> ruleInstance.id.value }
         .forEach { (ruleInstance, ruleIssues) ->
             renderRule(ruleInstance, ruleIssues, basePath)
         }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -72,7 +72,7 @@ fun Rule.lint(ktFile: KtFile, compilerResources: CompilerResources = FakeCompile
 
 private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> =
     filterNot {
-        it.entity.ktElement.isSuppressedBy(rule.ruleName.value, rule.aliases, RuleSet.Id("NoARuleSetId"))
+        it.entity.ktElement.isSuppressedBy(Rule.Id(rule.ruleName.value), rule.aliases, RuleSet.Id("NoARuleSetId"))
     }
 
 private val Rule.aliases: Set<String> get() = config.valueOrDefault(Config.ALIASES_KEY, emptyList<String>()).toSet()

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -72,7 +72,7 @@ fun Rule.lint(ktFile: KtFile, compilerResources: CompilerResources = FakeCompile
 
 private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> =
     filterNot {
-        it.entity.ktElement.isSuppressedBy(Rule.Id(rule.ruleName.value), rule.aliases, RuleSet.Id("NoARuleSetId"))
+        it.entity.ktElement.isSuppressedBy(Rule.Id(rule.ruleName.value), rule.aliases, RuleSet.Id("NotARuleSetId"))
     }
 
 private val Rule.aliases: Set<String> get() = config.valueOrDefault(Config.ALIASES_KEY, emptyList<String>()).toSet()

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -221,8 +221,8 @@ public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$NoRestr
 }
 
 public final class io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy$RestrictToSingleRule : io/github/detekt/tooling/api/spec/RulesSpec$RunPolicy {
-	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;)V
-	public final fun getRuleId ()Ljava/lang/String;
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Lio/gitlab/arturbosch/detekt/api/Rule$Id;)V
+	public final fun getRuleId ()Lio/gitlab/arturbosch/detekt/api/Rule$Id;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 }
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -62,6 +62,6 @@ interface RulesSpec {
         /**
          * Run a single rule.
          */
-        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: String) : RunPolicy()
+        class RestrictToSingleRule(val ruleSetId: RuleSet.Id, val ruleId: Rule.Id) : RunPolicy()
     }
 }


### PR DESCRIPTION
The same way we have `Rule.Name` and `RuleSet.Id` we should also have `Rule.Id` to have an api more type safe.

This PR also do another minor improvements in the code around these values.

Thanks to @TWiStErRob because the main idea of this PR came from him and we work on it on a fast pair programming session.

@TWiStErRob tell me if there is something else that I should cover.

~Blocked by:~
- #7263