### PR TITLE
Make `ConsoleReport` an interface instead of an abstract class

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -87,12 +87,14 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Confi
 	public abstract fun description ()Ljava/lang/String;
 }
 
-public abstract class io/gitlab/arturbosch/detekt/api/ConsoleReport : io/gitlab/arturbosch/detekt/api/Extension {
-	public fun <init> ()V
-	public fun getPriority ()I
-	public fun init (Lio/gitlab/arturbosch/detekt/api/Config;)V
-	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
+public abstract interface class io/gitlab/arturbosch/detekt/api/ConsoleReport : io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun render (Lio/gitlab/arturbosch/detekt/api/Detektion;)Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/ConsoleReport$DefaultImpls {
+	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;)I
+	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;Lio/gitlab/arturbosch/detekt/api/Config;)V
+	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
 public class io/gitlab/arturbosch/detekt/api/CorrectableCodeSmell : io/gitlab/arturbosch/detekt/api/CodeSmell {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConsoleReport.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConsoleReport.kt
@@ -7,12 +7,12 @@ package io.gitlab.arturbosch.detekt.api
  * If the default reporting mechanism should be turned off, exclude the entry 'FindingsReport'
  * in the 'console-reports' property of a detekt yaml config.
  */
-abstract class ConsoleReport : Extension {
+interface ConsoleReport : Extension {
 
     /**
      * Converts the given [detektion] into a string representation
      * to present it to the client.
      * The implementation specifies which parts of the report are important to the user.
      */
-    abstract fun render(detektion: Detektion): String?
+    fun render(detektion: Detektion): String?
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.core.reporting.filterEmptyIssues
 
-abstract class AbstractIssuesReport : ConsoleReport() {
+abstract class AbstractIssuesReport : ConsoleReport {
 
     private lateinit var config: Config
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReport.kt
@@ -9,7 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  * For instance the source lines of code and the McCabe complexity are calculated.
  * See: https://detekt.dev/configurations.html#console-reports
  */
-class ComplexityReport : ConsoleReport() {
+class ComplexityReport : ConsoleReport {
 
     override val id: String = "ComplexityReport"
     override val priority: Int = 20

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReport.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  * Contains notifications reported by the detekt analyzer.
  * See: https://detekt.dev/configurations.html#console-reports
  */
-class NotificationReport : ConsoleReport() {
+class NotificationReport : ConsoleReport {
 
     override val id: String = "NotificationReport"
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReport.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
  * Contains metrics and statistics concerning the analyzed project sorted by priority.
  * See: https://detekt.dev/configurations.html#console-reports
  */
-class ProjectStatisticsReport : ConsoleReport() {
+class ProjectStatisticsReport : ConsoleReport {
 
     override val id: String = "ProjectStatisticsReport"
     override val priority: Int = 10

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/reports/QualifiedNamesConsoleReport.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.sample.extensions.reports
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 
-class QualifiedNamesConsoleReport : ConsoleReport() {
+class QualifiedNamesConsoleReport : ConsoleReport {
 
     override val id: String = "QualifiedNamesConsoleReport"
 


### PR DESCRIPTION
`ConsoleReport` only contains an abstract function so it can be an `interface` instead of an `abstract class`