### PR TITLE
Ensure that `basePath` is always absolute

### DIFF
--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ProjectSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/ProjectSpec.kt
@@ -10,6 +10,8 @@ interface ProjectSpec {
 
     /**
      * A base path to relativize paths. Mostly used for generating path in the output or report.
+     *
+     * It is always an absolute path.
      */
     val basePath: Path
 

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProjectSpecBuilder.kt
@@ -4,11 +4,16 @@ import io.github.detekt.tooling.api.AnalysisMode
 import io.github.detekt.tooling.api.spec.ProjectSpec
 import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 @ProcessingModelDsl
 class ProjectSpecBuilder : Builder<ProjectSpec> {
 
-    var basePath: Path = Path("")
+    var basePath: Path = Path("").absolute()
+        set(value) {
+            require(basePath.isAbsolute) { "basepath should be absolute" }
+            field = value
+        }
     var inputPaths: Collection<Path> = emptyList()
     var analysisMode: AnalysisMode = AnalysisMode.light
 


### PR DESCRIPTION
The basepath that we receive should be always absolute. This will simplify the logic in the reporters.