### PR TITLE
Extract interfaces from detekt Gradle tasks

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -1,7 +1,41 @@
+public abstract interface class dev/detekt/gradle/plugin/CommonCompilationArgs {
+	public abstract fun getApiVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getFreeCompilerArgs ()Lorg/gradle/api/provider/ListProperty;
+	public abstract fun getFriendPaths ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
+	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
+	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
+}
+
+public abstract interface class dev/detekt/gradle/plugin/DetektBase : dev/detekt/gradle/plugin/JvmCompilationArgs {
+	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
+	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
+	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
+	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
+	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
+	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
+	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
+	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
+}
+
 public final class dev/detekt/gradle/plugin/DetektBasePlugin : org/gradle/api/Plugin {
 	public fun <init> ()V
 	public synthetic fun apply (Ljava/lang/Object;)V
 	public fun apply (Lorg/gradle/api/Project;)V
+}
+
+public abstract interface class dev/detekt/gradle/plugin/DetektCliTool : org/gradle/api/Task {
+	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+}
+
+public abstract interface class dev/detekt/gradle/plugin/JvmCompilationArgs : dev/detekt/gradle/plugin/CommonCompilationArgs {
+	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
+	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
 }
 
 public final class io/github/detekt/gradle/DetektKotlinCompilerPlugin : org/jetbrains/kotlin/gradle/plugin/KotlinCompilerPluginSupportPlugin {
@@ -39,71 +73,27 @@ public class io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension
 	public final fun isEnabled ()Lorg/gradle/api/provider/Property;
 }
 
