### PR TITLE
Fix typos and description consistency for naming rules

### DIFF
--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -16,7 +16,7 @@ import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
 
 /**
- * Reports when a boolean property doesn't match a pattern
+ * Reports boolean property names that do not follow the specified naming convention.
  *
  * <noncompliant>
  * val progressBar: Boolean = true
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
 @RequiresTypeResolution
 class BooleanPropertyNaming(config: Config) : Rule(
     config,
-    "Boolean property name should follow the naming convention set in the projects configuration."
+    "Boolean property name should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.resolve.typeBinding.createTypeBindingForReturnType
 @RequiresTypeResolution
 class BooleanPropertyNaming(config: Config) : Rule(
     config,
-    "Boolean property name should follow the naming convention set in the project's configuration."
+    "Boolean property name should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 @Alias("ClassName")
 class ClassNaming(config: Config) : Rule(
     config,
-    "A class or object name should follow the naming convention set in the project's configuration."
+    "A class or object name should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 @Alias("ClassName")
 class ClassNaming(config: Config) : Rule(
     config,
-    "A class or object name should fit the naming pattern defined in the projects configuration."
+    "A class or object name should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @ActiveByDefault(since = "1.0.0")
 class ConstructorParameterNaming(config: Config) : Rule(
     config,
-    "Constructor parameter names should follow the naming convention set in the project's configuration."
+    "Constructor parameter names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNaming.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @ActiveByDefault(since = "1.0.0")
 class ConstructorParameterNaming(config: Config) : Rule(
     config,
-    "Constructor parameter names should follow the naming convention set in the projects configuration."
+    "Constructor parameter names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 @Alias("EnumEntryName")
 class EnumNaming(config: Config) : Rule(
     config,
-    "Enum names should follow the naming convention set in the project's configuration."
+    "Enum names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 @Alias("EnumEntryName")
 class EnumNaming(config: Config) : Rule(
     config,
-    "Enum names should follow the naming convention set in the projects configuration."
+    "Enum names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 @Alias("FunctionMaxNameLength")
 class FunctionNameMaxLength(config: Config) : Rule(
     config,
-    "Function names should not be longer than the maximum set in the project's configuration."
+    "Function names should not be longer than the maximum set in detekt's configuration."
 ) {
 
     @Configuration("maximum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLength.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 @Alias("FunctionMaxNameLength")
 class FunctionNameMaxLength(config: Config) : Rule(
     config,
-    "Function names should not be longer than the maximum set in the project configuration."
+    "Function names should not be longer than the maximum set in the project's configuration."
 ) {
 
     @Configuration("maximum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 @Alias("FunctionMinNameLength")
 class FunctionNameMinLength(config: Config) : Rule(
     config,
-    "Function names should not be shorter than the minimum set in the project's configuration."
+    "Function names should not be shorter than the minimum set in detekt's configuration."
 ) {
 
     @Configuration("minimum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMinLength.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
 @Alias("FunctionMinNameLength")
 class FunctionNameMinLength(config: Config) : Rule(
     config,
-    "Function names should not be shorter than the minimum defined in the configuration."
+    "Function names should not be shorter than the minimum set in the project's configuration."
 ) {
 
     @Configuration("minimum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.KtUserType
 @Alias("FunctionName")
 class FunctionNaming(config: Config) : Rule(
     config,
-    "Function names should follow the naming convention set in the project's configuration."
+    "Function names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNaming.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.KtUserType
 @Alias("FunctionName")
 class FunctionNaming(config: Config) : Rule(
     config,
-    "Function names should follow the naming convention set in the configuration."
+    "Function names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 @ActiveByDefault(since = "1.0.0")
 class FunctionParameterNaming(config: Config) : Rule(
     config,
-    "Function parameter names should follow the naming convention set in the projects configuration."
+    "Function parameter names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtParameter
 @ActiveByDefault(since = "1.0.0")
 class FunctionParameterNaming(config: Config) : Rule(
     config,
-    "Function parameter names should follow the naming convention set in the project's configuration."
+    "Function parameter names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtParameter
  */
 class LambdaParameterNaming(config: Config) : Rule(
     config,
-    "Lambda parameter names should follow the naming convention set in the project's configuration."
+    "Lambda parameter names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNaming.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtParameter
  */
 class LambdaParameterNaming(config: Config) : Rule(
     config,
-    "Lambda parameter names should follow the naming convention set in the projects configuration."
+    "Lambda parameter names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassName.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.psi.KtUserType
 import org.jetbrains.kotlin.resolve.BindingContext
 
 /**
- * This rule reports a member that has the same as the containing class or object.
+ * This rule reports a member that has the same name as the containing class or object.
  * This might result in confusion.
  * The member should either be renamed or changed to a constructor.
  * Factory functions that create an instance of the class are exempt from this rule.

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.types.isError
 
 /**
  * Reports when property with 'is' prefix doesn't have a boolean type.
- * Please check the [chapter 8.3.2 at Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
+ * Please check [chapter 8.3.2 on the Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
  *
  * <noncompliant>
  * val isEnabled: Int = 500

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @Alias("ObjectPropertyName")
 class ObjectPropertyNaming(config: Config) : Rule(
     config,
-    "Property names inside objects should follow the naming convention set in the projects configuration."
+    "Property names inside objects should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNaming.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @Alias("ObjectPropertyName")
 class ObjectPropertyNaming(config: Config) : Rule(
     config,
-    "Property names inside objects should follow the naming convention set in the project's configuration."
+    "Property names inside objects should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 @Alias("PackageName")
 class PackageNaming(config: Config) : Rule(
     config,
-    "Package names should match the naming convention set in the configuration."
+    "Package names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNaming.kt
@@ -17,7 +17,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 @Alias("PackageName")
 class PackageNaming(config: Config) : Rule(
     config,
-    "Package names should follow the naming convention set in the project's configuration."
+    "Package names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -13,12 +13,12 @@ import org.jetbrains.kotlin.psi.psiUtil.isExtensionDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
- * Reports top level constant that which do not follow the specified naming convention.
+ * Reports top level property names that do not follow the specified naming convention.
  */
 @ActiveByDefault(since = "1.0.0")
 class TopLevelPropertyNaming(config: Config) : Rule(
     config,
-    "Top level property names should follow the naming convention set in the projects configuration."
+    "Top level property names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNaming.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 @ActiveByDefault(since = "1.0.0")
 class TopLevelPropertyNaming(config: Config) : Rule(
     config,
-    "Top level property names should follow the naming convention set in the project's configuration."
+    "Top level property names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class VariableMaxLength(config: Config) : Rule(
     config,
-    "Variable names should not be longer than the maximum set in the configuration."
+    "Variable names should not be longer than the maximum set in the project's configuration."
 ) {
 
     @Configuration("maximum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLength.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  */
 class VariableMaxLength(config: Config) : Rule(
     config,
-    "Variable names should not be longer than the maximum set in the project's configuration."
+    "Variable names should not be longer than the maximum set in detekt's configuration."
 ) {
 
     @Configuration("maximum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  */
 class VariableMinLength(config: Config) : Rule(
     config,
-    "Variable names should not be shorter than the minimum defined in the configuration."
+    "Variable names should not be shorter than the minimum set in the project's configuration."
 ) {
 
     @Configuration("minimum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLength.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
  */
 class VariableMinLength(config: Config) : Rule(
     config,
-    "Variable names should not be shorter than the minimum set in the project's configuration."
+    "Variable names should not be shorter than the minimum set in detekt's configuration."
 ) {
 
     @Configuration("minimum name length")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 @Alias("PropertyName")
 class VariableNaming(config: Config) : Rule(
     config,
-    "Variable names should follow the naming convention set in the projects configuration."
+    "Variable names should follow the naming convention set in the project's configuration."
 ) {
 
     @Configuration("naming pattern")

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNaming.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 @Alias("PropertyName")
 class VariableNaming(config: Config) : Rule(
     config,
-    "Variable names should follow the naming convention set in the project's configuration."
+    "Variable names should follow the naming convention set in detekt's configuration."
 ) {
 
     @Configuration("naming pattern")


### PR DESCRIPTION
This fixes typos in descriptions for naming rules and makes them consistent.
