### PR TITLE
Use correct lint function

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnusedImports
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.Test
 
 class NoUnusedImportsSpec {
@@ -28,7 +28,7 @@ class NoUnusedImportsSpec {
             fun f() = 5
         """.trimIndent()
 
-        val findings = NoUnusedImports(Config.empty).lint(code)
+        val findings = NoUnusedImports(Config.empty).compileAndLint(code)
 
         assertThat(findings)
             .hasSize(3)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -169,7 +168,7 @@ class CyclomaticComplexMethodSpec {
             )
             val subject = CyclomaticComplexMethod(config)
 
-            assertThat(subject.lint(code)).hasStartSourceLocations(SourceLocation(39, 5))
+            assertThat(subject.compileAndLint(code)).hasStartSourceLocations(SourceLocation(39, 5))
         }
 
         @Test
@@ -177,7 +176,7 @@ class CyclomaticComplexMethodSpec {
             val config = TestConfig("allowedComplexity" to "4")
             val subject = CyclomaticComplexMethod(config)
 
-            val findings = subject.lint(code)
+            val findings = subject.compileAndLint(code)
 
             assertThat(findings).hasSize(5)
             assertThat(findings).hasStartSourceLocations(
@@ -195,7 +194,7 @@ class CyclomaticComplexMethodSpec {
             val subject = CyclomaticComplexMethod(config)
 
             val code = """
-|                fun complexMethodWith2Statements(i: Int) {
+                fun complexMethodWith2Statements(i: Int) {
                     when (i) {
                         1 -> print("one")
                         2 -> print("two")
@@ -207,7 +206,7 @@ class CyclomaticComplexMethodSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.lint(code)
+            val findings = subject.compileAndLint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -299,7 +298,7 @@ class CyclomaticComplexMethodSpec {
 }
 
 private fun assertExpectedComplexityValue(code: String, config: TestConfig, expectedValue: Int) {
-    val findings = CyclomaticComplexMethod(config).lint(code)
+    val findings = CyclomaticComplexMethod(config).compileAndLint(code)
 
     assertThat(findings).hasStartSourceLocations(SourceLocation(1, 5))
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 private fun subject(allowedLines: Int) = LargeClass(TestConfig("allowedLines" to allowedLines))
@@ -37,7 +36,7 @@ class LargeClassSpec {
              */
             val aTopLevelPropertyOfNestedClasses = 0
         """.trimIndent()
-        val findings = subject(allowedLines = 4).lint(code)
+        val findings = subject(allowedLines = 4).compileAndLint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocations(SourceLocation(7, 15))
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NestedBlockDepthSpec {
@@ -54,7 +53,7 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.lint(code)
+        val findings = subject.compileAndLint(code)
         assertThat(findings).singleElement()
             .isThresholded()
             .hasValue(5)

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -131,7 +131,7 @@ class EmptyCodeSpec {
     @Test
     fun `reports an empty kotlin file`() {
         val rule = EmptyKotlinFile(Config.empty)
-        assertThat(rule.lint("")).hasSize(1)
+        assertThat(rule.compileAndLint("")).hasSize(1)
     }
 
     @Test

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class EmptyKotlinFileSpec {
@@ -12,7 +11,7 @@ class EmptyKotlinFileSpec {
     @Test
     fun `reports empty if file is blank`() {
         val code = ""
-        assertThat(subject.lint(code))
+        assertThat(subject.compileAndLint(code))
             .singleElement()
             .hasSourceLocation(1, 1)
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -150,7 +150,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -59,7 +58,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasSize(6)
+        assertThat(subject.compileAndLint(code)).hasSize(6)
     }
 
     @Test
@@ -108,7 +107,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -63,7 +63,7 @@ class IteratorHasNextCallsNextMethodSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasSize(4)
+        assertThat(subject.compileAndLint(code)).hasSize(4)
     }
 
     @Test
@@ -91,6 +91,6 @@ class IteratorHasNextCallsNextMethodSpec {
             
             abstract class AbstractIteratorNotOverridden : Iterator<String>
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -63,7 +63,7 @@ class IteratorNotThrowingNoSuchElementExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasSize(4)
+        assertThat(subject.compileAndLint(code)).hasSize(4)
     }
 
     @Test
@@ -91,6 +91,6 @@ class IteratorNotThrowingNoSuchElementExceptionSpec {
             
             abstract class AbstractIteratorNotOverridden : Iterator<String>
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingWhenCaseSpec.kt
@@ -158,7 +158,7 @@ class MissingWhenCaseSpec(private val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                val actual = subject.lintWithContext(env, code)
+                val actual = subject.compileAndLintWithContext(env, code)
                 assertThat(actual).hasSize(1)
                 assertThat(actual.first().message).isEqualTo(
                     "When expression is missing cases: VariantC. Either add missing cases or a default `else` case."

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/RedundantElseInWhenSpec.kt
@@ -207,7 +207,7 @@ class RedundantElseInWhenSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -21,7 +22,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x = 5
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 35)
         }
@@ -32,7 +33,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x = 5
                 val y = checkNotNull(x)
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 33)
         }
@@ -47,7 +48,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 69)
         }
@@ -62,7 +63,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo(5))
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(66 to 88)
         }
@@ -74,7 +75,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(System.currentTimeMillis())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(16 to 58)
         }
@@ -88,7 +89,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -101,7 +102,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -115,7 +116,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x: Int? = 5
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -125,7 +126,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x: Int? = null
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -139,7 +140,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -153,7 +154,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -167,7 +168,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo<Int?>(5))
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -48,7 +47,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasSize(5)
+        assertThat(subject.compileAndLint(code)).hasSize(5)
     }
 
     @Test
@@ -87,7 +86,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -67,7 +66,7 @@ class ThrowingExceptionInMainSpec {
             fun main(args: String) { throw IllegalArgumentException() }
             fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -191,7 +190,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a private top level function`() {
             assertThat(
-                subject.lintWithContext(
+                subject.compileAndLintWithContext(
                     env,
                     """
                         internal fun bar() = 5

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -67,7 +66,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun methodNameEqualsClassName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -77,7 +76,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsObjectName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -87,7 +86,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsClassName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -97,7 +96,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsObjectName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -109,7 +108,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -121,7 +120,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -134,7 +133,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -144,7 +143,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsInterfaceName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -157,7 +156,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -170,7 +169,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -183,7 +182,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -200,7 +199,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -215,7 +214,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -72,7 +72,7 @@ class TopLevelPropertyNamingSpec {
                 val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -80,7 +80,7 @@ class TopLevelPropertyNamingSpec {
             val code = """
                 val _nAme = "Artur"
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -88,7 +88,7 @@ class TopLevelPropertyNamingSpec {
             val code = """
                 private val __NAME = "Artur"
             """.trimIndent()
-            io.gitlab.arturbosch.detekt.test.assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -316,7 +316,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = field.get(null) // access static field
                     }
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -38,7 +37,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
             val klass = Void::class
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -57,14 +57,14 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports functions which return constants`() {
-            assertThat(subject.lint(code)).hasSize(6)
+            assertThat(subject.compileAndLint(code)).hasSize(6)
         }
 
         @Test
         fun `reports overridden functions which return constants`() {
             val config = TestConfig(IGNORE_OVERRIDABLE_FUNCTION to "false")
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.lint(code)).hasSize(9)
+            assertThat(rule.compileAndLint(code)).hasSize(9)
         }
 
         @Test
@@ -110,7 +110,7 @@ class FunctionOnlyReturningConstantSpec {
                 
                 fun functionNotReturningConstantString1(str: String) = "str: ${'$'}str"
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -33,13 +33,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -67,13 +67,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -101,13 +101,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 14)
         }
     }
@@ -118,13 +118,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -135,26 +135,26 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
         @Test
         fun `should be ignored when ignoredNumbers contains it verbatim`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2L"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2L"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be ignored when ignoredNumbers contains it as floating point`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2f"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2f"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be ignored when ignoredNumbers contains 2 but not -2`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0")))
-                .lint(code)
+                .compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -182,13 +182,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
     }
@@ -216,13 +216,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -250,13 +250,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers contains 300`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains a floating point 300`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300.0"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300.0"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -267,13 +267,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains a binary literal 0b01001`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("0b01001"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("0b01001"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -284,25 +284,25 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
 
         @Test
         fun `should not be reported when ignored verbatim`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100_000"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100_000"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored with different underscores`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("10_00_00"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("10_00_00"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored without underscores`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100000"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100000"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -313,7 +313,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(1, 17),
@@ -327,7 +327,7 @@ class MagicNumberSpec {
     @Nested
     inner class `a when statement with magic numbers` {
         val code = """
-            fun test(x: Int) {
+            fun test(x: Int): Int {
                 when (x) {
                     5 -> return 5
                     4 -> return 4
@@ -360,7 +360,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -375,7 +375,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -386,7 +386,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -398,13 +398,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains it`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf(".5"))).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf(".5"))).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -520,7 +520,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not report any issues by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -532,7 +532,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -544,7 +544,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -556,7 +556,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -568,7 +568,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -580,7 +580,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings).hasStartSourceLocation(4, 35)
         }
 
@@ -592,7 +592,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).compileAndLint(code)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(4, 35),
@@ -607,7 +607,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not lead to a crash #276`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -628,7 +628,7 @@ class MagicNumberSpec {
             @Test
             fun `should not ignore int`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.lint(code("53"))).hasSize(1)
+                assertThat(rule.compileAndLint(code("53"))).hasSize(1)
             }
 
             @Test
@@ -640,23 +640,23 @@ class MagicNumberSpec {
             @Test
             fun `should not ignore binary`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.lint(code("0b01001"))).hasSize(1)
+                assertThat(rule.compileAndLint(code("0b01001"))).hasSize(1)
             }
 
             @Test
             fun `should ignore integer with underscores`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.lint(code("101_000"))).hasSize(1)
+                assertThat(rule.compileAndLint(code("101_000"))).hasSize(1)
             }
 
             @Test
             fun `should ignore numbers by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code("53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code("53"))).isEmpty()
             }
 
             @Test
             fun `should ignore negative numbers by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code("-53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code("-53"))).isEmpty()
             }
 
             @Test
@@ -691,21 +691,21 @@ class MagicNumberSpec {
 
             @Test
             fun `should detect the argument by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code("53"))).hasSize(1)
+                assertThat(MagicNumber(Config.empty).compileAndLint(code("53"))).hasSize(1)
             }
         }
 
         @Nested
         inner class `in function invocation` {
             private fun code(number: Number) = """
-                fun tested(someVal: Int, other: String = "default")
+                fun tested(someVal: Int, other: String = "default") {}
                 
                 val t = tested(someVal = $number)
             """.trimIndent()
 
             @Test
             fun `should ignore int by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code(53))).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code(53))).isEmpty()
             }
 
             @Test
@@ -715,12 +715,12 @@ class MagicNumberSpec {
 
             @Test
             fun `should ignore binary by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code(0b01001))).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code(0b01001))).isEmpty()
             }
 
             @Test
             fun `should ignore integer with underscores`() {
-                assertThat(MagicNumber(Config.empty).lint(code(101_000))).isEmpty()
+                assertThat(MagicNumber(Config.empty).compileAndLint(code(101_000))).isEmpty()
             }
         }
 
@@ -735,13 +735,13 @@ class MagicNumberSpec {
 
             @Test
             fun `should be reported by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
+                assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(1)
             }
 
             @Test
             fun `numbers when 'ignoreEnums' is set to true`() {
                 val rule = MagicNumber(TestConfig(IGNORE_ENUMS to "true"))
-                assertThat(rule.lint(code)).isEmpty()
+                assertThat(rule.compileAndLint(code)).isEmpty()
             }
         }
 
@@ -757,7 +757,7 @@ class MagicNumberSpec {
             @Test
             fun `should be reported`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.lint(code)).hasSize(1)
+                assertThat(rule.compileAndLint(code)).hasSize(1)
             }
 
             @Test
@@ -768,7 +768,7 @@ class MagicNumberSpec {
                         IGNORE_ENUMS to "true",
                     )
                 )
-                assertThat(rule.lint(code)).isEmpty()
+                assertThat(rule.compileAndLint(code)).isEmpty()
             }
         }
 
