### PR TITLE
Issue #7634: Make `UndocumentedPublicClass` configurable to flag `com…

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -71,6 +71,7 @@ comments:
     searchInInnerObject: true
     searchInInnerInterface: true
     searchInProtectedClass: false
+    flagCompanionWithoutName: true
   UndocumentedPublicFunction:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -71,7 +71,7 @@ comments:
     searchInInnerObject: true
     searchInInnerInterface: true
     searchInProtectedClass: false
-    ignoreUnnamedCompanionObject: false
+    ignoreDefaultCompanionObject: false
   UndocumentedPublicFunction:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -71,7 +71,7 @@ comments:
     searchInInnerObject: true
     searchInInnerInterface: true
     searchInProtectedClass: false
-    flagCompanionWithoutName: true
+    ignoreUnnamedCompanionObject: false
   UndocumentedPublicFunction:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -52,9 +52,9 @@ class UndocumentedPublicClass(config: Config) : Rule(
         super.visitClass(klass)
     }
 
-    private fun requiresDocumentation(klass: KtClass): Boolean {
-        return klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface()
-    }
+    private fun requiresDocumentation(
+        klass: KtClass,
+    ) = klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface()
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val isNonPublicCompanionWithoutNameOrDisabled = declaration.isCompanionWithoutName() &&

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -96,9 +96,9 @@ class UndocumentedPublicClass(config: Config) : Rule(
     private fun KtObjectDeclaration.isDefaultCompanionObject() =
         isCompanion() &&
             nameAsSafeName.asString() == "Companion" &&
-            // For companions _named_ `Companion`, we want to check if the name is a duplicate occurance. If so, it's
-            // not a companion without name.
-            text.lowercase().countOccurrencesOf("companion") == 1
+            // For companions _named_ `Companion`, we treat this as a "non-default" companion object. It simplifies
+            // the expected logic and narrows an edge-case.
+            nameIdentifier?.text != "Companion"
 
     private fun KtClass.isNestedClass() =
         !isInterface() && !isTopLevel() && !isInner() && searchInNestedClass

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -42,7 +42,7 @@ class UndocumentedPublicClass(config: Config) : Rule(
     private val searchInProtectedClass: Boolean by config(false)
 
     @Configuration("if companion object without a name should be flagged")
-    private val flagCompanionWithoutName: Boolean by config(true)
+    private val ignoreUnnamedCompanionObject: Boolean by config(false)
 
     override fun visitClass(klass: KtClass) {
         if (requiresDocumentation(klass)) {
@@ -52,14 +52,13 @@ class UndocumentedPublicClass(config: Config) : Rule(
         super.visitClass(klass)
     }
 
-    private fun requiresDocumentation(
-        klass: KtClass
-    ) =
-        klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface()
+    private fun requiresDocumentation(klass: KtClass): Boolean {
+        return klass.isTopLevel() || klass.isInnerClass() || klass.isNestedClass() || klass.isInnerInterface()
+    }
 
     override fun visitObjectDeclaration(declaration: KtObjectDeclaration) {
         val isNonPublicCompanionWithoutNameOrDisabled = declaration.isCompanionWithoutName() &&
-            (!declaration.isPublic || !flagCompanionWithoutName)
+            (!declaration.isPublic || ignoreUnnamedCompanionObject)
 
         if (
             isNonPublicCompanionWithoutNameOrDisabled ||

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -41,7 +41,7 @@ class UndocumentedPublicClass(config: Config) : Rule(
     @Configuration("if protected classes should be searched")
     private val searchInProtectedClass: Boolean by config(false)
 
-    @Configuration("if companion object without names should be flagged")
+    @Configuration("if companion object without a name should be flagged")
     private val flagCompanionWithoutName: Boolean by config(true)
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClass.kt
@@ -13,7 +13,6 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.psiUtil.isPublic
-import org.jetbrains.kotlin.utils.addToStdlib.countOccurrencesOf
 
 /**
  * This rule reports public classes, objects and interfaces which do not have the required documentation.

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -12,6 +12,7 @@ private const val SEARCH_IN_INNER_CLASS = "searchInInnerClass"
 private const val SEARCH_IN_INNER_OBJECT = "searchInInnerObject"
 private const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
 private const val SEARCH_IN_PROTECTED_CLASS = "searchInProtectedClass"
+private const val FLAG_COMPANION_WITHOUT_NAME = "flagCompanionWithoutName"
 
 class UndocumentedPublicClassSpec {
     val subject = UndocumentedPublicClass(Config.empty)
@@ -267,6 +268,19 @@ class UndocumentedPublicClassSpec {
             }
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).hasSize(3)
+    }
+
+    @Test
+    fun `should not report in public companion class if disabled`() {
+        val code = """
+            /** Some doc */
+            public class PublicClass {
+                public companion object
+            }
+        """.trimIndent()
+        assertThat(
+            UndocumentedPublicClass(TestConfig(FLAG_COMPANION_WITHOUT_NAME to "false")
+        ).compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -279,8 +279,10 @@ class UndocumentedPublicClassSpec {
             }
         """.trimIndent()
         assertThat(
-            UndocumentedPublicClass(TestConfig(FLAG_COMPANION_WITHOUT_NAME to "false")
-        ).compileAndLint(code)).isEmpty()
+            UndocumentedPublicClass(
+                TestConfig(FLAG_COMPANION_WITHOUT_NAME to "false")
+            ).compileAndLint(code)
+        ).isEmpty()
     }
 
     @Test

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -344,11 +344,19 @@ class UndocumentedPublicClassSpec {
     fun `should report for public named companion classes if ignore disabled`() {
         val code = """
             /** Some doc */
-            public class PublicClass {
+            public class ContentClass {
                 public companion object Content {
                     public val x: String = ""
                 }
+            }
+
+            /** Some doc */
+            public class BracesClass {
                 public companion object Braces {}
+            }
+
+            /** Some doc */
+            public class EmptyClass {
                 public companion object Empty
             }
         """.trimIndent()

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -12,7 +12,7 @@ private const val SEARCH_IN_INNER_CLASS = "searchInInnerClass"
 private const val SEARCH_IN_INNER_OBJECT = "searchInInnerObject"
 private const val SEARCH_IN_INNER_INTERFACE = "searchInInnerInterface"
 private const val SEARCH_IN_PROTECTED_CLASS = "searchInProtectedClass"
-private const val FLAG_COMPANION_WITHOUT_NAME = "flagCompanionWithoutName"
+private const val IGNORE_UNNAMED_COMPANION_OBJECT = "ignoreUnnamedCompanionObject"
 
 class UndocumentedPublicClassSpec {
     val subject = UndocumentedPublicClass(Config.empty)
@@ -271,7 +271,24 @@ class UndocumentedPublicClassSpec {
     }
 
     @Test
-    fun `should not report in public companion class if disabled`() {
+    fun `should not report in public companion class with content if disabled`() {
+        val code = """
+            /** Some doc */
+            public class PublicClass {
+                public companion object {
+                    public val x: String = ""
+                }
+            }
+        """.trimIndent()
+        assertThat(
+            UndocumentedPublicClass(
+                TestConfig(IGNORE_UNNAMED_COMPANION_OBJECT to "true")
+            ).compileAndLint(code)
+        ).isEmpty()
+    }
+
+    @Test
+    fun `should not report in empty public companion class with content if disabled`() {
         val code = """
             /** Some doc */
             public class PublicClass {
@@ -280,7 +297,7 @@ class UndocumentedPublicClassSpec {
         """.trimIndent()
         assertThat(
             UndocumentedPublicClass(
-                TestConfig(FLAG_COMPANION_WITHOUT_NAME to "false")
+                TestConfig(IGNORE_UNNAMED_COMPANION_OBJECT to "true")
             ).compileAndLint(code)
         ).isEmpty()
     }


### PR DESCRIPTION
…panion object` without name

Closes #7634 in favour of leaving the rule as described with configuration to disable to pre-#7219 value.
