### PR TITLE
Non nullable `CompilerResources`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -268,11 +268,11 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Requi
 }
 
 public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/DetektVisitor {
-	public field compilerResources Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+	protected field compilerResources Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Ljava/lang/String;)V
 	public final fun getAutoCorrect ()Z
 	public final fun getBindingContext ()Lorg/jetbrains/kotlin/resolve/BindingContext;
-	public final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/CompilerResources;
+	protected final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	public final fun getConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun getDescription ()Ljava/lang/String;
 	public fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
@@ -280,7 +280,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun report (Lio/gitlab/arturbosch/detekt/api/Finding;)V
 	public final fun setBindingContext (Lorg/jetbrains/kotlin/resolve/BindingContext;)V
-	public final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
+	protected final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
 	public fun visit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun visitFile$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lorg/jetbrains/kotlin/resolve/BindingContext;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -268,6 +268,7 @@ public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Requi
 }
 
 public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/api/DetektVisitor {
+	public field compilerResources Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Config;Ljava/lang/String;)V
 	public final fun getAutoCorrect ()Z
 	public final fun getBindingContext ()Lorg/jetbrains/kotlin/resolve/BindingContext;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -46,7 +46,7 @@ open class Rule(
     fun visitFile(
         root: KtFile,
         bindingContext: BindingContext = BindingContext.EMPTY,
-        compilerResources: CompilerResources? = null
+        compilerResources: CompilerResources?
     ): List<Finding> {
         findings.clear()
         this.bindingContext = bindingContext

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -27,7 +27,7 @@ open class Rule(
     open val ruleName: Name get() = Name(javaClass.simpleName)
 
     var bindingContext: BindingContext = BindingContext.EMPTY
-    var compilerResources: CompilerResources? = null
+    lateinit var compilerResources: CompilerResources
 
     val autoCorrect: Boolean
         get() = config.valueOrDefault(Config.AUTO_CORRECT_KEY, false) &&
@@ -46,7 +46,7 @@ open class Rule(
     fun visitFile(
         root: KtFile,
         bindingContext: BindingContext = BindingContext.EMPTY,
-        compilerResources: CompilerResources?
+        compilerResources: CompilerResources
     ): List<Finding> {
         findings.clear()
         this.bindingContext = bindingContext

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -27,7 +27,7 @@ open class Rule(
     open val ruleName: Name get() = Name(javaClass.simpleName)
 
     var bindingContext: BindingContext = BindingContext.EMPTY
-    lateinit var compilerResources: CompilerResources
+    protected lateinit var compilerResources: CompilerResources
 
     val autoCorrect: Boolean
         get() = config.valueOrDefault(Config.AUTO_CORRECT_KEY, false) &&

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.modifiedText
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtFile
@@ -80,7 +81,7 @@ private fun runRule(config: Config): Pair<KtFile, List<Finding>> {
     val rules = ruleSet.rules
         .map { (ruleName, provider) -> provider(config.subConfig(ruleSet.id.value).subConfig(ruleName.value)) }
         .filter { it.config.valueOrDefault("active", false) }
-    return testFile to rules.flatMap { it.visitFile(testFile) }
+    return testFile to rules.flatMap { it.lint(testFile) }
 }
 
 private fun wasFormatted(file: KtFile) = file.modifiedText == contentAfterChainWrapping

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
 import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -73,7 +74,7 @@ class FormattingRuleSpec {
         val expectedPath = Path("src/test/resources/configTests/chain-wrapping-before.kt").absolute()
 
         val rule = ChainWrapping(Config.empty)
-        val findings = rule.visitFile(compileForTest(expectedPath))
+        val findings = rule.lint(compileForTest(expectedPath))
         assertThat(findings).anySatisfy { finding ->
             assertThat(finding.location.path).isEqualTo(expectedPath)
         }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/TestFiles.kt
@@ -4,6 +4,7 @@ import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.compileForTest
 import io.github.detekt.test.utils.resource
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.FakeCompilerResources
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
 import java.io.File
@@ -14,7 +15,7 @@ fun FormattingRule.lint(@Language("kotlin") content: String, fileName: String = 
         "filename must be a file name only and not contain any path elements"
     }
     val root = compileContentForTest(content, fileName)
-    return this.visitFile(root)
+    return this.visitFile(root, compilerResources = FakeCompilerResources())
 }
 
 fun loadFile(resourceName: String) = compileForTest(resource(resourceName).toPath())

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableType.kt
@@ -56,11 +56,10 @@ class CastNullableToNonNullableType(config: Config) : Rule(
         val typeRef = expression.right ?: return
         val simpleType = bindingContext[BindingContext.TYPE, typeRef] ?: return
         simpleType.isNullable().ifTrue { return }
-        val compilerResourcesNonNull = compilerResources ?: return
         expression.left.isNullable(
             bindingContext,
-            compilerResourcesNonNull.languageVersionSettings,
-            compilerResourcesNonNull.dataFlowValueFactory,
+            compilerResources.languageVersionSettings,
+            compilerResources.dataFlowValueFactory,
             shouldConsiderPlatformTypeAsNullable = ignorePlatformTypes.not(),
         ).ifFalse { return }
 

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -58,7 +58,6 @@ class NullableToStringCall(config: Config) : Rule(
 
     private fun KtStringTemplateEntry.hasNullableExpression(): Boolean {
         val expression = this.expression ?: return false
-        val compilerResources = super.compilerResources ?: return false
         return expression.isNullable(
             bindingContext,
             compilerResources.languageVersionSettings,

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -33,8 +33,6 @@ class UnnecessaryNotNullCheck(config: Config) : Rule(
     override fun visitCallExpression(expression: KtCallExpression) {
         super.visitCallExpression(expression)
 
-        val compilerResources = compilerResources ?: return
-
         val callee = expression.calleeExpression ?: return
         val argument = expression.valueArguments.firstOrNull()?.getArgumentExpression() ?: return
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifier.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifier.kt
@@ -58,8 +58,7 @@ class RedundantVisibilityModifier(config: Config) : Rule(
      * See: https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
      */
     private fun isExplicitApiModeActive(): Boolean {
-        val resources = compilerResources ?: return false
-        val flag = resources.languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode)
+        val flag = compilerResources.languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode)
         return flag != ExplicitApiMode.DISABLED
     }
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnit.kt
@@ -107,8 +107,7 @@ class OptionalUnit(config: Config) : Rule(
         }
 
     private fun isExplicitApiModeActive(): Boolean {
-        val resources = compilerResources ?: return false
-        val flag = resources.languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode)
+        val flag = compilerResources.languageVersionSettings.getFlag(AnalysisFlags.explicitApiMode)
         return flag != ExplicitApiMode.DISABLED
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.FakeCompilerResources
 import io.gitlab.arturbosch.detekt.test.assertThat
@@ -185,12 +184,6 @@ class RedundantVisibilityModifierSpec {
         @Test
         fun `reports public function in class if explicit API mode is disabled`() {
             val findings = subject.compileAndLint(code, FakeCompilerResources(ExplicitApiMode.DISABLED))
-            assertThat(findings).hasSize(1)
-        }
-
-        @Test
-        fun `reports public function in class if compiler resources are not available`() {
-            val findings = subject.visitFile(compileContentForTest(code), compilerResources = null)
             assertThat(findings).hasSize(1)
         }
     }


### PR DESCRIPTION
The `core` always provides a `CompilerResources`. It can't be `null` but we had it as nullable on our API. There is no reason to keep it like that.