@@ -814,19 +814,22 @@ class MagicNumberSpec {
         @Test
         fun `reports no finding`() {
             val code = "class SomeClassWithDefault(val defaultValue: Int = 10)"
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for an explicit declaration`() {
             val code = "class SomeClassWithDefault constructor(val defaultValue: Int = 10)"
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
-            val code =
-                "class SomeClassWithDefault constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS))"
+            val code = """
+                import java.time.Duration
+
+                class SomeClassWithDefault constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS))
+            """.trimIndent()
             assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
     }
@@ -838,17 +841,17 @@ class MagicNumberSpec {
         fun `reports no finding`() {
             val code = """
                 class SomeClassWithDefault {
-                    constructor(val defaultValue: Int = 10) { }
+                    constructor(defaultValue: Int = 10) { }
                 }
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
             val code = """
                 class SomeClassWithDefault {
-                    constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
+                    constructor(defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
                 }
             """.trimIndent()
             assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
@@ -860,13 +863,13 @@ class MagicNumberSpec {
 
         @Test
         fun `reports no finding`() {
-            val code = "fun f(p: Int = 100)"
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            val code = "fun f(p: Int = 100) {}"
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
-            val code = "fun f(p: Duration = 10.toDuration(DurationUnit.MILLISECONDS))"
+            val code = "fun f(p: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) {}"
             assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
     }
@@ -888,33 +891,33 @@ class MagicNumberSpec {
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell by default`(code: String) {
-            assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
+            assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell if ranges are not ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).compileAndLint(code))
                 .hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports no finding if ranges are ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code))
                 .isEmpty()
         }
 
         @Test
         fun `reports a finding for a parenthesized number if ranges are ignored`() {
             val code = "val foo : Int = (127)"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code)).hasSize(1)
         }
 
         @Test
         fun `reports a finding for an addition if ranges are ignored`() {
             val code = "val foo : Int = 1 + 27"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code)).hasSize(1)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -141,7 +141,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report long imports`() {
         val code = "import a.b.c.d.e"
 
-        assertThat(rule.lint(code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -34,7 +34,7 @@ class ModifierOrderSpec {
             assertThat(subject.compileAndLint("internal data class Test(val test: String)")).isEmpty()
             assertThat(subject.lint("private actual class Test(val test: String)")).isEmpty()
             assertThat(subject.lint("expect annotation class Test")).isEmpty()
-            assertThat(subject.lint("private /* comment */ data class Test(val test: String)")).isEmpty()
+            assertThat(subject.compileAndLint("private /* comment */ data class Test(val test: String)")).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NewLineAtEndOfFileSpec {
@@ -26,6 +25,6 @@ class NewLineAtEndOfFileSpec {
     @Test
     fun `should not flag an empty kt file`() {
         val code = ""
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10 - 1) {}
             }
         """.trimIndent()
-        val findings = subject.lint(code)
+        val findings = subject.compileAndLint(code)
         assertThat(findings).singleElement().hasMessage("`..` call can be replaced with `..<`")
     }
 
@@ -28,7 +28,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 ..< 10 - 1) {}
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10) {}
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -49,26 +49,26 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10 - 2) {}
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
     @DisplayName("reports for '..'")
     fun reportsForDoubleDots() {
         val code = "val r = 0 .. 10 - 1"
-        assertThat(subject.lint(code)).hasSize(1)
+        assertThat(subject.compileAndLint(code)).hasSize(1)
     }
 
     @Test
     fun `does not report binary expressions without a range operator`() {
         val code = "val sum = 1 + 2"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
     fun `reports for 'rangeTo'`() {
         val code = "val r = 0.rangeTo(10 - 1)"
-        val findings = subject.lint(code)
+        val findings = subject.compileAndLint(code)
         assertThat(findings).singleElement().hasMessage("`rangeTo` call can be replaced with `..<`")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
@@ -175,7 +175,7 @@ class RedundantVisibilityModifierSpec {
         val code = compileContentForTest(
             """
                 public class A() {
-                    fun f()
+                    fun f() {}
                 }
             """.trimIndent()
         )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
@@ -26,7 +26,7 @@ class SpacingAfterPackageDeclarationSpec {
     @Test
     fun `has no import declaration`() {
         val code = "package test\n\nclass A {}"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class SpacingAfterPackageDeclarationSpec {
     @Test
     fun `has no package and import declaration`() {
         val code = "class A {}"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test
@@ -49,7 +49,7 @@ class SpacingAfterPackageDeclarationSpec {
 
     @Test
     fun `is an empty kt file`() {
-        assertThat(subject.lint("")).isEmpty()
+        assertThat(subject.compileAndLint("")).isEmpty()
     }
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -20,7 +21,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ThrowsCount(Config.empty).lint(code)).isEmpty()
+            assertThat(ThrowsCount(Config.empty).compileAndLint(code)).isEmpty()
         }
     }
 
@@ -32,13 +33,15 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ThrowsCount(Config.empty).lint(code)).isEmpty()
+            assertThat(ThrowsCount(Config.empty).compileAndLint(code)).isEmpty()
         }
     }
 
     @Nested
     inner class `code with 2 throw expressions` {
         val code = """
+            import java.io.IOException
+
             fun f2(x: Int) {
                 when (x) {
                     1 -> throw IOException()
@@ -50,13 +53,15 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation`() {
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 
     @Nested
     inner class `code with 3 throw expressions` {
         val code = """
+            import java.io.IOException
+
             fun f1(x: Int) {
                 when (x) {
                     1 -> throw IOException()
@@ -69,13 +74,15 @@ class ThrowsCountSpec {
 
         @Test
         fun `reports violation by default`() {
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 
     @Nested
     inner class `code with an override function with 3 throw expressions` {
         val code = """
+            import java.io.IOException
+
             override fun f3(x: Int) {
                 when (x) {
                     1 -> throw IOException()
@@ -112,7 +119,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `reports violation by default`() {
-            val findings = subject.lint(code)
+            val findings = subject.compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.location.source.line).isEqualTo(4)
         }
@@ -121,6 +128,8 @@ class ThrowsCountSpec {
     @Nested
     inner class `max count == 3` {
         val code = """
+            import java.io.IOException
+
             fun f4(x: String?) {
                 val denulled = x ?: throw IOException()
                 val int = x?.toInt() ?: throw IOException()
@@ -132,14 +141,14 @@ class ThrowsCountSpec {
         fun `does not report when max parameter is 3`() {
             val config = TestConfig(MAX to "3")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
         fun `reports violation when max parameter is 2`() {
             val config = TestConfig(MAX to "2")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 
@@ -160,14 +169,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithGuardClause)).isEmpty()
+            assertThat(subject.compileAndLint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithGuardClause)).hasSize(1)
         }
     }
 
@@ -188,14 +197,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithGuardClause)).isEmpty()
+            assertThat(subject.compileAndLint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithGuardClause)).hasSize(1)
         }
     }
 
@@ -223,7 +232,7 @@ class ThrowsCountSpec {
         fun `should report violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -244,7 +253,7 @@ class ThrowsCountSpec {
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -265,7 +274,7 @@ class ThrowsCountSpec {
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -289,14 +298,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithMultipleGuardClauses)).isEmpty()
+            assertThat(subject.compileAndLint(codeWithMultipleGuardClauses)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.lint(codeWithMultipleGuardClauses)).hasSize(1)
+            assertThat(subject.compileAndLint(codeWithMultipleGuardClauses)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -138,7 +137,8 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report if result of apply is used - #2938`() {
             assertThat(
-                subject.compileAndLint(
+                subject.compileAndLintWithContext(
+                    env,
                     """
                         fun main() {
                             val a = listOf(mutableListOf(""))

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -122,7 +121,7 @@ class UnnecessaryBackticksSpec {
                 import test.`Foo Bar`
                 class `Foo Bar`
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -10,7 +11,7 @@ class UnnecessaryInheritanceSpec {
 
     @Test
     fun `has unnecessary super type declarations`() {
-        val findings = subject.lint(
+        val findings = subject.compileAndLint(
             """
                 class A : Any()
                 class B : Object()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -35,7 +36,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Nested
@@ -50,7 +51,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -65,7 +66,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Nested
@@ -85,7 +86,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -103,7 +104,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -121,7 +122,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -142,7 +143,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -161,7 +162,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -180,7 +181,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -218,7 +219,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -237,7 +238,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -254,7 +255,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -271,7 +272,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -288,7 +289,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -311,7 +312,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -328,7 +329,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -352,7 +353,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -371,7 +372,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -388,7 +389,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -414,7 +415,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -429,7 +430,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -438,13 +439,13 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             class A {
                 inner class B {
                     fun inner() {
-                        return Unit.apply { this@inner }
+                        return Unit.apply { this@B }
                     }
                 }
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -459,6 +460,6 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Named
@@ -15,7 +16,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on val assignment`(testCase: RuleTestCase) {
         val code = "val local = (5)"
 
-        assertThat(testCase.rule.lint(code)).hasSize(1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -23,7 +24,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on val assignment operation`(testCase: RuleTestCase) {
         val code = "val local = (5 + 3)"
 
-        assertThat(testCase.rule.lint(code)).hasSize(1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -31,7 +32,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on function call`(testCase: RuleTestCase) {
         val code = "val local = 3.plus((5))"
 
-        assertThat(testCase.rule.lint(code)).hasSize(1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -39,13 +40,13 @@ class UnnecessaryParenthesesSpec {
     fun `unnecessary parentheses in other parentheses`(testCase: RuleTestCase) {
         val code = """
             fun x(a: String, b: String) {
-                if ((a equals b)) {
+                if ((a == b)) {
                     println("Test")
                 }
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -61,7 +62,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -77,7 +78,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -97,13 +98,13 @@ class UnnecessaryParenthesesSpec {
     fun `does not report well behaved parentheses`(testCase: RuleTestCase) {
         val code = """
             fun x(a: String, b: String) {
-                if (a equals b) {
+                if (a == b) {
                     println("Test")
                 }
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -166,7 +167,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -185,7 +186,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -216,7 +217,7 @@ class UnnecessaryParenthesesSpec {
             class Clazz: Comparable<String> by ("hello".filter { it != 'l' })
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -234,7 +235,7 @@ class UnnecessaryParenthesesSpec {
             val c = (4 + 5) * 3 // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
     }
 
     @ParameterizedTest
@@ -248,7 +249,7 @@ class UnnecessaryParenthesesSpec {
             val b2 = (1 * 2) * 3
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(5)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -261,7 +262,7 @@ class UnnecessaryParenthesesSpec {
             val c = (true || false) && false // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
 
     @ParameterizedTest
@@ -275,7 +276,7 @@ class UnnecessaryParenthesesSpec {
             val b2 = (true || false) || false
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(5)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -286,7 +287,7 @@ class UnnecessaryParenthesesSpec {
             val e = false or (true and false) // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -330,7 +331,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -347,7 +348,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 2)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 2)
     }
 
     @ParameterizedTest
@@ -385,7 +386,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -408,7 +409,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
 
     @ParameterizedTest
@@ -428,7 +429,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -447,7 +448,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -467,7 +468,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @Test
@@ -489,7 +490,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.lint(code)).hasSize(3)
+        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.compileAndLint(code)).hasSize(3)
     }
 
     @Test
@@ -510,7 +511,7 @@ class UnnecessaryParenthesesSpec {
                 val violation3 = ++((a.value))
             }
         """.trimIndent()
-        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.lint(code)).hasSize(5)
+        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.compileAndLint(code)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -533,7 +534,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -557,7 +558,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 3)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 3)
     }
 
     @ParameterizedTest
@@ -567,7 +568,7 @@ class UnnecessaryParenthesesSpec {
             val a = ((false || (((true && false)))))
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
     }
 
     companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -592,7 +593,7 @@ class UnusedImportSpec(val env: KotlinCoreEnvironment) {
             fun doesNothing(thing: HashMap<String, String>) {
             }
         """.trimIndent()
-        val findings = subject.lintWithContext(env, code)
+        val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -607,7 +608,7 @@ class UnusedImportSpec(val env: KotlinCoreEnvironment) {
             @Ann(HashMap::class)
             fun foo() {}
         """.trimIndent()
-        val findings = subject.lintWithContext(env, code)
+        val findings = subject.compileAndLintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -1,17 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-@KotlinCoreEnvironmentTest
-class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
+class UnusedParameterSpec {
     val subject = UnusedParameter(Config.empty)
 
     @Nested
@@ -24,7 +21,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -35,7 +32,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -46,7 +43,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -57,7 +54,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -68,7 +65,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -83,7 +80,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -97,13 +94,13 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                         return 5
                     }
                 
-                    private fun usedMethod2(unusedParameter: Int) {
+                    private fun usedMethod2(unusedParameter: Int): Int {
                         return 5
                     }
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(2)
+            assertThat(subject.compileAndLint(code)).hasSize(2)
         }
 
         @Test
@@ -118,7 +115,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -133,7 +130,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -148,7 +145,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
 
         @Test
@@ -163,7 +160,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.compileAndLint(code)).hasSize(1)
         }
     }
 
@@ -175,7 +172,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 fun foo(@Suppress("UnusedParameter") unused: String){}
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -184,7 +181,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 fun foo(@Suppress("UnusedParameter") unused: String, unusedWithoutAnnotation: String){}
             """.trimIndent()
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$unusedWithoutAnnotation: String")
@@ -197,7 +194,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 fun foo(unused: String, otherUnused: String){}
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -210,7 +207,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -222,7 +219,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -238,7 +235,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 
@@ -250,7 +247,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                 fun foo(unused: Int){}
             """.trimIndent()
 
-            val lint = subject.lint(code)
+            val lint = subject.compileAndLint(code)
 
             assertThat(lint.first().message).startsWith("Function parameter")
         }
@@ -270,7 +267,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
 
         @Test
@@ -280,7 +277,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                     println("b")
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 
@@ -291,7 +288,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(`foo bar`: Int) = `foo bar`
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 
@@ -310,7 +307,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                     ) = 1
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(6, 9)
+            assertThat(subject.compileAndLint(code)).hasSize(1).hasStartSourceLocation(6, 9)
         }
     }
 
@@ -327,7 +324,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1).hasStartSourceLocation(1, 9)
+            assertThat(subject.compileAndLint(code)).hasSize(1).hasStartSourceLocation(1, 9)
         }
 
         @Test
@@ -341,7 +338,7 @@ class UnusedParameterSpec(val env: KotlinCoreEnvironment) {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLint(code)).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -429,7 +428,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).lint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -454,7 +453,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).lint(code)
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(10, 5)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -194,7 +194,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 private fun unusedTopLevelFunction() = 5
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -206,7 +206,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     calledFromMain()
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -304,7 +304,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): String = ""
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -313,7 +313,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): String = ""
             """.trimIndent()
 
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.signature).isEqualTo("Test.kt\$private fun foo(): String")
@@ -404,7 +404,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -415,7 +415,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -426,7 +426,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     private operator fun A.invoke(i: Int): Int = i
                     val answer = B()(1)
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -456,7 +456,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code))
+                assertThat(subject.compileAndLintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(
                         SourceLocation(3, 24)
@@ -473,7 +473,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(nullableInt)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code))
+                assertThat(subject.compileAndLintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(
                         SourceLocation(2, 24)
@@ -862,7 +862,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -881,7 +881,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -900,7 +900,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -45,7 +45,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -59,7 +59,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -73,7 +73,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -88,14 +88,14 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `does fail when enabled with invalid regex`() {
             val config = TestConfig(ALLOWED_NAMES_PATTERN to "*foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java)
-                .isThrownBy { UnusedPrivateProperty(config).lint(regexTestingCode) }
+                .isThrownBy { UnusedPrivateProperty(config).compileAndLintWithContext(env, regexTestingCode) }
         }
     }
 
@@ -114,7 +114,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(0)
         }
 
@@ -129,7 +129,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocation(4, 21)
         }
@@ -146,7 +146,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(2)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -161,7 +161,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -176,7 +176,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -212,7 +212,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -237,7 +237,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     println(o("$\\{PC.Companion.OO.BLA.toString()}"))
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
     }
 
@@ -258,7 +258,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(4)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
         }
 
         @Test
@@ -272,7 +272,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     const val TEXT = "text"
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -291,7 +291,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -305,7 +305,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -321,7 +321,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -349,7 +349,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -362,7 +362,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(1, 13))
         }
@@ -374,7 +374,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                private val ignored = 3 // ignored   
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
         }
     }
@@ -389,7 +389,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val ignored = ""
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -407,7 +407,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 27),
@@ -429,7 +429,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 17),
@@ -446,7 +446,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -459,7 +459,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -471,7 +471,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Test(@Suppress("UnusedPrivateProperty") private val foo: String) {}
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -483,7 +483,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 ) {}
             """.trimIndent()
 
