### PR TITLE
Switch to Shadow plugin fork

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -2,7 +2,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 import java.io.ByteArrayOutputStream
 
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("module")
     id("application")
 }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -8,7 +8,7 @@ version = "$kotlinVersion-$detektVersion"
 
 plugins {
     id("module")
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("de.undercouch.download") version "5.6.0"
 }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    id("io.github.goooler.shadow") version "8.1.8"
     id("module")
     id("application")
 }


### PR DESCRIPTION
This is being kept up to date with updated dependencies and fixes for Gradle deprecations.

Fixes this deprecation in our build: https://ge.detekt.dev/s/sc5xnws6al44c/deprecations?expanded=WyIxMDYiXQ#102

See https://github.com/johnrengelman/shadow/pull/876.