### PR TITLE
UnnecessaryReversed style rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -778,6 +778,8 @@ style:
   UnnecessaryParentheses:
     active: false
     allowForUnclearPrecedence: false
+  UnnecessaryReversed:
+    active: false
   UnusedImport:
     active: false
   UnusedParameter:

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/StyleGuideProvider.kt
@@ -115,6 +115,7 @@ class StyleGuideProvider : DefaultRuleSetProvider {
             ::DoubleNegativeLambda,
             ::UseLet,
             ::DoubleNegativeExpression,
+            ::UnnecessaryReversed,
         )
     )
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversed.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversed.kt
@@ -1,0 +1,95 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.rules.isCalling
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+
+/**
+ * `if` expressions that either check for not-null and return `null` in the false case or check for `null` and returns
+ * `null` in the truthy case are better represented as `?.let {}` blocks.
+ *
+ * <noncompliant>
+ * listOf(1,2)
+ *  .sorted()
+ *  .asReversed()
+ * </noncompliant>
+ *
+ * <compliant>
+ * listOf(1,2)
+ *  .sortedDescending()
+ * </compliant>
+ */
+@RequiresTypeResolution
+class UnnecessaryReversed(
+    config: Config,
+) : Rule(
+    config,
+    "Use single sort operation instead of sorting followed by `.asReversed()`, " +
+        "eg. use `.sortedByDescending { .. }` instead of `.sortedBy { it.priority }.asReversed()`",
+) {
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (!expression.isCalling(reverseFunctionNames, bindingContext)) return
+
+        val parentCall = expression.getPrevCallInChainOrNull() ?: return
+
+        val parentCallFqName = parentCall.getResolvedCall(bindingContext)
+            ?.resultingDescriptor
+            ?.fqNameOrNull()
+            ?: return
+
+        val callFqName = expression.getResolvedCall(bindingContext)
+            ?.resultingDescriptor
+            ?.fqNameOrNull()
+            ?: return
+
+        if (!parentCall.isCalling(sortFunctionNames, bindingContext)) return
+
+        val suggestion = reversePairs[parentCallFqName]?.let {
+            "Replace `${parentCallFqName.shortName()}().${callFqName.shortName()}()` by single `${it.shortName()}()`"
+        } ?: description
+
+        report(
+            CodeSmell(
+                entity = Entity.from(expression),
+                message = suggestion,
+                references = listOf(Entity.from(expression), Entity.from(parentCall)),
+            ),
+        )
+    }
+
+    private fun KtExpression.getPrevCallInChainOrNull(): KtCallExpression? =
+        parent.collectDescendantsOfType<KtCallExpression>()
+            .dropLastWhile { it.psiOrParent == psiOrParent }
+            .lastOrNull()
+
+    companion object {
+        private val reverseFunctionNames = listOf(
+            FqName("kotlin.collections.reversed"),
+            FqName("kotlin.collections.asReversed"),
+        )
+
+        private val sortFunctionNames = listOf(
+            FqName("kotlin.collections.sortedBy"),
+            FqName("kotlin.collections.sortedByDescending"),
+            FqName("kotlin.collections.sorted"),
+            FqName("kotlin.collections.sortedDescending"),
+        )
+
+        private val reversePairs = mapOf(
+            FqName("kotlin.collections.sortedBy") to FqName("kotlin.collections.sortedByDescending"),
+            FqName("kotlin.collections.sorted") to FqName("kotlin.collections.sortedDescending"),
+        ).let { map ->
+            map + map.map { it.value to it.key }.toMap()
+        }
+    }
+}

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
@@ -1,0 +1,98 @@
+package io.gitlab.arturbosch.detekt.rules.style
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class UnnecessaryReversedSpec(
+    val env: KotlinCoreEnvironment,
+) {
+    val subject = UnnecessaryReversed(Config.empty)
+
+    @Test
+    @Suppress("IgnoredReturnValue")
+    fun `reports when sortedBy is followed by asReversed()`() {
+        val code =
+            """
+            fun foo() {
+             val bar = listOf(1, 2, 3)
+              .sorted()
+                 .asReversed()
+                }
+            """.trimIndent()
+
+        val findings = subject.compileAndLintWithContext(env, code)
+
+        assertThat(findings)
+            .isNotEmpty
+            .hasStartSourceLocation(4, 7)
+            .withFailMessage("Replace `sorted().asReversed()` by single `sortedDescending()`")
+    }
+
+    @Test
+    @Suppress("IgnoredReturnValue")
+    fun `reports when sortedBy is followed by reversed()`() {
+        val code =
+            """
+            fun foo() {
+                val bar = listOf(1, 2, 3)
+                    .sorted()
+                    .reversed()
+             }
+            """.trimIndent()
+
+        val findings = subject.compileAndLintWithContext(env, code)
+
+        assertThat(findings)
+            .isNotEmpty
+            .hasStartSourceLocation(4, 10)
+            .withFailMessage("Replace `sorted().reversed()` by single `sortedDescending()`")
+            .isNotNull()
+    }
+
+    @Test
+    @Suppress("IgnoredReturnValue")
+    fun `reports when sortedDescending is followed by asReversed()`() {
+        val code =
+            """
+            fun foo() {
+                val bar = listOf(1, 2, 3)
+                    .sortedDescending()
+                    .asReversed()
+             }
+            """.trimIndent()
+
+        val findings = subject.compileAndLintWithContext(env, code)
+
+        assertThat(findings)
+            .isNotEmpty
+            .hasStartSourceLocation(4, 10)
+            .withFailMessage("Replace `sortedDescending().asReversed()` by single `sorted()`")
+            .isNotNull()
+    }
+
+    @Test
+    @Suppress("IgnoredReturnValue")
+    fun `reports when sortedDescending is followed by reversed()`() {
+        val code =
+            """
+            fun foo() {
+                val bar = listOf(1, 2, 3)
+                    .sortedDescending()
+                    .reversed()
+             }
+            """.trimIndent()
+
+        val findings = subject.compileAndLintWithContext(env, code)
+
+        assertThat(findings)
+            .isNotEmpty
+            .hasStartSourceLocation(4, 10)
+            .withFailMessage("Replace `sortedDescending().reversed()` by single `sorted()`")
+            .isNotNull()
+    }
+}


### PR DESCRIPTION
Introduces a new style rule to fix #7480 that detects collection reversal immediately after a sorting operation. 

## non-compliant

```kt
 listOf(1,2)
 .sorted()
 .asReversed()
```
## compliant

```kt
 listOf(1,2)
 .sortedDescending()
```