-            val lint = subject.lintWithContext(env, code)
+            val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$Test\$private val bar: String")
@@ -499,7 +499,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 ) {}
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -516,7 +516,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -527,7 +527,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -539,7 +539,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val lint = subject.lintWithContext(env, code)
+            val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$Test\$private val bar: String = \"bar\"")
@@ -555,7 +555,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -573,7 +573,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -589,7 +589,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val foo = 1
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
     }
 
@@ -622,7 +622,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                class Test(vararg unused: Any)
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -633,7 +633,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Child(private vararg val used: Any) : Parent(used)
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -644,16 +644,16 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Foo(private vararg val used: Any) : Super(used)
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .isEmpty()
         }
 
         @Test
         fun `reports destructuring vararg parameters`() {
             val code = """
-            class TestConfig(val foo: String, vararg pairs: Pair<String, Any>) : Config {
-                val values: Map<String, Any> = mapOf(*pairs)
-            }
+                class TestConfig(val foo: String, vararg pairs: Pair<String, Any>) : Config {
+                    val values: Map<String, Any> = mapOf(*pairs)
+                }
             """.trimIndent()
 
             assertThat(subject.lintWithContext(env, code))
@@ -665,7 +665,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(private val unused: Any)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -680,7 +680,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isNotEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isNotEmpty()
         }
 
         @Test
