### PR TITLE
Remove `Compactable`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -20,10 +20,6 @@ public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/de
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Compactable {
-	public abstract fun compact ()Ljava/lang/String;
-}
-
 public final class io/gitlab/arturbosch/detekt/api/CompilerResources {
 	public fun <init> (Lorg/jetbrains/kotlin/config/LanguageVersionSettings;Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;)V
 	public final fun getDataFlowValueFactory ()Lorg/jetbrains/kotlin/resolve/calls/smartcasts/DataFlowValueFactory;
@@ -118,10 +114,9 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion : org/
 	public abstract fun getNotifications ()Ljava/util/Collection;
 }
 
-public final class io/gitlab/arturbosch/detekt/api/Entity : io/gitlab/arturbosch/detekt/api/Compactable {
+public final class io/gitlab/arturbosch/detekt/api/Entity {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Entity$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;)V
-	public fun compact ()Ljava/lang/String;
 	public final fun getKtElement ()Lorg/jetbrains/kotlin/psi/KtElement;
 	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
 	public final fun getName ()Ljava/lang/String;
@@ -187,10 +182,10 @@ public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
 	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Issue;)Lio/gitlab/arturbosch/detekt/api/Location;
 }
 
-public final class io/gitlab/arturbosch/detekt/api/Location : io/gitlab/arturbosch/detekt/api/Compactable {
+public final class io/gitlab/arturbosch/detekt/api/Location {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/nio/file/Path;)V
-	public fun compact ()Ljava/lang/String;
+	public final fun compact ()Ljava/lang/String;
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getPath ()Ljava/nio/file/Path;
 	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -185,7 +185,6 @@ public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
 public final class io/gitlab/arturbosch/detekt/api/Location {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Location$Companion;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/nio/file/Path;)V
-	public final fun compact ()Ljava/lang/String;
 	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
 	public final fun getPath ()Ljava/nio/file/Path;
 	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -16,10 +16,7 @@ class Entity(
     val signature: String,
     val location: Location,
     val ktElement: KtElement
-) : Compactable {
-
-    override fun compact(): String = "[$name] at ${location.compact()}"
-
+) {
     override fun toString(): String =
         "Entity(name=$name, signature=$signature, location=$location, ktElement=$ktElement)"
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -62,13 +62,3 @@ class Entity(
         }
     }
 }
