### PR TITLE
Fix redundant empty tags in baseline XML

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
@@ -54,11 +54,18 @@ internal class BaselineFormat : BaselineProvider {
     private fun XMLStreamWriter.save(baseline: Baseline) {
         document {
             tag(SMELL_BASELINE) {
-                tag(MANUALLY_SUPPRESSED_ISSUES) {
-                    baseline.manuallySuppressedIssues.forEach { tag(ID, it) }
+                if (baseline.manuallySuppressedIssues.isNotEmpty()) {
+                    tag(MANUALLY_SUPPRESSED_ISSUES) {
+                        baseline.manuallySuppressedIssues.forEach { tag(ID, it) }
+                    }
                 }
-                tag(CURRENT_ISSUES) {
-                    baseline.currentIssues.forEach { tag(ID, it) }
+
+                if (baseline.currentIssues.isEmpty()) {
+                    writeEmptyElement(CURRENT_ISSUES)
+                } else {
+                    tag(CURRENT_ISSUES) {
+                        baseline.currentIssues.forEach { tag(ID, it) }
+                    }
                 }
             }
         }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineFormat.kt
@@ -54,7 +54,9 @@ internal class BaselineFormat : BaselineProvider {
     private fun XMLStreamWriter.save(baseline: Baseline) {
         document {
             tag(SMELL_BASELINE) {
-                if (baseline.manuallySuppressedIssues.isNotEmpty()) {
+                if (baseline.manuallySuppressedIssues.isEmpty()) {
+                    writeEmptyElement(MANUALLY_SUPPRESSED_ISSUES)
+                } else {
                     tag(MANUALLY_SUPPRESSED_ISSUES) {
                         baseline.manuallySuppressedIssues.forEach { tag(ID, it) }
                     }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -177,7 +177,7 @@ class BaselineResultMappingSpec {
                     <ID>LongParameterList:Signature</ID>
                     <ID>LongMethod:Signature</ID>
                   </ManuallySuppressedIssues>
-                  <CurrentIssues></CurrentIssues>
+                  <CurrentIssues/>
                 </SmellBaseline>
             """.trimIndent()
         )


### PR DESCRIPTION
Fixes #7622

The `CurrentIssues` tag is reduced to a self-closing tag if there are no current issues. Likewise for the `ManuallySuppressedIssues` tag.