### PR TITLE
Remove usage of DEVELOCITY_ACCESS_KEY env var in build scripts

### DIFF
--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -23,7 +23,6 @@ buildCache {
     remote(develocity.buildCache) {
         server = "https://ge.detekt.dev"
         isEnabled = true
-        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
-        isPush = isCiBuild && !accessKey.isNullOrEmpty()
+        isPush = isCiBuild
     }
 }

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -27,7 +27,6 @@ buildCache {
     remote(develocity.buildCache) {
         server = "https://ge.detekt.dev"
         isEnabled = true
-        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
-        isPush = isCiBuild && !accessKey.isNullOrEmpty()
+        isPush = isCiBuild
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -69,8 +69,7 @@ buildCache {
     remote(develocity.buildCache) {
         server = "https://ge.detekt.dev"
         isEnabled = true
-        val accessKey = System.getenv("DEVELOCITY_ACCESS_KEY")
-        isPush = isCiBuild && !accessKey.isNullOrEmpty()
+        isPush = isCiBuild
     }
 }
 


### PR DESCRIPTION
The gradle action generates short-lived access tokens that are used when Gradle is run.

See here for more:
https://github.com/gradle/actions/blob/v4.0.0/docs/setup-gradle.md#short-lived-access-tokens

The problem is that the short-lived access token is stored in DEVELOCITY_ACCESS_KEY env var, which is read by settings script, so any change to the env var value invalidates the configuration cache.

Since the short-lived token is generated on every Gradle invocation, the configuration cache will always be invalidated, harming performance on CI on main branch.

This commit stops reading the env var value. Develocity will reject pushes that do not have the correct secret set so this is no less secure.

References:
* Request for short-lived token: https://github.com/detekt/detekt/actions/runs/10382818395/job/28746563357#step:4:102
* "Configuration cache cannot be reused: https://github.com/detekt/detekt/actions/runs/10382818395/job/28746563357#step:5:20