### PR TITLE
Revert "chore(deps): update dependency gradle to v8.10.1 (#7613)"

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This reverts commit 87f5711b7d9a4eece57652f97af6561c3f7a31ee.

There are intermittent errors since 8.10.1 update:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':detekt-sample-extensions:compileKotlin'.
> Could not create task ':detekt-sample-extensions:checkKotlinGradlePluginConfigurationErrors'.
   > DefaultTaskCollection#configureEach(Action) on task set cannot be executed in the current context.
```

This was mentioned in comments on this issue so I expect it will get addressed in the next Gradle point release https://github.com/gradle/gradle/issues/30472