-
-/**
- * Provides a compact string representation.
- */
-interface Compactable {
-    /**
-     * Contract to format implementing object to a string representation.
-     */
-    fun compact(): String
-}

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -20,8 +20,6 @@ class Location(
     val text: TextLocation,
     val path: Path,
 ) {
-    fun compact(): String = "$path:$source"
-
     override fun toString(): String =
         "Location(source=$source, endSource=$endSource, text=$text, path=$path)"
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -19,9 +19,8 @@ class Location(
     val endSource: SourceLocation,
     val text: TextLocation,
     val path: Path,
-) : Compactable {
-
-    override fun compact(): String = "$path:$source"
+) {
+    fun compact(): String = "$path:$source"
 
     override fun toString(): String =
         "Location(source=$source, endSource=$endSource, text=$text, path=$path)"

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -38,14 +38,6 @@ class EntitySpec {
         }
 
         @Test
-        fun `includes function name in entity compact`() {
-            val memberFunction = functions.first { it.name == "memberFun" }
-
-            assertThat(Entity.atName(memberFunction).compact())
-                .isEqualTo("[memberFun] at $path:5:17")
-        }
-
-        @Test
         fun `toString gives all details`() {
             val memberFunction = functions.first { it.name == "memberFun" }
 
@@ -70,11 +62,6 @@ class EntitySpec {
         }
 
         @Test
-        fun `includes class name in entity compact`() {
-            assertThat(Entity.atName(clazz).compact()).isEqualTo("[C] at $path:3:7")
-        }
-
-        @Test
         fun `toString gives all details`() {
             assertThat(Entity.atName(clazz).toString())
                 .isEqualTo(
@@ -95,14 +82,6 @@ class EntitySpec {
 
             assertThat(Entity.from(code).signature).isEqualTo(expectedResult)
             assertThat(Entity.atPackageOrFirstDecl(code).signature).isEqualTo(expectedResult)
-        }
-
-        @Test
-        fun `includes file name in entity compact`() {
-            val expectedResult = "[EntitySpecFixture.kt] at $path:1:1"
-
-            assertThat(Entity.from(code).compact()).isEqualTo(expectedResult)
-            assertThat(Entity.atPackageOrFirstDecl(code).compact()).isEqualTo(expectedResult)
         }
 
         @Test

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core.reporting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Location
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 
@@ -52,3 +53,5 @@ private fun Issue.truncatedMessage(): String {
 }
 
 private fun Issue.detailed(): String = "${ruleInstance.id} - [${truncatedMessage()}] at ${location.compact()}"
+
+internal fun Location.compact(): String = "$path:$source"

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReport.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.core.reporting.compact
 
 /**
  * A lightweight versions of the console report, where each line contains location, messages and issue id only.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -29,10 +29,10 @@ class FileBasedIssuesReportSpec {
         assertThat(output).isEqualTo(
             """
                 ${location1.path}
-                	TestSmell/id - [TestMessage] at ${location1.compact()}
-                	TestSmell/id - [TestMessage] at ${location1.compact()}
+                	TestSmell/id - [TestMessage] at ${location1.path}:1:1
+                	TestSmell/id - [TestMessage] at ${location1.path}:1:1
                 ${location2.path}
-                	TestSmell/id - [TestMessage] at ${location2.compact()}
+                	TestSmell/id - [TestMessage] at ${location2.path}:1:1
                 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -28,10 +28,10 @@ class IssuesReportSpec {
         assertThat(output).isEqualTo(
             """
                 Ruleset1
-                	TestSmell/id - [TestMessage] at ${location.compact()}
-                	TestSmell/id - [TestMessage] at ${location.compact()}
+                	TestSmell/id - [TestMessage] at ${location.path}:1:1
+                	TestSmell/id - [TestMessage] at ${location.path}:1:1
                 Ruleset2
-                	TestSmell/id - [TestMessage] at ${location.compact()}
+                	TestSmell/id - [TestMessage] at ${location.path}:1:1
                 
             """.trimIndent()
         )

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -22,8 +22,8 @@ class LiteIssuesReportSpec {
         )
         assertThat(subject.render(detektion)).isEqualTo(
             """
-                ${location.compact()}: TestMessage [SpacingAfterPackageDeclaration/id]
-                ${location.compact()}: TestMessage [UnnecessarySafeCall]
+                ${location.path}:1:1: TestMessage [SpacingAfterPackageDeclaration/id]
+                ${location.path}:1:1: TestMessage [UnnecessarySafeCall]
 
             """.trimIndent()
         )

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -25,4 +25,4 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 private fun Issue.compactWithSignature(): String =
     "${ruleInstance.id} - ${entity.compact()} - Signature=${entity.signature}"
 
-private fun Entity.compact(): String = "[$name] at ${location.compact()}"
+private fun Entity.compact(): String = "[$name] at ${location.path}:${location.source}"

--- a/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
+++ b/detekt-report-txt/src/main/kotlin/io/github/detekt/report/txt/TxtOutputReport.kt
@@ -1,6 +1,7 @@
 package io.github.detekt.report.txt
 
 import io.gitlab.arturbosch.detekt.api.Detektion
+import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
@@ -23,3 +24,5 @@ class TxtOutputReport : BuiltInOutputReport, OutputReport() {
 
 private fun Issue.compactWithSignature(): String =
     "${ruleInstance.id} - ${entity.compact()} - Signature=${entity.signature}"
+
+private fun Entity.compact(): String = "[$name] at ${location.compact()}"

--- a/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
+++ b/detekt-report-txt/src/test/kotlin/io/github/detekt/report/txt/TxtOutputReportSpec.kt
@@ -21,7 +21,7 @@ class TxtOutputReportSpec {
         val location = createLocation()
         val detektion = TestDetektion(createIssue(createRuleInstance(), location))
         assertThat(TxtOutputReport().render(detektion))
-            .isEqualTo("TestSmell/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature\n")
+            .isEqualTo("TestSmell/id - [TestEntity] at ${location.path}:1:1 - Signature=TestEntitySignature\n")
     }
 
     @Test
@@ -35,9 +35,9 @@ class TxtOutputReportSpec {
         assertThat(TxtOutputReport().render(detektion))
             .isEqualTo(
                 """
-                    TestSmellA/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
-                    TestSmellB/id - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
-                    TestSmellC - [TestEntity] at ${location.compact()} - Signature=TestEntitySignature
+                    TestSmellA/id - [TestEntity] at ${location.path}:1:1 - Signature=TestEntitySignature
+                    TestSmellB/id - [TestEntity] at ${location.path}:1:1 - Signature=TestEntitySignature
+                    TestSmellC - [TestEntity] at ${location.path}:1:1 - Signature=TestEntitySignature
 
                 """.trimIndent()
             )


### PR DESCRIPTION
This interface provide us nothing. It had two implementations but no one was using it for polymorphism or nothing similar.

The idea behind this is to simplify `Entity` and `Location` for #6879 and, in general, make our public api smaller.