### PR TITLE
Automatically handle "multiPlatformEnabled" option in JVM compilation analysis tasks

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -61,6 +61,7 @@ public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
@@ -90,6 +91,7 @@ public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -35,6 +35,7 @@ internal fun Project.registerJvmCompilationDetektTask(
         detektTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
         detektTask.optIn.convention(siblingTask.compilerOptions.optIn)
         detektTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
+        detektTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
         if (compilation.name == "main") {
             detektTask.explicitApi.convention(mapExplicitArgMode())
         }
@@ -78,6 +79,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         createBaselineTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
         createBaselineTask.optIn.convention(siblingTask.compilerOptions.optIn)
         createBaselineTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
+        createBaselineTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
         if (compilation.name == "main") {
             createBaselineTask.explicitApi.convention(mapExplicitArgMode())
         }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -26,6 +26,7 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
+import io.gitlab.arturbosch.detekt.invoke.MultiPlatformEnabledArgument
 import io.gitlab.arturbosch.detekt.invoke.NoJdkArgument
 import io.gitlab.arturbosch.detekt.invoke.OptInArguments
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
@@ -125,6 +126,9 @@ abstract class Detekt @Inject constructor(
     abstract val noJdk: Property<Boolean>
 
     @get:Input
+    abstract val multiPlatformEnabled: Property<Boolean>
+
+    @get:Input
     abstract val ignoreFailures: Property<Boolean>
 
     @get:Input
@@ -195,6 +199,7 @@ abstract class Detekt @Inject constructor(
             FriendPathArgs(friendPaths),
             NoJdkArgument(noJdk.get()),
             ExplicitApiArgument(explicitApi.orNull),
+            MultiPlatformEnabledArgument(multiPlatformEnabled.get()),
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
             .plus("-no-stdlib")
             .plus("-no-reflect")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -21,6 +21,7 @@ import io.gitlab.arturbosch.detekt.invoke.InputArgument
 import io.gitlab.arturbosch.detekt.invoke.JdkHomeArgument
 import io.gitlab.arturbosch.detekt.invoke.JvmTargetArgument
 import io.gitlab.arturbosch.detekt.invoke.LanguageVersionArgument
+import io.gitlab.arturbosch.detekt.invoke.MultiPlatformEnabledArgument
 import io.gitlab.arturbosch.detekt.invoke.NoJdkArgument
 import io.gitlab.arturbosch.detekt.invoke.OptInArguments
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
@@ -111,6 +112,9 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     abstract val noJdk: Property<Boolean>
 
     @get:Input
+    abstract val multiPlatformEnabled: Property<Boolean>
+
+    @get:Input
     @get:Optional
     abstract val autoCorrect: Property<Boolean>
 
@@ -168,6 +172,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             FriendPathArgs(friendPaths),
             NoJdkArgument(noJdk.get()),
             ExplicitApiArgument(explicitApi.orNull),
+            MultiPlatformEnabledArgument(multiPlatformEnabled.get()),
         ).flatMap(CliArgument::toArgument)
             .plus("-no-stdlib")
             .plus("-no-reflect")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/SharedTasks.kt
@@ -37,6 +37,7 @@ internal fun Project.setDetektTaskDefaults(extension: DetektExtension) {
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         it.noJdk.convention(false)
+        it.multiPlatformEnabled.convention(false)
     }
 }
 
@@ -66,5 +67,6 @@ internal fun Project.setCreateBaselineTaskDefaults(extension: DetektExtension) {
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         it.noJdk.convention(false)
+        it.multiPlatformEnabled.convention(false)
     }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -30,6 +30,7 @@ private const val JDK_HOME_PARAMETER = "--jdk-home"
 private const val BASE_PATH_PARAMETER = "--base-path"
 private const val OPT_IN_PARAMETER = "-opt-in"
 private const val NO_JDK_PARAMETER = "-no-jdk"
+private const val MULTIPLATFORM_ENABLED_PARAMETER = "-Xmulti-platform"
 private const val EXPLICIT_API_MODE = "-Xexplicit-api"
 
 /* parameters passed with single hyphen prefix must be passed at end of command line argument list so they get passed
@@ -180,3 +181,6 @@ internal data class NoJdkArgument(override val value: Boolean) : BoolCliArgument
 internal data class ExplicitApiArgument(val mode: String?) : CliArgument() {
     override fun toArgument() = mode?.let { listOf("$EXPLICIT_API_MODE=$it") }.orEmpty()
 }
+
+internal data class MultiPlatformEnabledArgument(override val value: Boolean) :
+    BoolCliArgument(value, MULTIPLATFORM_ENABLED_PARAMETER)


### PR DESCRIPTION
Related to #4465 

Fixes #7533 (tested locally - we need tests added eventually, should cover under #7421).