### PR TITLE
Remove `Rule.lint(Path)` overload function from `:detekt-test`

### DIFF
--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -39,7 +39,6 @@ public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
 	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;)Ljava/util/List;
 	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;)Ljava/util/List;
-	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/nio/file/Path;)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;)Ljava/util/List;
 	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.test
 
 import io.github.detekt.test.utils.KotlinScriptEngine
 import io.github.detekt.test.utils.compileContentForTest
-import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.api.CompilerResources
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
@@ -14,7 +13,6 @@ import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
-import java.nio.file.Path
 
 private val shouldCompileTestSnippets: Boolean =
     System.getProperty("compile-test-snippets", "false")!!.toBoolean()
@@ -28,11 +26,6 @@ fun Rule.compileAndLint(@Language("kotlin") content: String): List<Finding> {
 
 fun Rule.lint(@Language("kotlin") content: String): List<Finding> {
     val ktFile = compileContentForTest(content)
-    return visitFile(ktFile).filterSuppressed(this)
-}
-
-fun Rule.lint(path: Path): List<Finding> {
-    val ktFile = compileForTest(path)
     return visitFile(ktFile).filterSuppressed(this)
 }
 


### PR DESCRIPTION
This function was used in the begining of detekt to tests the rules. But we find out that have the code that we are testing on another file wasn't good so we moved all those test to the new `Rule.lint(String)` (and friends). Now we can remove this. If someone out there is using this it's easy for them to replicate or a good excuse to stop using that bad pattern.