### PR TITLE
Version catalog clean up

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,12 +8,12 @@ repositories {
 }
 
 dependencies {
-    implementation(libs.plugins.kotlin.asDependency())
-    implementation(libs.plugins.githubRelease.asDependency())
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.gradleNexus.publish.plugin)
     implementation(libs.semver4j)
-    implementation(libs.plugins.nexusPublish.asDependency())
-    implementation(libs.plugins.binaryCompatibilityValidator.asDependency())
-    implementation(libs.plugins.dokka.asDependency())
+    implementation(libs.breadmoirai.githubRelease.plugin)
+    implementation(libs.binaryCompatibilityValidator.plugin)
+    implementation(libs.dokka.plugin)
 }
 
 kotlin {
@@ -31,6 +31,3 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach 
         compilerExecutionStrategy = org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.OUT_OF_PROCESS
     }
 }
-
-fun Provider<PluginDependency>.asDependency(): Provider<String> =
-    this.map { "${it.pluginId}:${it.pluginId}.gradle.plugin:${it.version}" }

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -10,7 +10,7 @@ dependencies {
     implementation(projects.detektUtils)
 
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testFixturesImplementation(projects.detektTestUtils)
 }
 

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly(projects.detektReportXml)
 
     testImplementation(projects.detektTestUtils)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testRuntimeOnly(projects.detektFormatting)
 
     pluginsJar(projects.detektFormatting)

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -26,8 +26,8 @@ dependencies {
     runtimeOnly(projects.detektCore)
     runtimeOnly(projects.detektRules)
 
-    testImplementation(libs.assertj)
-    testImplementation(libs.kotlinCompileTesting)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.kctfork.core)
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -6,8 +6,8 @@ dependencies {
     api(projects.detektApi)
     api(projects.detektParser)
     api(projects.detektTooling)
-    implementation(libs.snakeyaml)
-    implementation(libs.kotlin.reflection)
+    implementation(libs.snakeyaml.engine)
+    implementation(libs.kotlin.reflect)
     implementation(projects.detektMetrics)
     implementation(projects.detektPsiUtils)
     implementation(projects.detektUtils)
@@ -21,7 +21,7 @@ dependencies {
     testImplementation(projects.detektTest)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.classgraph)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testRuntimeOnly(libs.slf4j.simple)
 }
 

