### PR TITLE
Add missing closing parenthesis to code example

### DIFF
--- a/website/versioned_docs/version-1.23.5/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.5/introduction/extensions.md
@@ -44,7 +44,7 @@ class TooManyFunctions(config: Config) : Rule(config) {
         super.visitKtFile(file)
         if (amount > threshold) {
             report(CodeSmell(issue, Entity.from(file), 
-                "Too many functions can make the maintainability of a file costlier")
+                "Too many functions can make the maintainability of a file costlier"))
         }
         amount = 0
     }

--- a/website/versioned_docs/version-1.23.6/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.6/introduction/extensions.md
@@ -44,7 +44,7 @@ class TooManyFunctions(config: Config) : Rule(config) {
         super.visitKtFile(file)
         if (amount > threshold) {
             report(CodeSmell(issue, Entity.from(file), 
-                "Too many functions can make the maintainability of a file costlier")
+                "Too many functions can make the maintainability of a file costlier"))
         }
         amount = 0
     }

--- a/website/versioned_docs/version-1.23.7/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.7/introduction/extensions.md
@@ -44,7 +44,7 @@ class TooManyFunctions(config: Config) : Rule(config) {
         super.visitKtFile(file)
         if (amount > threshold) {
             report(CodeSmell(issue, Entity.from(file), 
-                "Too many functions can make the maintainability of a file costlier")
+                "Too many functions can make the maintainability of a file costlier"))
         }
         amount = 0
     }


### PR DESCRIPTION
The code example was missing a closing parenthesis. I noticed that when copy-pasting the example into an IDE. I am not sure if you are fixing issues in docs retroactively. The issue seems to be fixed already under `website/docs/`.