### PR TITLE
Revert "Install JDK 21 in Vercel build environment"

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "installCommand": "dnf install -y java-21-amazon-corretto-devel && yarn install",
   "github": {
     "silent": true
   },


### PR DESCRIPTION
Reverts detekt/detekt#7573

Testing if this is still required after Gradle 8.10.1 which fixed a regression which possibly caused the original issue.