@@ -688,7 +688,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(val unused: Any)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -698,7 +698,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     init { used.toString() }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -710,7 +710,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -721,7 +721,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val bar: String,
                 )
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -732,7 +732,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val bar: String,
                 )
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -741,7 +741,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 @JvmInline value class Foo(private val value: String)
                 inline class Bar(private val value: String)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -752,7 +752,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(unused: Any)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -761,7 +761,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 open class Parent(val ignored: Any)
                 class Test(used: Any) : Parent(used)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -773,7 +773,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -783,7 +783,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     val usedString = used.toString()
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -795,7 +795,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     val findings: Map<Any,Any>
                 ) : Detektion by result
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -812,7 +812,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     constructor(used: Any)
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(2)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
@@ -41,7 +41,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 fun foo() { val unused = 1 }
             """.trimIndent()
 
-            val lint = subject.lintWithContext(env, code)
+            val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint.first())
                 .hasMessage("Variable `unused` is unused.")
@@ -61,7 +61,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }
@@ -76,7 +76,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(3, 9),
@@ -90,7 +90,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 fun foo(bar:Int) { }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).hasSize(0)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
         }
     }
 
@@ -107,7 +107,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(4, 13))
         }
@@ -130,7 +130,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(5, 11))
         }
@@ -162,7 +162,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -172,7 +172,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                   for (i in 0 until 10) { }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(2, 8))
         }
@@ -187,7 +187,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -200,7 +200,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(2)
+            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -214,7 +214,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -281,7 +281,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val results = subject.lintWithContext(env, code)
+            val results = subject.compileAndLintWithContext(env, code)
             assertThat(results).hasSize(2)
             assertThat(results).anyMatch { it.message == "Variable `org` is unused." }
             assertThat(results).anyMatch { it.message == "Variable `detekt` is unused." }
@@ -350,7 +350,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(2, 16))
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -367,7 +366,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report inline classes`() {
-        assertThat(subject.lint("inline class A(val x: Int)")).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, "inline class A(val x: Int)")).isEmpty()
     }
 
     @Test
@@ -376,7 +375,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             @JvmInline
             value class A(val x: Int)
         """.trimIndent()
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -19,7 +20,7 @@ class UtilityClassWithPublicConstructorSpec {
 
         @BeforeEach
         fun beforeEachTest() {
-            findings = subject.lint(
+            findings = subject.compileAndLint(
                 """
                     class UtilityClassWithDefaultConstructor { // violation
                         companion object {
@@ -97,7 +98,7 @@ class UtilityClassWithPublicConstructorSpec {
         @Suppress("LongMethod") // TODO split this up into multiple test case functions.
         @Test
         fun `does not report given classes`() {
-            val findings = subject.lint(
+            val findings = subject.compileAndLint(
                 """
                     class UtilityClassWithPrimaryPrivateConstructorOk private constructor() {
                         companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLint
-import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -67,7 +66,7 @@ class WildcardImportSpec {
                 import java.util.*
             """.trimIndent()
 
-            val findings = WildcardImport(Config.empty).lint(code2)
+            val findings = WildcardImport(Config.empty).compileAndLint(code2)
             assertThat(findings).isEmpty()
         }
     }


### PR DESCRIPTION
There were places where we were using `compileAndLint` that we should use `compileAndLintWithContext`, other that use `lint` that could use `compileAndLint` and similar cases. This PR fixes a lot of them (probably this is not exhaustive but at least it's better than before).

This PR will also help to move from `@RequireTypeSolving` as an annotation to an interface.