### PR TITLE
Remove usage of context receivers

### DIFF
--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -15,7 +15,3 @@ consumeGeneratedConfig(
     fromConfiguration = "generatedRuleauthorsConfig",
     forTask = tasks.processResources
 )
-
-kotlin {
-    compilerOptions.freeCompilerArgs.add("-Xcontext-receivers")
-}

--- a/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/io/gitlab/arturbosch/detekt/authors/ViolatesTypeResolutionRequirements.kt
@@ -67,19 +67,17 @@ class ViolatesTypeResolutionRequirements(config: Config) : Rule(
         usesBindingContext = usesBindingContext ||
             (expression is KtNameReferenceExpression && expression.text == "bindingContext")
     }
+
+    private inline fun <reified T : Any> KtClass.extendsFrom(kClass: KClass<T>): Boolean =
+        bindingContext[BindingContext.CLASS, this]
+            ?.getAllSuperclassesWithoutAny()
+            .orEmpty()
+            .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }
+
+    private inline fun <reified T : Any> KtClass.isAnnotatedWith(kClass: KClass<T>): Boolean =
+        annotationEntries
+            .asSequence()
+            .mapNotNull { it.typeReference }
+            .mapNotNull { bindingContext[BindingContext.TYPE, it] }
+            .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }
 }
-
-context(Rule)
-private inline fun <reified T : Any> KtClass.extendsFrom(kClass: KClass<T>): Boolean =
-    bindingContext[BindingContext.CLASS, this]
-        ?.getAllSuperclassesWithoutAny()
-        .orEmpty()
-        .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }
-
-context(Rule)
-private inline fun <reified T : Any> KtClass.isAnnotatedWith(kClass: KClass<T>): Boolean =
-    annotationEntries
-        .asSequence()
-        .mapNotNull { it.typeReference }
-        .mapNotNull { bindingContext[BindingContext.TYPE, it] }
-        .any { it.fqNameOrNull()?.toString() == checkNotNull(kClass.qualifiedName) }


### PR DESCRIPTION
https://kotlinlang.org/docs/whatsnew2020.html#phased-replacement-of-context-receivers-with-context-parameters

There's no good reason to keep this minor existing usage of context receivers while we wait for context parameters to be delivered.