### PR TITLE
md report doesn't depend on ktElement any more

### DIFF
--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -6,24 +6,24 @@ import io.github.detekt.metrics.processors.complexityKey
 import io.github.detekt.metrics.processors.linesKey
 import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
-import io.github.detekt.test.utils.internal.FakeKtElement
-import io.github.detekt.test.utils.internal.FakePsiFile
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.test.TestDetektion
+import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createEntity
 import io.gitlab.arturbosch.detekt.test.createIssue
 import io.gitlab.arturbosch.detekt.test.createLocation
 import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
-import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.psi.KtElement
 import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+import kotlin.io.path.absolute
 
 class MdOutputReportSpec {
-    private val mdReport = MdOutputReport()
+    private val basePath = Path("src/test/resources").absolute()
+    private val mdReport = MdOutputReport().apply { init(TestSetupContext(basePath = basePath)) }
     private val detektion = createTestDetektionWithMultipleSmells()
     private val result = mdReport.render(detektion)
         .replace("""\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d UTC""".toRegex(), "2024-07-21 21:34:16 UTC")
@@ -211,54 +211,15 @@ class MdOutputReportSpec {
     }
 }
 
-private fun fakeKtElement(): KtElement {
-    @Language("kotlin")
-    val code = """
-        package com.example.test
-        
-        import io.github.*
-        
-        class Test() {
-            val greeting: String = "Hello, World!"
-        
-            init {
-                println(greetings)
-            }
-        
-            fun foo() {
-                println(greetings)
-                return this
-            }
-        }
-    """.trimIndent()
-    val fakePsiFile = FakePsiFile(code)
-    val fakeKtElement = FakeKtElement(fakePsiFile)
-
-    return fakeKtElement
-}
-
 private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = createEntity(
-        location = createLocation(
-            path = "src/main/com/sample/Sample1.kt",
-            position = 9 to 17,
-            text = 17..20,
-        ),
-        ktElement = fakeKtElement(),
+        location = createLocation(path = "src/main/com/sample/Sample1.kt", position = 9 to 17, text = 17..20),
     )
     val entity2 = createEntity(
-        location = createLocation(
-            path = "src/main/com/sample/Sample2.kt",
-            position = 13 to 17,
-        ),
-        ktElement = fakeKtElement(),
+        location = createLocation(path = "src/main/com/sample/Sample2.kt", position = 13 to 17),
     )
     val entity3 = createEntity(
-        location = createLocation(
-            path = "src/main/com/sample/Sample3.kt",
-            position = 14 to 16,
-        ),
-        ktElement = fakeKtElement(),
+        location = createLocation(path = "src/main/com/sample/Sample3.kt", position = 14 to 16),
     )
 
     return createMdDetektion(

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -26,6 +26,110 @@ class MdOutputReportSpec {
     private val mdReport = MdOutputReport()
     private val detektion = createTestDetektionWithMultipleSmells()
     private val result = mdReport.render(detektion)
+        .replace("""\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d UTC""".toRegex(), "2024-07-21 21:34:16 UTC")
+        .replace("""\[detekt version \d+\.\d+.\d+]""".toRegex(), "[detekt version 1.23.6]")
+
+    @Suppress("LongMethod")
+    @Test
+    fun checkAll() {
+        assertThat(result).isEqualTo(
+            """
+                # detekt
+                
+                ## Metrics
+                
+                * 10,000 M1
+                
+                * 2 M2
+                
+                ## Complexity Report
+                
+                * 2,222 lines of code (loc)
+                
+                * 20 source lines of code (sloc)
+                
+                * 10 logical lines of code (lloc)
+                
+                * 2 comment lines of code (cloc)
+                
+                * 10 cyclomatic complexity (mcc)
+                
+                * 10 cognitive complexity
+                
+                * 3 number of total code smells
+                
+                * 10% comment source ratio
+                
+                * 1,000 mcc per 1,000 lloc
+                
+                * 300 code smells per 1,000 lloc
+                
+                ## Issues (3)
+                
+                ### Section-1, rule_a/id (2)
+                
+                Description rule_a
+                
+                [Documentation](https://detekt.dev/docs/rules/section-1#rule_a)
+                
+                * src/main/com/sample/Sample1.kt:9:17
+                ```
+                Issue message 1
+                ```
+                ```kotlin
+                6      val greeting: String = "Hello, World!"
+                7  
+                8      init {
+                9          println(greetings)
+                !                  ^ error
+                10     }
+                11 
+                12     fun foo() {
+                
+                ```
+                
+                * src/main/com/sample/Sample2.kt:13:17
+                ```
+                Issue message 2
+                ```
+                ```kotlin
+                10     }
+                11 
+                12     fun foo() {
+                13         println(greetings)
+                !!                 ^ error
+                14         return this
+                15     }
+                16 }
+                
+                ```
+                
+                ### Section-2, rule_b (1)
+                
+                Description rule_b
+                
+                [Documentation](https://detekt.dev/docs/rules/section-2#rule_b)
+                
+                * src/main/com/sample/Sample3.kt:14:16
+                ```
+                Issue message 3
+                ```
+                ```kotlin
+                11 
+                12     fun foo() {
+                13         println(greetings)
+                14         return this
+                !!                ^ error
+                15     }
+                16 }
+                
+                ```
+                
+                generated with [detekt version 1.23.6](https://detekt.dev/) on 2024-07-21 21:34:16 UTC
+                
+            """.trimIndent()
+        )
+    }
 
     @Test
     fun `renders Markdown structure correctly`() {

--- a/detekt-report-md/src/test/resources/src/main/com/sample/Sample1.kt
+++ b/detekt-report-md/src/test/resources/src/main/com/sample/Sample1.kt
@@ -1,0 +1,16 @@
+package com.example.test
+
+import io.github.*
+
+class Test() {
+    val greeting: String = "Hello, World!"
+
+    init {
+        println(greetings)
+    }
+
+    fun foo() {
+        println(greetings)
+        return this
+    }
+}

--- a/detekt-report-md/src/test/resources/src/main/com/sample/Sample2.kt
+++ b/detekt-report-md/src/test/resources/src/main/com/sample/Sample2.kt
@@ -1,0 +1,16 @@
+package com.example.test
+
+import io.github.*
+
+class Test() {
+    val greeting: String = "Hello, World!"
+
+    init {
+        println(greetings)
+    }
+
+    fun foo() {
+        println(greetings)
+        return this
+    }
+}

--- a/detekt-report-md/src/test/resources/src/main/com/sample/Sample3.kt
+++ b/detekt-report-md/src/test/resources/src/main/com/sample/Sample3.kt
@@ -1,0 +1,16 @@
+package com.example.test
+
+import io.github.*
+
+class Test() {
+    val greeting: String = "Hello, World!"
+
+    init {
+        println(greetings)
+    }
+
+    fun foo() {
+        println(greetings)
+        return this
+    }
+}


### PR DESCRIPTION
This PR refactors the .md report to stop using the `KtElement`.

This PR is needed to implement #6879. We need to remove `KtElement` from `Issue`. For this reason we need to stop using `KtElement`.