--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -7,14 +7,14 @@ val extraDepsToPackage: Configuration by configurations.creating
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
-    implementation(libs.ktlintRulesetStandard) {
+    implementation(libs.ktlint.rulesetStandard) {
         exclude(group = "org.jetbrains.kotlin")
     }
 
     runtimeOnly(libs.slf4j.api)
 
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(libs.classgraph)
 
     testRuntimeOnly(libs.slf4j.nop)

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 
     testImplementation(projects.detektCore)
     testImplementation(projects.detektTestUtils)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(libs.classgraph)
     testRuntimeOnly(projects.detektRules)
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -37,14 +37,14 @@ testing {
     suites {
         getByName("test", JvmTestSuite::class) {
             dependencies {
-                implementation(libs.assertj)
+                implementation(libs.assertj.core)
                 implementation(libs.kotlin.gradle.plugin)
                 implementation(gradleKotlinDsl())
             }
         }
         register<JvmTestSuite>("functionalTest") {
             dependencies {
-                implementation(libs.assertj)
+                implementation(libs.assertj.core)
                 implementation(testFixtures(project()))
             }
 
@@ -61,7 +61,7 @@ testing {
         }
         register<JvmTestSuite>("functionalTestMinSupportedGradle") {
             dependencies {
-                implementation(libs.assertj)
+                implementation(libs.assertj.core)
                 implementation(testFixtures(project()))
             }
             targets {
@@ -80,7 +80,7 @@ val testKitJava17RuntimeOnly: Configuration by configurations.creating
 val testKitGradleMinVersionRuntimeOnly: Configuration by configurations.creating
 
 dependencies {
-    compileOnly(libs.android.gradle.minSupported)
+    compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.kotlin.gradlePluginApi)
     implementation(libs.sarif4k)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -38,7 +38,7 @@ testing {
         getByName("test", JvmTestSuite::class) {
             dependencies {
                 implementation(libs.assertj)
-                implementation(libs.kotlin.gradle)
+                implementation(libs.kotlin.gradle.plugin)
                 implementation(gradleKotlinDsl())
             }
         }
@@ -81,19 +81,19 @@ val testKitGradleMinVersionRuntimeOnly: Configuration by configurations.creating
 
 dependencies {
     compileOnly(libs.android.gradle.minSupported)
-    compileOnly(libs.kotlin.gradle)
+    compileOnly(libs.kotlin.gradle.plugin)
     compileOnly(libs.kotlin.gradlePluginApi)
     implementation(libs.sarif4k)
     testFixturesCompileOnly(libs.jetbrains.annotations)
     compileOnly(libs.jetbrains.annotations)
 
-    testKitRuntimeOnly(libs.kotlin.gradle)
-    testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle) {
+    testKitRuntimeOnly(libs.kotlin.gradle.plugin)
+    testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle.plugin) {
         attributes {
             attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("6.8.3"))
         }
     }
-    testKitJava17RuntimeOnly(libs.android.gradle.maxSupported)
+    testKitJava17RuntimeOnly(libs.android.gradle.plugin)
 
     // We use this published version of the detekt-formatting to self analyse this project.
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")

--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testRuntimeOnly(projects.detektPsiUtils)
 }

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
     testImplementation(projects.detektTestUtils)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }
 
 tasks.withType<Test>().configureEach {

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     api(libs.kotlin.compilerEmbeddable)
 
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestUtils)
 }

--- a/detekt-report-html/build.gradle.kts
+++ b/detekt-report-html/build.gradle.kts
@@ -12,5 +12,5 @@ dependencies {
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-report-md/build.gradle.kts
+++ b/detekt-report-md/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
 
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-report-sarif/build.gradle.kts
+++ b/detekt-report-sarif/build.gradle.kts
@@ -9,6 +9,6 @@ dependencies {
     testImplementation(projects.detektTooling)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(projects.detektTest)
 }

--- a/detekt-report-txt/build.gradle.kts
+++ b/detekt-report-txt/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-report-xml/build.gradle.kts
+++ b/detekt-report-xml/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(testFixtures(projects.detektApi))
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(projects.detektTestUtils)
 }

--- a/detekt-rules-complexity/build.gradle.kts
+++ b/detekt-rules-complexity/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -6,7 +6,7 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
-    testRuntimeOnly(libs.kotlinx.coroutines)
-    testRuntimeOnly(libs.kotlinx.coroutines.test)
+    testImplementation(libs.assertj.core)
+    testRuntimeOnly(libs.kotlinx.coroutinesCore)
+    testRuntimeOnly(libs.kotlinx.coroutinesTest)
 }

--- a/detekt-rules-documentation/build.gradle.kts
+++ b/detekt-rules-documentation/build.gradle.kts
@@ -6,6 +6,6 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(testFixtures(projects.detektApi))
 }

--- a/detekt-rules-empty/build.gradle.kts
+++ b/detekt-rules-empty/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -7,5 +7,5 @@ dependencies {
     compileOnly(projects.detektPsiUtils)
     implementation(projects.detektTooling)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-exceptions/build.gradle.kts
+++ b/detekt-rules-exceptions/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }
 
 consumeGeneratedConfig(

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(kotlin("stdlib-jdk8"))
+    compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)

--- a/detekt-rules-naming/build.gradle.kts
+++ b/detekt-rules-naming/build.gradle.kts
@@ -6,5 +6,5 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }
 
 consumeGeneratedConfig(

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    compileOnly(kotlin("stdlib-jdk8"))
+    compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -8,5 +8,5 @@ dependencies {
     compileOnly(projects.detektPsiUtils)
     testImplementation(projects.detektMetrics)
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-rules/build.gradle.kts
+++ b/detekt-rules/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(projects.detektRulesNaming)
     testImplementation(projects.detektRulesPerformance)
     testImplementation(projects.detektRulesStyle)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
     testImplementation(libs.classgraph)
     testImplementation(testFixtures(projects.detektApi))
 }

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -9,5 +9,5 @@ dependencies {
     // When creating a sample extension, change this dependency to the detekt-test version you build against
     // e.g. io.gitlab.arturbosch.detekt:detekt-test:1.x.x
     testImplementation(projects.detektTest)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -4,13 +4,13 @@ plugins {
 }
 
 dependencies {
-    api(libs.kotlin.stdlibJdk8)
-    api(libs.junit.api)
+    api(libs.kotlin.stdlib)
+    api(libs.junit.jupiterApi)
     implementation(projects.detektParser)
     implementation(libs.kotlin.mainKts)
-    implementation(libs.kotlinx.coroutines)
+    implementation(libs.kotlinx.coroutinesCore)
 
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }
 
 apiValidation {

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -7,6 +7,6 @@ dependencies {
     api(projects.detektApi)
     api(projects.detektTestUtils)
     implementation(projects.detektUtils)
-    compileOnly(libs.assertj)
+    compileOnly(libs.assertj.core)
     implementation(projects.detektCore)
 }

--- a/detekt-tooling/build.gradle.kts
+++ b/detekt-tooling/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     api(projects.detektApi)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestUtils)
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }
 
 apiValidation {

--- a/detekt-utils/build.gradle.kts
+++ b/detekt-utils/build.gradle.kts
@@ -3,5 +3,5 @@ plugins {
 }
 
 dependencies {
-    testImplementation(libs.assertj)
+    testImplementation(libs.assertj.core)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,9 +14,9 @@ gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin",
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.
-android-gradle-plugin = "com.android.tools.build:gradle:8.5.1"
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "8.5.1" }
 
-semver4j = "org.semver4j:semver4j:5.3.0"
+semver4j = { module = "org.semver4j:semver4j", version = "5.3.0" }
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
@@ -24,28 +24,28 @@ kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref 
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
-kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.11.0" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 # This represents the oldest AGP version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
-android-gradleApi = "com.android.tools.build:gradle-api:7.1.3"
+android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "7.1.3" }
 
-ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint"  }
+ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version = "1.3.1"  }
 slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 
 junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 
