### PR TITLE
Suppress missleading warning

### DIFF
--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -189,4 +189,5 @@ private fun MarkdownContent.snippetCode(lines: Sequence<String>, location: Sourc
     return codeBlock("kotlin") { text }
 }
 
+@Suppress("UnusedReceiverParameter")
 internal fun MarkdownContent.link(text: String, url: String) = "[$text]($url)"


### PR DESCRIPTION
It's true that the function doesn't need any the receiver but this function is inside a DSL and the receiver helps to ensure that we always call it in the right scope.
