### PR TITLE
Revert "Pass API & language versions to source set analysis tasks"

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -92,8 +92,6 @@ class DetektBasePlugin : Plugin<Project> {
                         if (sourceSet.name == "main") {
                             detektTask.explicitApi.convention(mapExplicitArgMode())
                         }
-                        detektTask.languageVersion.convention(provider { sourceSet.languageSettings.languageVersion })
-                        detektTask.apiVersion.convention(provider { sourceSet.languageSettings.apiVersion })
                         detektTask.description = "Run detekt analysis for ${sourceSet.name} source set"
                     }
 
@@ -112,10 +110,6 @@ class DetektBasePlugin : Plugin<Project> {
                         if (sourceSet.name == "main") {
                             createBaselineTask.explicitApi.convention(mapExplicitArgMode())
                         }
-                        createBaselineTask.languageVersion.convention(
-                            provider { sourceSet.languageSettings.languageVersion }
-                        )
-                        createBaselineTask.apiVersion.convention(provider { sourceSet.languageSettings.apiVersion })
                         createBaselineTask.description = "Creates detekt baseline for ${sourceSet.name} source set"
                     }
                 }


### PR DESCRIPTION
Reverts detekt/detekt#7482

Fixes #7638 

Once merged, let's reopen #7471, add it to 2.0.0 milestone but block it while waiting for a response on https://youtrack.jetbrains.com/issue/KT-71478/Gradle-Plugin-API-KDoc-clarify-intention-of-soft-deprecating-LanguageSettings-interface.

Also note that neither this nor #7482 are in 2.0.0 milestone which hopefully ensures they don't show up in release notes.