-public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/SourceTask {
+public abstract class io/gitlab/arturbosch/detekt/Detekt : org/gradle/api/tasks/SourceTask, dev/detekt/gradle/plugin/DetektBase, dev/detekt/gradle/plugin/DetektCliTool {
 	public fun <init> (Lorg/gradle/api/model/ObjectFactory;Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun check ()V
-	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
-	public abstract fun getApiVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
-	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
-	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
-	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
-	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getFailOnSeverity ()Lorg/gradle/api/provider/Property;
-	public abstract fun getFreeCompilerArgs ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getFriendPaths ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
-	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
-	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
-	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
-	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
-	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getReports ()Lio/gitlab/arturbosch/detekt/extensions/DetektReports;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public final fun reports (Lorg/gradle/api/Action;)V
 }
 
-public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org/gradle/api/tasks/SourceTask {
+public abstract class io/gitlab/arturbosch/detekt/DetektCreateBaselineTask : org/gradle/api/tasks/SourceTask, dev/detekt/gradle/plugin/DetektBase, dev/detekt/gradle/plugin/DetektCliTool {
 	public fun <init> (Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun baseline ()V
-	public abstract fun getAllRules ()Lorg/gradle/api/provider/Property;
-	public abstract fun getApiVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
-	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
-	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
-	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
-	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
-	public abstract fun getFreeCompilerArgs ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getFriendPaths ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
-	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
-	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
-	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
-	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
-	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
-	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
-	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
-	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 }
 
-public abstract class io/gitlab/arturbosch/detekt/DetektGenerateConfigTask : org/gradle/api/DefaultTask {
+public abstract class io/gitlab/arturbosch/detekt/DetektGenerateConfigTask : org/gradle/api/DefaultTask, dev/detekt/gradle/plugin/DetektCliTool {
 	public fun <init> (Lorg/gradle/workers/WorkerExecutor;Lorg/gradle/api/provider/ProviderFactory;)V
 	public final fun generateConfig ()V
 	public abstract fun getConfigFile ()Lorg/gradle/api/file/RegularFileProperty;
-	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
-	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 }
 
 public final class io/gitlab/arturbosch/detekt/DetektPlugin : org/gradle/api/Plugin {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/CommonCompilationArgs.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/CommonCompilationArgs.kt
@@ -1,0 +1,51 @@
+package dev.detekt.gradle.plugin
+
+import org.gradle.api.Incubating
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+
+/**
+ * Mashup of base/common compilation parameters from:
+ * * [org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions]
+ * * [org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerToolOptions]
+ * * [org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool]
+ * * [org.jetbrains.kotlin.gradle.tasks.BaseKotlinCompile]
+ */
+interface CommonCompilationArgs {
+    // org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+    @get:Optional
+    @get:Input
+    val apiVersion: Property<String>
+
+    // org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+    @get:Optional
+    @get:Input
+    val languageVersion: Property<String>
+
+    // org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerOptions
+    @get:Input
+    val optIn: ListProperty<String>
+
+    // org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompilerToolOptions
+    @get:Input
+    @get:Incubating
+    val freeCompilerArgs: ListProperty<String>
+
+    // org.jetbrains.kotlin.gradle.tasks.KotlinCompileTool (as 'libraries')
+    @get:Classpath
+    @get:Optional
+    val classpath: ConfigurableFileCollection
+
+    // org.jetbrains.kotlin.gradle.tasks.BaseKotlinCompile
+    @get:Internal
+    val friendPaths: ConfigurableFileCollection
+
+    // org.jetbrains.kotlin.gradle.tasks.BaseKotlinCompile
+    @get:Input
+    val multiPlatformEnabled: Property<Boolean>
+}

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBase.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBase.kt
@@ -1,0 +1,57 @@
+package dev.detekt.gradle.plugin
+
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Console
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.options.Option
+
+interface DetektBase : JvmCompilationArgs {
+
+    @get:Console
+    val debug: Property<Boolean>
+
+    @get:Internal
+    val parallel: Property<Boolean>
+
+    val baseline: RegularFileProperty
+
+    @get:InputFiles
+    @get:Optional
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    val config: ConfigurableFileCollection
+
+    @get:Input
+    @get:Optional
+    val disableDefaultRuleSets: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    val buildUponDefaultConfig: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    val ignoreFailures: Property<Boolean>
+
+    @get:Input
+    @get:Optional
+    val allRules: Property<Boolean>
+
+    /**
+     * Respect only the file path for incremental build. Using @InputFile respects both file path and content.
+     */
+    @get:Input
+    @get:Optional
+    val basePath: Property<String>
+
+    @get:Input
+    @get:Optional
+    @get:Option(option = "auto-correct", description = "Allow rules to auto correct code if they support it")
+    val autoCorrect: Property<Boolean>
+}

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektCliTool.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektCliTool.kt
@@ -1,0 +1,13 @@
+package dev.detekt.gradle.plugin
+
+import org.gradle.api.Task
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.tasks.Classpath
+
+interface DetektCliTool : Task {
+    @get:Classpath
+    val detektClasspath: ConfigurableFileCollection
+
+    @get:Classpath
+    val pluginClasspath: ConfigurableFileCollection
+}

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/JvmCompilationArgs.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/JvmCompilationArgs.kt
@@ -1,0 +1,23 @@
+package dev.detekt.gradle.plugin
+
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+
+/**
+ * Selection of parameters relevant for compilation analysis on JVM platforms. See
+ * [org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompilerOptions].
+ */
+interface JvmCompilationArgs : CommonCompilationArgs {
+    @get:Internal
+    val jdkHome: DirectoryProperty
+
+    @get:Input
+    @get:Optional
+    val jvmTarget: Property<String>
+
+    @get:Input
+    val noJdk: Property<Boolean>
+}

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/Detekt.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
+import dev.detekt.gradle.plugin.DetektBase
+import dev.detekt.gradle.plugin.DetektCliTool
 import io.gitlab.arturbosch.detekt.extensions.DetektReportType
 import io.gitlab.arturbosch.detekt.extensions.DetektReports
 import io.gitlab.arturbosch.detekt.extensions.FailOnSeverity
@@ -31,18 +33,12 @@ import io.gitlab.arturbosch.detekt.invoke.NoJdkArgument
 import io.gitlab.arturbosch.detekt.invoke.OptInArguments
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
 import org.gradle.api.Action
-import org.gradle.api.Incubating
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -54,7 +50,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
 import javax.inject.Inject
@@ -64,87 +59,16 @@ abstract class Detekt @Inject constructor(
     private val objects: ObjectFactory,
     private val workerExecutor: WorkerExecutor,
     private val providers: ProviderFactory,
-) : SourceTask() {
-
-    @get:Classpath
-    abstract val detektClasspath: ConfigurableFileCollection
-
-    @get:Classpath
-    abstract val pluginClasspath: ConfigurableFileCollection
+) : DetektBase, DetektCliTool, SourceTask() {
 
     @get:InputFiles // Why not InputFile? See https://github.com/gradle/gradle/issues/2016
     @get:Optional
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val baseline: RegularFileProperty
-
-    @get:InputFiles
-    @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val config: ConfigurableFileCollection
-
-    @get:Classpath
-    @get:Optional
-    abstract val classpath: ConfigurableFileCollection
-
-    @get:Internal
-    abstract val friendPaths: ConfigurableFileCollection
-
-    @get:Input
-    @get:Optional
-    abstract val apiVersion: Property<String>
-
-    @get:Input
-    @get:Optional
-    abstract val languageVersion: Property<String>
-
-    @get:Input
-    @get:Optional
-    abstract val jvmTarget: Property<String>
-
-    @get:Internal
-    abstract val jdkHome: DirectoryProperty
-
-    @get:Console
-    abstract val debug: Property<Boolean>
-
-    @get:Internal
-    abstract val parallel: Property<Boolean>
-
-    @get:Input
-    abstract val disableDefaultRuleSets: Property<Boolean>
-
-    @get:Input
-    abstract val buildUponDefaultConfig: Property<Boolean>
-
-    @get:Input
-    abstract val allRules: Property<Boolean>
-
-    @get:Input
-    abstract val optIn: ListProperty<String>
-
-    @get:Input
-    abstract val noJdk: Property<Boolean>
-
-    @get:Input
-    abstract val multiPlatformEnabled: Property<Boolean>
-
-    @get:Input
-    abstract val ignoreFailures: Property<Boolean>
+    abstract override val baseline: RegularFileProperty
 
     @get:Input
     @get:Optional
     abstract val failOnSeverity: Property<FailOnSeverity>
-
-    @get:Input
-    @get:Option(option = "auto-correct", description = "Allow rules to auto correct code if they support it")
-    abstract val autoCorrect: Property<Boolean>
-
-    /**
-     * Respect only the file path for incremental build. Using @InputFile respects both file path and content.
-     */
-    @get:Input
-    @get:Optional
-    abstract val basePath: Property<String>
 
     @get:Nested
     /*
@@ -154,10 +78,6 @@ abstract class Detekt @Inject constructor(
     open val reports: DetektReports = objects.newInstance(DetektReports::class.java)
 
     private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
-
-    @get:Input
-    @get:Incubating
-    abstract val freeCompilerArgs: ListProperty<String>
 
     @get:Input
     @get:Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektCreateBaselineTask.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt
 
+import dev.detekt.gradle.plugin.DetektBase
+import dev.detekt.gradle.plugin.DetektCliTool
 import io.gitlab.arturbosch.detekt.invoke.AllRulesArgument
 import io.gitlab.arturbosch.detekt.invoke.ApiVersionArgument
 import io.gitlab.arturbosch.detekt.invoke.AutoCorrectArgument
@@ -25,17 +27,11 @@ import io.gitlab.arturbosch.detekt.invoke.MultiPlatformEnabledArgument
 import io.gitlab.arturbosch.detekt.invoke.NoJdkArgument
 import io.gitlab.arturbosch.detekt.invoke.OptInArguments
 import io.gitlab.arturbosch.detekt.invoke.ParallelArgument
-import org.gradle.api.Incubating
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Classpath
-import org.gradle.api.tasks.Console
 import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
@@ -55,7 +51,7 @@ import javax.inject.Inject
 abstract class DetektCreateBaselineTask @Inject constructor(
     private val workerExecutor: WorkerExecutor,
     private val providers: ProviderFactory,
-) : SourceTask() {
+) : DetektBase, DetektCliTool, SourceTask() {
 
     init {
         description = "Creates a detekt baseline on the given --baseline path."
@@ -63,86 +59,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     }
 
     @get:OutputFile
-    abstract val baseline: RegularFileProperty
-
-    @get:InputFiles
-    @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val config: ConfigurableFileCollection
-
-    @get:Classpath
-    abstract val detektClasspath: ConfigurableFileCollection
-
-    @get:Classpath
-    abstract val pluginClasspath: ConfigurableFileCollection
-
-    @get:Classpath
-    @get:Optional
-    abstract val classpath: ConfigurableFileCollection
-
-    @get:Internal
-    abstract val friendPaths: ConfigurableFileCollection
-
-    @get:Console
-    abstract val debug: Property<Boolean>
-
-    @get:Internal
-    abstract val parallel: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val disableDefaultRuleSets: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val buildUponDefaultConfig: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val ignoreFailures: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val allRules: Property<Boolean>
-
-    @get:Input
-    abstract val optIn: ListProperty<String>
-
-    @get:Input
-    abstract val noJdk: Property<Boolean>
-
-    @get:Input
-    abstract val multiPlatformEnabled: Property<Boolean>
-
-    @get:Input
-    @get:Optional
-    abstract val autoCorrect: Property<Boolean>
-
-    /**
-     * Respect only the file path for incremental build. Using @InputFile respects both file path and content.
-     */
-    @get:Input
-    @get:Optional
-    abstract val basePath: Property<String>
-
-    @get:Input
-    @get:Optional
-    abstract val jvmTarget: Property<String>
-
-    @get:Input
-    @get:Optional
-    abstract val apiVersion: Property<String>
-
-    @get:Input
-    @get:Optional
-    abstract val languageVersion: Property<String>
-
-    @get:Internal
-    abstract val jdkHome: DirectoryProperty
-
-    @get:Input
-    @get:Incubating
-    abstract val freeCompilerArgs: ListProperty<String>
+    abstract override val baseline: RegularFileProperty
 
     @get:Input
     @get:Optional

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -1,17 +1,16 @@
 package io.gitlab.arturbosch.detekt
 
+import dev.detekt.gradle.plugin.DetektCliTool
 import io.gitlab.arturbosch.detekt.invoke.CliArgument
 import io.gitlab.arturbosch.detekt.invoke.DetektInvoker
 import io.gitlab.arturbosch.detekt.invoke.DetektWorkAction
 import io.gitlab.arturbosch.detekt.invoke.GenerateConfigArgument
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.services.BuildService
 import org.gradle.api.services.BuildServiceParameters
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
@@ -24,18 +23,12 @@ import javax.inject.Inject
 abstract class DetektGenerateConfigTask @Inject constructor(
     private val workerExecutor: WorkerExecutor,
     private val providers: ProviderFactory,
-) : DefaultTask() {
+) : DetektCliTool, DefaultTask() {
 
     init {
         description = "Generate a detekt configuration file inside your project."
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
-
-    @get:Classpath
-    abstract val detektClasspath: ConfigurableFileCollection
-
-    @get:Classpath
-    abstract val pluginClasspath: ConfigurableFileCollection
 
     @get:OutputFile
     abstract val configFile: RegularFileProperty


### PR DESCRIPTION
Move common detekt Gradle task parameters into interfaces.

There are lots of ways to do this of course, so I'm open to feedback & suggestions on improvements on structure & naming.

Quick overview:
* `DetektBase` - these are detekt-specific configuration parameters. Anything used to configure detekt sits here.
* `CommonCompilationArgs` - common compiler args that apply to all compilations, including non-JVM targets. Separating from `JvmCompilationArgs` means we can add `JsCompilationArgs` and others in future.
* `JvmCompilationArgs` - JVM-specific compiler args
* `DetektCliTool` - it's unlikely we switch to tooling API for DGP 2.0.0 but separating this interface may make it easier to make the switch in future.

This will evolve as there's more I'd like to do to separate concerns in future PRs:
1. Add an `args` parameter to `DetektCliTool` and use common functions to launch the application using either worker API or the current default method.
2. Add lots of KDoc
3. Create separate interfaces & types to cleanly separate source set analysis tasks from compilation analysis tasks. We don't need things like JVM target, classpath etc. when analysing source sets.

It's enough though to fix #5940.