-sarif4k = "io.github.detekt.sarif4k:sarif4k:0.6.0"
-assertj-core = "org.assertj:assertj-core:3.26.3"
-classgraph = "io.github.classgraph:classgraph:4.8.174"
-snakeyaml-engine = "org.snakeyaml:snakeyaml-engine:2.7"
-jcommander = "org.jcommander:jcommander:1.83"
+sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version = "0.6.0" }
+assertj-core = { module = "org.assertj:assertj-core", version = "3.26.3" }
+classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.174" }
+snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version = "2.7" }
+jcommander = { module = "org.jcommander:jcommander", version = "1.83" }
 kctfork-core = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
-jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.1.0" }
 
 [plugins]
 # Do not declare plugins here - see https://github.com/detekt/detekt/pull/7088.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,51 +1,45 @@
 [versions]
-jacoco = "0.8.12"
-kotlin = "2.0.0"
 coroutines = "1.8.1"
-ktlint = "1.3.1"
+jacoco = "0.8.12"
 junit = "5.10.3"
+kotlin = "2.0.0"
+ktlint = "1.3.1"
 slf4j = "2.0.13"
 
 [libraries]
+# This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
+# Gradle plugin remains compatible.
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "8.5.1" }
 binaryCompatibilityValidator-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.16.2" }
 breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-# This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
-# Gradle plugin remains compatible.
-android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "8.5.1" }
-
-semver4j = { module = "org.semver4j:semver4j", version = "5.3.0" }
-
-kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
-kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "kotlin" }
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
-
-kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.11.0" }
-kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 # This represents the oldest AGP version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
 android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "7.1.3" }
