### PR TITLE
[1.x] Bump Kotlin to 2.0.20

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -636,8 +636,6 @@ public final class io/gitlab/arturbosch/detekt/api/ValueWithReason {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/ValuesWithReason : java/lang/Iterable, kotlin/jvm/internal/markers/KMappedMarker {
-	public final fun copy (Ljava/util/List;)Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;
-	public static synthetic fun copy$default (Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;Ljava/util/List;ILjava/lang/Object;)Lio/gitlab/arturbosch/detekt/api/ValuesWithReason;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun iterator ()Ljava/util/Iterator;

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.dokka)
     id("java-test-fixtures")
     alias(libs.plugins.binaryCompatibilityValidator)
-    id("dev.drewhamilton.poko") version "0.16.0"
+    id("dev.drewhamilton.poko") version "0.17.0"
 }
 
 dependencies {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ValuesWithReason.kt
@@ -31,6 +31,7 @@ fun valuesWithReason(values: List<ValueWithReason>): ValuesWithReason {
  * [ValuesWithReason] is essentially the same as [List] of [ValueWithReason]. Due to type erasure we cannot use the
  * list directly. Instances of this type should always created using the [valuesWithReason] factory method.
  */
+@ConsistentCopyVisibility
 data class ValuesWithReason internal constructor(private val values: List<ValueWithReason>) :
     Iterable<ValueWithReason> by values
 

--- a/detekt-compiler-plugin/gradle.properties
+++ b/detekt-compiler-plugin/gradle.properties
@@ -1,4 +1,4 @@
-kotlinCompilerChecksum=88d7d8bad362ae4e114a8b9668c6887b8c85f48e340883db0e317e47c8dc2f4f
+kotlinCompilerChecksum=5f5d2a8ad6a718a002acd0775b67a9e27035872fdbd4b0791e3cb3ea00095931
 
 kotlin.code.style=official
 systemProp.sonar.host.url=http://localhost:9000

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
@@ -1,9 +1,9 @@
 package io.github.detekt.compiler.plugin
 
 import io.github.detekt.compiler.plugin.internal.toSpec
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import kotlin.io.path.Path
@@ -17,7 +17,7 @@ class DetektCompilerPluginRegistrar : CompilerPluginRegistrar() {
             return
         }
 
-        val messageCollector = configuration.get(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+        val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         AnalysisHandlerExtension.registerExtension(
             DetektAnalysisExtension(

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.parser
 
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.environment.setIdeaIoUseFallback
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
@@ -54,7 +53,7 @@ fun createKotlinCoreEnvironment(
     // https://github.com/JetBrains/kotlin/commit/2568804eaa2c8f6b10b735777218c81af62919c1
     setIdeaIoUseFallback()
     configuration.put(
-        CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY,
+        CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
         PrintingMessageCollector(printStream, MessageRenderer.PLAIN_FULL_PATHS, false)
     )
     configuration.put(CommonConfigurationKeys.MODULE_NAME, "detekt")

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -3,7 +3,6 @@ package io.github.detekt.test.utils
 import io.github.detekt.parser.KtCompiler
 import kotlinx.coroutines.CoroutineScope
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -51,7 +50,7 @@ internal object KtTestCompiler : KtCompiler() {
     ): KotlinCoreEnvironmentWrapper {
         val configuration = CompilerConfiguration()
         configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
-        configuration.put(CLIConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+        configuration.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
 
         if (System.getenv("JAVA_HOME") != null) {
             configuration.put(JVMConfigurationKeys.JDK_HOME, File(System.getenv("JAVA_HOME")))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 dokka = "1.9.20"
 jacoco = "0.8.12"
-kotlin = "2.0.10"
+kotlin = "2.0.20"
 ktlint = "0.50.0"
 junit = "5.10.2"
 contester = "0.2.0"
@@ -47,7 +47,7 @@ contester-breakpoint = { module = "io.github.davidburstrom.contester:contester-b
 contester-driver = { module = "io.github.davidburstrom.contester:contester-driver", version.ref = "contester" }
 kotlinCompileTesting = { module = "dev.zacsweers.kctfork:core", version = "0.5.0-alpha07" }
 jetbrains-annotations = "org.jetbrains:annotations:24.1.0"
-poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version = "0.16.0" }
+poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version = "0.17.0" }
 
 [plugins]
 binaryCompatibilityValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.16.3" }


### PR DESCRIPTION
This is essentially https://github.com/detekt/detekt/pull/7580 but against the `release/1.x` branch.