### PR TITLE
Update compose.md

### DIFF
--- a/website/docs/introduction/compose.md
+++ b/website/docs/introduction/compose.md
@@ -31,7 +31,7 @@ Choose _either_ of the following options:
 
 See [TopLevelPropertyNaming](/docs/rules/naming#toplevelpropertynaming).
 
-Compose guidelines prescribe `CamelCase` for top-level constants.
+Compose guidelines prescribe `PascalCase` for top-level constants.
 
 ##### Default Style:
 

--- a/website/versioned_docs/version-1.23.6/introduction/compose.md
+++ b/website/versioned_docs/version-1.23.6/introduction/compose.md
@@ -31,7 +31,7 @@ Choose _either_ of the following options:
 
 See [TopLevelPropertyNaming](/docs/rules/naming#toplevelpropertynaming).
 
-Compose guidelines prescribe `CamelCase` for top-level constants.
+Compose guidelines prescribe `PascalCase` for top-level constants.
 
 ##### Default Style:
 


### PR DESCRIPTION
In the docs it is stated that

> Compose guidelines prescribe CamelCase for top-level constants.

https://detekt.dev/docs/introduction/compose#toplevelpropertynaming-for-compose

However, the compose guidlines state the following:

> Jetpack Compose framework development MUST name deeply immutable constants following the permitted object declaration convention of PascalCase as documented [here](https://kotlinlang.org/docs/reference/coding-conventions.html#property-names) as a replacement for any usage of CAPITALS_AND_UNDERSCORES. Enum class values MUST also be named using PascalCase as documented in the same section.

https://android.googlesource.com/platform/frameworks/support/+/androidx-main/compose/docs/compose-api-guidelines.md#singletons_constants_sealed-class-and-enum-class-values

Therefore top-level constants should use PascalCase (as in the exmaple below) and not camle case.

This pr changes `CamleCase` to `PascalCase` in the docs.