-
-ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version = "1.3.1"  }
-slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
-slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
-slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
-
-junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
-
-sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version = "0.6.0" }
 assertj-core = { module = "org.assertj:assertj-core", version = "3.26.3" }
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.174" }
-snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version = "2.7" }
 jcommander = { module = "org.jcommander:jcommander", version = "1.83" }
-kctfork-core = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
 jetbrains-annotations = { module = "org.jetbrains:annotations", version = "24.1.0" }
+junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+kctfork-core = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
+kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
+kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
+kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.11.0" }
+ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version = "1.3.1"  }
+sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version = "0.6.0" }
+semver4j = { module = "org.semver4j:semver4j", version = "5.3.0" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
+slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+snakeyaml-engine = { module = "org.snakeyaml:snakeyaml-engine", version = "2.7" }
 
 [plugins]
 # Do not declare plugins here - see https://github.com/detekt/detekt/pull/7088.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,34 +22,30 @@ semver4j = "org.semver4j:semver4j:5.3.0"
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "kotlin" }
-kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
-kotlin-reflection = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 
 kotlinx-html = "org.jetbrains.kotlinx:kotlinx-html-jvm:0.11.0"
-kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
+kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 
 # This represents the oldest AGP version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.
-android-gradle-minSupported = "com.android.tools.build:gradle-api:7.1.3"
+android-gradleApi = "com.android.tools.build:gradle-api:7.1.3"
 
-# This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
-# Gradle plugin remains compatible.
-android-gradle-maxSupported = "com.android.tools.build:gradle:8.5.1"
-
-ktlintRulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint"  }
+ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint"  }
 slf4j-nop = { module = "org.slf4j:slf4j-nop", version.ref = "slf4j" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
 slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 
-junit-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 
 sarif4k = "io.github.detekt.sarif4k:sarif4k:0.6.0"
-assertj = "org.assertj:assertj-core:3.26.3"
+assertj-core = "org.assertj:assertj-core:3.26.3"
 classgraph = "io.github.classgraph:classgraph:4.8.174"
-snakeyaml = "org.snakeyaml:snakeyaml-engine:2.7"
+snakeyaml-engine = "org.snakeyaml:snakeyaml-engine:2.7"
 jcommander = "org.jcommander:jcommander:1.83"
-kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
+kctfork-core = { module = "dev.zacsweers.kctfork:core", version = "0.5.1" }
 jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,4 @@
 [versions]
-dokka = "1.9.20"
 jacoco = "0.8.12"
 kotlin = "2.0.0"
 coroutines = "1.8.1"
@@ -10,7 +9,7 @@ slf4j = "2.0.13"
 [libraries]
 binaryCompatibilityValidator-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.16.2" }
 breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
-dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "1.9.20" }
 gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,10 +8,18 @@ junit = "5.10.3"
 slf4j = "2.0.13"
 
 [libraries]
+binaryCompatibilityValidator-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.16.2" }
+breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
+dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+# This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
+# Gradle plugin remains compatible.
+android-gradle-plugin = "com.android.tools.build:gradle:8.5.1"
+
 semver4j = "org.semver4j:semver4j:5.3.0"
 
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
-kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "kotlin" }
 kotlin-stdlibJdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
@@ -45,8 +53,4 @@ kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.5.1
 jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
 
 [plugins]
-kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.16.2" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-githubRelease = { id = "com.github.breadmoirai.github-release", version = "2.5.2" }
+# Do not declare plugins here - see https://github.com/detekt/detekt/pull/7088.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,6 @@ slf4j = "2.0.13"
 [libraries]
 semver4j = "org.semver4j:semver4j:5.3.0"
 
-kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }


### PR DESCRIPTION
A somewhat opinionated clean up of our version catalog, based on the best practices published on the Gradle blog: https://blog.gradle.org/best-practices-naming-version-catalog-entries