### PR TITLE
Create `FakeCompilerResources` and add `CompilerResources` as parameter on `Rule.lint` extensions

### DIFF
--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -1,3 +1,8 @@
+public final class io/gitlab/arturbosch/detekt/test/FakeCompilerResourcesKt {
+	public static final fun FakeCompilerResources (Lorg/jetbrains/kotlin/config/ExplicitApiMode;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+	public static synthetic fun FakeCompilerResources$default (Lorg/jetbrains/kotlin/config/ExplicitApiMode;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+}
+
 public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/core/api/AbstractAssert {
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Finding;)V
 	public final fun getActual ()Lio/gitlab/arturbosch/detekt/api/Finding;
@@ -36,11 +41,16 @@ public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
-	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;)Ljava/util/List;
-	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;)Ljava/util/List;
-	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;)Ljava/util/List;
-	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;)Ljava/util/List;
-	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;)Ljava/util/List;
+	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static synthetic fun compileAndLint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FakeCompilerResources.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FakeCompilerResources.kt
@@ -1,0 +1,25 @@
+package io.gitlab.arturbosch.detekt.test
+
+import io.gitlab.arturbosch.detekt.api.CompilerResources
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.ApiVersion
+import org.jetbrains.kotlin.config.ExplicitApiMode
+import org.jetbrains.kotlin.config.LanguageVersion
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
+import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
+
+@Suppress("FunctionName")
+fun FakeCompilerResources(
+    mode: ExplicitApiMode = ExplicitApiMode.DISABLED,
+): CompilerResources {
+    val languageVersionSettings = LanguageVersionSettingsImpl(
+        languageVersion = LanguageVersion.LATEST_STABLE,
+        apiVersion = ApiVersion.LATEST_STABLE,
+        analysisFlags = mapOf(AnalysisFlags.explicitApiMode to mode),
+        specificFeatures = emptyMap(),
+    )
+    return CompilerResources(
+        languageVersionSettings,
+        DataFlowValueFactoryImpl(languageVersionSettings)
+    )
+}


### PR DESCRIPTION
Closes #7485

Probably this is not still perfect but it's a step forward to have an easier way to test a Rule that uses the `CompilerResources`.

I think that it's not perfect because the `LanguageVersionSettings` from an `env` and the one that we pass as parameter can be different instances and probably they should be the same. But right now I don't know how to configure `env`. 