### PR TITLE
Remove `KtElement` from `Issue`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -175,7 +175,6 @@ public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Issue$Entity {
-	public abstract fun getKtElement ()Lorg/jetbrains/kotlin/psi/KtElement;
 	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getSignature ()Ljava/lang/String;

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api
 
-import org.jetbrains.kotlin.psi.KtElement
 import java.nio.file.Path
 
 /**
@@ -24,7 +23,6 @@ interface Issue {
         val name: String
         val signature: String
         val location: Location
-        val ktElement: KtElement
     }
 
     interface Location {

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.test
 
-import io.github.detekt.test.utils.internal.FakeKtElement
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleInstance
@@ -8,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
-import org.jetbrains.kotlin.psi.KtElement
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -71,12 +69,10 @@ fun createRuleInstance(
 fun createEntity(
     signature: String = "TestEntitySignature",
     location: Issue.Location = createLocation(),
-    ktElement: KtElement = FakeKtElement(),
 ): Issue.Entity = IssueImpl.Entity(
     name = "TestEntity",
     signature = signature,
     location = location,
-    ktElement = ktElement
 )
 
 fun createLocation(
@@ -106,7 +102,6 @@ private data class IssueImpl(
         override val name: String,
         override val signature: String,
         override val location: Issue.Location,
-        override val ktElement: KtElement
     ) : Issue.Entity
 
     data class Location(

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/MessageCollectorExtensions.kt
@@ -7,7 +7,6 @@ import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 
 fun MessageCollector.info(msg: String) {
     this.report(CompilerMessageSeverity.INFO, msg)
@@ -31,16 +30,12 @@ fun MessageCollector.reportIssues(result: Detektion) {
 }
 
 fun Issue.renderAsCompilerWarningMessage(): Pair<String, CompilerMessageLocation?> {
-    val location = MessageUtil.psiElementToMessageLocation(entity.ktElement)
-
-    val sourceLocation = location?.let {
-        CompilerMessageLocation.create(
-            entity.location.path.toString(),
-            entity.location.source.line,
-            entity.location.source.column,
-            location.lineContent
-        )
-    }
+    val sourceLocation = CompilerMessageLocation.create(
+        entity.location.path.toString(),
+        entity.location.source.line,
+        entity.location.source.column,
+        null
+    )
 
     return "${ruleInstance.id}: $message" to sourceLocation
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -25,7 +25,6 @@ import io.gitlab.arturbosch.detekt.core.suppressors.isSuppressedBy
 import io.gitlab.arturbosch.detekt.core.util.isActiveOrDefault
 import io.gitlab.arturbosch.detekt.core.util.shouldAnalyzeFile
 import org.jetbrains.kotlin.config.languageVersionSettings
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
@@ -197,7 +196,7 @@ private fun Finding.toIssue(rule: RuleInstance, severity: Severity, basePath: Pa
     }
 
 private fun Entity.toIssue(basePath: Path): Issue.Entity =
-    IssueImpl.Entity(name, signature, location.toIssue(basePath), ktElement)
+    IssueImpl.Entity(name, signature, location.toIssue(basePath))
 
 private fun Location.toIssue(basePath: Path): Issue.Location =
     IssueImpl.Location(source, endSource, text, basePath.relativize(path))
@@ -217,7 +216,6 @@ private data class IssueImpl(
         override val name: String,
         override val signature: String,
         override val location: Issue.Location,
-        override val ktElement: KtElement
     ) : Issue.Entity
 
     data class Location(

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.xml
 
-import io.github.detekt.test.utils.internal.FakeKtElement
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createEntity
@@ -23,7 +22,6 @@ class XmlOutputReportSpec {
             path = "src/main/com/sample/Sample1.kt",
             position = 11 to 1,
         ),
-        FakeKtElement()
     )
     private val entity2 = createEntity(
         "Sample2",
@@ -31,7 +29,6 @@ class XmlOutputReportSpec {
             path = "src/main/com/sample/Sample2.kt",
             position = 22 to 2,
         ),
-        FakeKtElement()
     )
     private val outputReport = XmlOutputReport()
 


### PR DESCRIPTION
After all the refactors we can remove `KtElement` form `Issue`. This was a blocker for #6879. Now `Issue` should be easily serailizable (but we need to implement it).