### PR TITLE
Refactor `detekt-with-type-resolution` workflow

### DIFF
--- a/.github/workflows/execute-detekt.yaml
+++ b/.github/workflows/execute-detekt.yaml
@@ -1,4 +1,4 @@
-name: detekt with type resolution
+name: Execute detekt
 
 on:
   push:
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 jobs:
-  plain:
+  cli:
     permissions:
       contents: read  # for actions/checkout to fetch code
       security-events: write  # for github/codeql-action/upload-sarif to upload SARIF results
@@ -35,12 +35,6 @@ jobs:
 
       - name: Run detekt-cli with argsfile
         run: ./gradlew :detekt-cli:runWithArgsFile
-
-      - name: Upload SARIF to GitHub using the upload-sarif action
-        uses: github/codeql-action/upload-sarif@4dd16135b69a43b6c8efb853346f8437d92d3c93 # v3
-        if: success() || failure()
-        with:
-          sarif_file: build/detekt-report.sarif
 
 
   gradle:


### PR DESCRIPTION
This workflow had some issues that I'm fixing on this PR:

- It was called `detekt-with-type-resolution` but it had 2 different jobs and one of them didn't use type resolution.
- The one without type resolution was called "plain" but in fact what it was doing was to execute the detekt `cli`. For that reason now the jobs are called `cli` and `gradle`.
- We were uploading the `sarif` of both jobs. In general this means that we upload some issues twice. For that reason I'm not uploading the `sarif` generated by the `cli` job. It should be a subset of the issues that `gradle` finds so it's better to just upload the `gradle` sarif.

If you agree with these changes we will need to change which are the required jobs to pass to merge a PR.