### PR TITLE
Simplify detekt.api.Extension

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -79,7 +79,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigValidator 
 
 public final class io/gitlab/arturbosch/detekt/api/ConfigValidator$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
@@ -93,7 +92,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConsoleReport : 
 
 public final class io/gitlab/arturbosch/detekt/api/ConsoleReport$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
@@ -137,13 +135,11 @@ public final class io/gitlab/arturbosch/detekt/api/Entity$Companion {
 public abstract interface class io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun getId ()Ljava/lang/String;
 	public abstract fun getPriority ()I
-	public abstract fun init (Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public abstract fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/Extension;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/Extension;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/Extension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
@@ -156,7 +152,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListe
 
 public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;)V
@@ -224,7 +219,6 @@ public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/a
 	public fun <init> ()V
 	public abstract fun getEnding ()Ljava/lang/String;
 	public fun getPriority ()I
-	public fun init (Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public abstract fun render (Lio/gitlab/arturbosch/detekt/api/Detektion;)Ljava/lang/String;
 	public final fun write (Ljava/nio/file/Path;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
@@ -257,7 +251,6 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ReportingExtensi
 
 public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImpls {
 	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Config;)V
 	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public static fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 	public static fun onRawResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Extension.kt
@@ -22,14 +22,6 @@ interface Extension {
     val priority: Int get() = -1
 
     /**
-     * Allows to read any or even user defined properties from the detekt yaml config
-     * to setup this extension.
-     */
-    fun init(config: Config) {
-        // implement for setup code
-    }
-
-    /**
      * Setup extension by querying common paths and config options.
      */
     fun init(context: SetupContext) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -16,7 +16,6 @@ inline fun <reified T : Extension> loadExtensions(
         .filter(predicate)
         .sortedByDescending { it.priority }
         .onEach {
-            it.init(settings.config)
             it.init(settings)
         }
         .also {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.core.reporting.filterEmptyIssues
 
 abstract class AbstractIssuesReport : ConsoleReport {
@@ -12,8 +13,8 @@ abstract class AbstractIssuesReport : ConsoleReport {
 
     override val priority: Int = 40
 
-    override fun init(config: Config) {
-        this.config = config
+    override fun init(context: SetupContext) {
+        this.config = context.config
     }
 
     override fun render(detektion: Detektion): String? {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.core.reporting
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 
@@ -10,7 +11,7 @@ internal object AutoCorrectableIssueAssert {
 
     fun isReportNull(report: ConsoleReport) {
         val config = TestConfig("excludeCorrectable" to "true")
-        report.init(config)
+        report.init(TestSetupContext(config))
         val correctableCodeSmell = createIssue(autoCorrectEnabled = true)
         val detektionWithCorrectableSmell = TestDetektion(correctableCodeSmell)
         val result = report.render(detektionWithCorrectableSmell)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInstance
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 class FileBasedIssuesReportSpec {
 
-    private val subject = createFileBasedIssuesReport()
+    private val subject = FileBasedIssuesReport().apply { init(TestSetupContext()) }
 
     @Test
     fun `has the reference content`() {
@@ -49,10 +49,4 @@ class FileBasedIssuesReportSpec {
         val report = FileBasedIssuesReport()
         AutoCorrectableIssueAssert.isReportNull(report)
     }
-}
-
-private fun createFileBasedIssuesReport(): FileBasedIssuesReport {
-    val report = FileBasedIssuesReport()
-    report.init(Config.empty)
-    return report
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInstance
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test
 
 class IssuesReportSpec {
 
-    private val subject = createIssuesReport()
+    private val subject = IssuesReport().apply { init(TestSetupContext()) }
 
     @Test
     fun `has the reference content`() {
@@ -69,10 +69,4 @@ class IssuesReportSpec {
         assertThat(output)
             .contains("MultilineRule - [A multiline message.]")
     }
-}
-
-private fun createIssuesReport(): IssuesReport {
-    val report = IssuesReport()
-    report.init(Config.empty)
-    return report
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.core.reporting.AutoCorrectableIssueAssert
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInstance
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test
 
 class LiteIssuesReportSpec {
 
-    private val subject = createIssuesReport()
+    private val subject = LiteIssuesReport().apply { init(TestSetupContext()) }
 
     @Test
     fun `reports non-empty issues`() {
@@ -40,8 +40,4 @@ class LiteIssuesReportSpec {
         val report = LiteIssuesReport()
         AutoCorrectableIssueAssert.isReportNull(report)
     }
-}
-
-private fun createIssuesReport() = LiteIssuesReport().apply {
-    init(Config.empty)
 }


### PR DESCRIPTION
Right now we have two different ways to configure an `Extension`. That can be simplified because one function is a super set of the other.