### PR TITLE
Add alias for EnumNaming and EnumEntryNameCase

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -320,6 +320,7 @@ naming:
     excludeClassPattern: '$^'
   EnumNaming:
     active: true
+    aliases: ['EnumEntryName']
     enumEntryPattern: '[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: false

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/EnumEntryNameCase.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.formatting.wrappers
 
 import com.pinterest.ktlint.ruleset.standard.rules.EnumEntryNameCaseRule
 import io.gitlab.arturbosch.detekt.api.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.Alias
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.internal.AutoCorrectable
 import io.gitlab.arturbosch.detekt.formatting.FormattingRule
@@ -11,6 +12,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
  */
 @AutoCorrectable(since = "1.4.0")
 @ActiveByDefault(since = "1.22.0")
+@Alias("EnumEntryName")
 class EnumEntryNameCase(config: Config) : FormattingRule(
     config,
     "Reports enum entries with names that don't meet standard conventions."

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -67,6 +67,7 @@ formatting:
     indentSize: 4
   EnumEntryNameCase:
     active: true
+    aliases: ['EnumEntryName']
     autoCorrect: true
   EnumWrapping:
     active: true

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.ActiveByDefault
+import io.gitlab.arturbosch.detekt.api.Alias
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Configuration
@@ -13,6 +14,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
  * Reports enum names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
+@Alias("EnumEntryName")
 class EnumNaming(config: Config) : Rule(
     config,
     "Enum names should follow the naming convention set in the projects configuration."

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisMode.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/AnalysisMode.kt
@@ -6,13 +6,11 @@ enum class AnalysisMode {
      * Allows rules to analyse the PSI & AST of files and also use additional information from the compiler like types,
      * symbols and smart casts. [light] mode is faster but rules that use additional compiler information will not run.
      */
-    @Suppress("EnumNaming", "EnumEntryNameCase")
     full,
 
     /**
      * Allows rules to analyse the PSI & AST of files only. Use [full] mode to allow rules to use additional information
      * from the compiler like types, symbols and smart casts.
      */
-    @Suppress("EnumNaming", "EnumEntryNameCase")
     light,
 }


### PR DESCRIPTION
Fixes #7491

We didn't have the alias for these two rules