### PR TITLE
Stop explicitly creating generated config parent dirs

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektGenerateConfigTask.kt
@@ -17,7 +17,6 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
-import java.nio.file.Files
 import javax.inject.Inject
 
 @CacheableTask
@@ -52,8 +51,6 @@ abstract class DetektGenerateConfigTask @Inject constructor(
             logger.warn("Skipping config file generation; file already exists at ${configFile.get().asFile}")
             return
         }
-
-        Files.createDirectories(configFile.get().asFile.parentFile.toPath())
 
         if (providers.isWorkerApiEnabled()) {
             logger.info("Executing $name using Worker API")


### PR DESCRIPTION
Gradle takes care of this when input & output file parameters are correctly annotated.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
