### PR TITLE
Remove exclude autocorrect

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -43,7 +43,6 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             autoCorrect = args.autoCorrect
             activateAllRules = args.allRules
             failurePolicy = args.failurePolicy
-            excludeCorrectable = false // not yet supported; loaded from config
             runPolicy = args.toRunPolicy()
         }
 

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/runners/RunnerSpec.kt
@@ -234,14 +234,9 @@ class RunnerSpec {
         fun `succeeds with --autocorrect with single autocorrectable fix`() {
             val inputPath = resourceAsPath("/autocorrect/SingleRule.kt")
 
-            assertThatThrownBy {
-                Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
-            }.isInstanceOf(IssuesFound::class.java)
+            Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
 
             assertThat(errPrintStream.toString()).isEmpty()
-            assertThat(outPrintStream.toString())
-                .contains("${inputPath.absolutePathString()}:3:1: Needless blank line(s) [NoConsecutiveBlankLines]")
-                .contains("$modificationMessagePrefix${inputPath.absolutePathString()}$modificationMessageSuffix")
             assertThat(inputPath).content().isEqualToNormalizingNewlines(
                 """
                     class Test {
@@ -256,19 +251,9 @@ class RunnerSpec {
         fun `succeeds with --autocorrect with multiple autocorrectable fixes`() {
             val inputPath = resourceAsPath("/autocorrect/MultipleRules.kt")
 
-            assertThatThrownBy {
-                Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
-            }.isInstanceOf(IssuesFound::class.java)
+            Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
 
             assertThat(errPrintStream.toString()).isEmpty()
-            assertThat(outPrintStream.toString())
-                .contains("${inputPath.absolutePathString()}:5:24: Line must not end with \".\" [ChainWrapping]")
-                .contains("${inputPath.absolutePathString()}:6:28: Line must not end with \".\" [ChainWrapping]")
-                .contains("${inputPath.absolutePathString()}:7:36: Line must not end with \"?.\" [ChainWrapping]")
-                .contains("${inputPath.absolutePathString()}:10:15: Line must not end with \"?:\" [ChainWrapping]")
-                .contains("${inputPath.absolutePathString()}:3:1: Needless blank line(s) [NoConsecutiveBlankLines]")
-                .contains("${inputPath.absolutePathString()}:12:1: Needless blank line(s) [NoConsecutiveBlankLines]")
-                .contains("$modificationMessagePrefix${inputPath.absolutePathString()}$modificationMessageSuffix")
             assertThat(inputPath).content().isEqualToNormalizingNewlines(
                 """
                     class Test {
@@ -292,14 +277,9 @@ class RunnerSpec {
         fun `keeps LF line endings after autocorrect`() {
             val inputPath = resourceAsPath("/autocorrect/SingleRuleLF.kt")
 
-            assertThatThrownBy {
-                Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
-            }.isInstanceOf(IssuesFound::class.java)
+            Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
 
             assertThat(errPrintStream.toString()).isEmpty()
-            assertThat(outPrintStream.toString())
-                .contains("${inputPath.absolutePathString()}:3:1: Needless blank line(s) [NoConsecutiveBlankLines]")
-                .contains("$modificationMessagePrefix${inputPath.absolutePathString()}$modificationMessageSuffix")
             assertThat(inputPath).content().isEqualTo("class Test {\n\n}\n")
         }
 
@@ -307,14 +287,9 @@ class RunnerSpec {
         fun `keeps CRLF line endings after autocorrect`() {
             val inputPath = resourceAsPath("/autocorrect/SingleRuleCRLF.kt")
 
-            assertThatThrownBy {
-                Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
-            }.isInstanceOf(IssuesFound::class.java)
+            Runner(parseArguments(args + inputPath.toString()), outPrintStream, errPrintStream).execute()
 
             assertThat(errPrintStream.toString()).isEmpty()
-            assertThat(outPrintStream.toString())
-                .contains("${inputPath.absolutePathString()}:3:1: Needless blank line(s) [NoConsecutiveBlankLines]")
-                .contains("$modificationMessagePrefix${inputPath.absolutePathString()}$modificationMessageSuffix")
             assertThat(inputPath).content().isEqualTo("class Test {\r\n\r\n}\r\n")
         }
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePolicies.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePolicies.kt
@@ -2,27 +2,26 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.spec.RulesSpec
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.core.reporting.filterAutoCorrectedIssues
 
-internal fun RulesSpec.FailurePolicy.check(result: Detektion, config: Config) {
+internal fun RulesSpec.FailurePolicy.check(result: Detektion) {
     when (this) {
         RulesSpec.FailurePolicy.NeverFail -> Unit
-        is RulesSpec.FailurePolicy.FailOnSeverity -> result.checkForIssuesWithSeverity(config, minSeverity)
+        is RulesSpec.FailurePolicy.FailOnSeverity -> result.checkForIssuesWithSeverity(minSeverity)
     }
 }
 
-private fun Detektion.checkForIssuesWithSeverity(config: Config, minSeverity: Severity) {
-    val issueCount = computeIssueCount(config, minSeverity)
+private fun Detektion.checkForIssuesWithSeverity(minSeverity: Severity) {
+    val issueCount = computeIssueCount(minSeverity)
     if (issueCount > 0) {
         throw IssuesFound("Analysis failed with $issueCount issues.")
     }
 }
 
-private fun Detektion.computeIssueCount(config: Config, minSeverity: Severity): Int =
-    filterAutoCorrectedIssues(config)
+private fun Detektion.computeIssueCount(minSeverity: Severity): Int =
+    filterAutoCorrectedIssues()
         .count { it.severity.isAtLeast(minSeverity) }
 
 private fun Severity.isAtLeast(severity: Severity): Boolean = this.ordinal <= severity.ordinal

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.Location
@@ -23,22 +22,12 @@ internal fun printIssues(issues: Map<String, List<Issue>>): String =
         }
     }
 
-const val BUILD = "build"
-const val EXCLUDE_CORRECTABLE = "excludeCorrectable"
-
 const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
 
 private const val REPORT_MESSAGE_SIZE_LIMIT = 80
 private val messageReplacementRegex = Regex("\\s+")
 
-fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
-
-fun Detektion.filterAutoCorrectedIssues(config: Config): List<Issue> {
-    if (!config.excludeCorrectable()) {
-        return issues
-    }
-    return issues.filter { issue -> !issue.autoCorrectEnabled }
-}
+fun Detektion.filterAutoCorrectedIssues(): List<Issue> = issues.filterNot { issue -> issue.autoCorrectEnabled }
 
 private fun Issue.truncatedMessage(): String {
     val message = message

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/Reporting.kt
@@ -33,8 +33,6 @@ private val messageReplacementRegex = Regex("\\s+")
 
 fun Config.excludeCorrectable(): Boolean = subConfig(BUILD).valueOrDefault(EXCLUDE_CORRECTABLE, false)
 
-fun Detektion.filterEmptyIssues(config: Config): List<Issue> = this.filterAutoCorrectedIssues(config)
-
 fun Detektion.filterAutoCorrectedIssues(config: Config): List<Issue> {
     if (!config.excludeCorrectable()) {
         return issues

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
@@ -18,7 +18,7 @@ abstract class AbstractIssuesReport : ConsoleReport {
     }
 
     override fun render(detektion: Detektion): String? {
-        val issues = detektion.filterAutoCorrectedIssues(config)
+        val issues = detektion.filterAutoCorrectedIssues()
         if (issues.isEmpty()) {
             return null
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/AbstractIssuesReport.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.ConsoleReport
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.SetupContext
-import io.gitlab.arturbosch.detekt.core.reporting.filterEmptyIssues
+import io.gitlab.arturbosch.detekt.core.reporting.filterAutoCorrectedIssues
 
 abstract class AbstractIssuesReport : ConsoleReport {
 
@@ -18,7 +18,7 @@ abstract class AbstractIssuesReport : ConsoleReport {
     }
 
     override fun render(detektion: Detektion): String? {
-        val issues = detektion.filterEmptyIssues(config)
+        val issues = detektion.filterAutoCorrectedIssues(config)
         if (issues.isEmpty()) {
             return null
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -8,7 +8,6 @@ import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.UnexpectedError
 import io.github.detekt.tooling.api.spec.ProcessingSpec
 import io.github.detekt.tooling.internal.DefaultAnalysisResult
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.config.check
@@ -38,7 +37,7 @@ class AnalysisFacade(
         when (val error = result.exceptionOrNull()) {
             null -> {
                 val container = checkNotNull(result.getOrNull()) { "Result should not be null at this point." }
-                DefaultAnalysisResult(container, checkFailurePolicy(container, config))
+                DefaultAnalysisResult(container, checkFailurePolicy(container))
             }
 
             is InvalidConfig -> DefaultAnalysisResult(null, error)
@@ -46,13 +45,13 @@ class AnalysisFacade(
         }
     }
 
-    private fun checkFailurePolicy(result: Detektion, config: Config): DetektError? {
+    private fun checkFailurePolicy(result: Detektion): DetektError? {
         if (spec.baselineSpec.shouldCreateDuringAnalysis) {
             return null // never fail the build as on next run all current issues are suppressed via the baseline
         }
 
         val error = runCatching {
-            spec.rulesSpec.failurePolicy.check(result, config)
+            spec.rulesSpec.failurePolicy.check(result)
         }.exceptionOrNull()
 
         return when {

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -1,6 +1,3 @@
-build:
-  excludeCorrectable: false
-
 config:
   validation: true
   warningsAsErrors: false

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePoliciesKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePoliciesKtTest.kt
@@ -2,9 +2,7 @@ package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.spec.RulesSpec
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -25,7 +23,7 @@ class FailurePoliciesKtTest {
         fun `does not fail without an issue`() {
             val result = TestDetektion()
 
-            subject.check(result, Config.empty)
+            subject.check(result)
         }
 
         @ParameterizedTest
@@ -33,7 +31,7 @@ class FailurePoliciesKtTest {
         fun `does not fail on issue with any severity`(issueSeverity: Severity) {
             val result = TestDetektion(createIssue(severity = issueSeverity))
 
-            subject.check(result, Config.empty)
+            subject.check(result)
         }
     }
 
@@ -45,7 +43,7 @@ class FailurePoliciesKtTest {
         fun `does not fail without an issue`() {
             val result = TestDetektion()
 
-            subject.check(result, Config.empty)
+            subject.check(result)
         }
 
         @ParameterizedTest
@@ -53,7 +51,7 @@ class FailurePoliciesKtTest {
         fun `fails on at least one issue at or above threshold`(issueSeverity: Severity) {
             val result = TestDetektion(createIssue(severity = issueSeverity))
 
-            assertThatThrownBy { subject.check(result, Config.empty) }
+            assertThatThrownBy { subject.check(result) }
                 .isInstanceOf(IssuesFound::class.java)
         }
 
@@ -62,15 +60,14 @@ class FailurePoliciesKtTest {
         fun `does not fail on issue below threshold`(issueSeverity: Severity) {
             val result = TestDetektion(createIssue(severity = issueSeverity))
 
-            subject.check(result, Config.empty)
+            subject.check(result)
         }
 
         @Test
-        fun `does not fail on correctable issue if configured`() {
+        fun `does not fail on correctable issue`() {
             val result = TestDetektion(createIssue(severity = Severity.Error, autoCorrectEnabled = true))
-            val config = TestConfig("excludeCorrectable" to "true")
 
-            subject.check(result, config)
+            subject.check(result)
         }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/AutoCorrectableIssueAssert.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createIssue
@@ -10,8 +9,7 @@ import org.assertj.core.api.Assertions.assertThat
 internal object AutoCorrectableIssueAssert {
 
     fun isReportNull(report: ConsoleReport) {
-        val config = TestConfig("excludeCorrectable" to "true")
-        report.init(TestSetupContext(config))
+        report.init(TestSetupContext())
         val correctableCodeSmell = createIssue(autoCorrectEnabled = true)
         val detektionWithCorrectableSmell = TestDetektion(correctableCodeSmell)
         val result = report.render(detektionWithCorrectableSmell)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -8,8 +8,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
 
     override fun print(item: List<RuleSetPage>): String =
         yaml {
-            yaml { defaultBuildConfiguration() }
-            emptyLine()
             yaml { defaultConfigConfiguration() }
             emptyLine()
             yaml { defaultProcessorsConfiguration() }
@@ -28,11 +26,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             item.sortedBy { it.ruleSet.name }
                 .forEach { printRuleSetPage(it) }
         }
-
-    private fun defaultBuildConfiguration(): String = """
-        build:
-          excludeCorrectable: false
-    """.trimIndent()
 
     private fun defaultConfigConfiguration(): String = """
         config:

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/DetektYmlConfigSpec.kt
@@ -13,7 +13,6 @@ import kotlin.io.path.absolute
 class DetektYmlConfigSpec {
 
     private val generalConfigKeys = listOf(
-        "build",
         "config",
         "processors",
         "console-reports",

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
@@ -42,11 +42,6 @@ class ConfigPrinterSpec {
     }
 
     @Test
-    fun `prints default build configuration`() {
-        assertThat(yamlString).contains("build:")
-    }
-
-    @Test
     fun `prints default config configuration`() {
         assertThat(yamlString).contains("config:")
     }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -178,7 +178,6 @@ public abstract interface class io/github/detekt/tooling/api/spec/ReportsSpec$Re
 public abstract interface class io/github/detekt/tooling/api/spec/RulesSpec {
 	public abstract fun getActivateAllRules ()Z
 	public abstract fun getAutoCorrect ()Z
-	public abstract fun getExcludeCorrectable ()Z
 	public abstract fun getFailurePolicy ()Lio/github/detekt/tooling/api/spec/RulesSpec$FailurePolicy;
 	public abstract fun getRunPolicy ()Lio/github/detekt/tooling/api/spec/RulesSpec$RunPolicy;
 }
@@ -353,12 +352,10 @@ public final class io/github/detekt/tooling/dsl/RulesSpecBuilder : io/github/det
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getActivateAllRules ()Z
 	public final fun getAutoCorrect ()Z
-	public final fun getExcludeCorrectable ()Z
 	public final fun getFailurePolicy ()Lio/github/detekt/tooling/api/spec/RulesSpec$FailurePolicy;
 	public final fun getRunPolicy ()Lio/github/detekt/tooling/api/spec/RulesSpec$RunPolicy;
 	public final fun setActivateAllRules (Z)V
 	public final fun setAutoCorrect (Z)V
-	public final fun setExcludeCorrectable (Z)V
 	public final fun setFailurePolicy (Lio/github/detekt/tooling/api/spec/RulesSpec$FailurePolicy;)V
 	public final fun setRunPolicy (Lio/github/detekt/tooling/api/spec/RulesSpec$RunPolicy;)V
 }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/spec/RulesSpec.kt
@@ -17,11 +17,6 @@ interface RulesSpec {
     val failurePolicy: FailurePolicy
 
     /**
-     * Issues which were corrected should not be taken into account for calculating the max issue threshold.
-     */
-    val excludeCorrectable: Boolean
-
-    /**
      * Policy to decide if detekt throws an error.
      */
     sealed class FailurePolicy {

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
@@ -8,14 +8,12 @@ class RulesSpecBuilder : Builder<RulesSpec> {
 
     var activateAllRules: Boolean = false
     var failurePolicy: FailurePolicy = FailurePolicy.FailOnSeverity(Severity.Error)
-    var excludeCorrectable: Boolean = false
     var autoCorrect: Boolean = false
     var runPolicy: RulesSpec.RunPolicy = RulesSpec.RunPolicy.NoRestrictions
 
     override fun build(): RulesSpec = RulesModel(
         activateAllRules,
         failurePolicy,
-        excludeCorrectable,
         autoCorrect,
         runPolicy
     )
@@ -24,7 +22,6 @@ class RulesSpecBuilder : Builder<RulesSpec> {
 private data class RulesModel(
     override val activateAllRules: Boolean,
     override val failurePolicy: FailurePolicy,
-    override val excludeCorrectable: Boolean,
     override val autoCorrect: Boolean,
     override val runPolicy: RulesSpec.RunPolicy
 ) : RulesSpec


### PR DESCRIPTION
This was never fully implemented and no one complained about it. Also I plan to change the autocorrect information in the `CodeSmell` for a new `suppress` that tells you why an issue is suppressed, for example, because it is autocorrected.

For now I'm just removing the `excludeAutocorrect` and enable it by default. You will not see autocorrected issues on the reports. As soon as I implement the `suppress` a custom report could decide to show those.