### PR TITLE
`LongParameterList` uses `BindingContext` so it needs to add `@RequiresTypeResolution`

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterList.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Configuration
 import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
 import io.gitlab.arturbosch.detekt.api.configWithFallback
@@ -24,6 +25,7 @@ import org.jetbrains.kotlin.psi.KtSecondaryConstructor
  */
 @Suppress("ViolatesTypeResolutionRequirements")
 @ActiveByDefault(since = "1.0.0")
+@RequiresTypeResolution
 class LongParameterList(config: Config) : Rule(
     config,
     "The more parameters a function has the more complex it is. Long parameter lists are often " +


### PR DESCRIPTION
I'm not 100% sure about this. `LongParameterList` uses the `bindingContext` but only for the excluder so I'm not sure about how to procede. I see two options:

- This one: `LongParameterList` only works with type resolution
- Remove the Type Resolution from the Excluder. This will make the support of `excludeAnnotation` a bit worst but I think that it will still be good enough.