### PR TITLE
SuspendFunInFinallySection - New rule for linting suspend calls in `finally` section

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -185,6 +185,8 @@ coroutines:
     active: true
   SleepInsteadOfDelay:
     active: true
+  SuspendFunInFinallySection:
+    active: false
   SuspendFunSwallowedCancellation:
     active: false
   SuspendFunWithCoroutineScopeReceiver:

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutinesProvider.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutinesProvider.kt
@@ -23,6 +23,7 @@ class CoroutinesProvider : DefaultRuleSetProvider {
             ::SuspendFunWithFlowReturnType,
             ::SuspendFunWithCoroutineScopeReceiver,
             ::SuspendFunSwallowedCancellation,
+            ::SuspendFunInFinallySection
         )
     )
 }

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 import io.gitlab.arturbosch.detekt.api.CodeSmell
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -41,7 +41,7 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
  * </compliant>
  *
  */
-@RequiresTypeResolution
+@RequiresFullAnalysis
 class SuspendFunInFinallySection(config: Config) : Rule(
     config,
     "Suspend functions should not be called from a 'finally' section without using 'NonCancellable' " +

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -75,7 +75,6 @@ class SuspendFunInFinallySection(config: Config) : Rule(
     private fun KtCallExpression.parentCallsUpTo(topParent: PsiElement) =
         generateSequence(this as PsiElement) { it.parent }
             .takeWhile { it != topParent }
-            // .takeIf { !it.any { element -> element is KtLambdaExpression } }
             .filter { it is KtCallExpression }
             .map { it as KtCallExpression }
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -79,11 +79,11 @@ class SuspendFunInFinallySection(config: Config) : Rule(
             .filter { it is KtCallExpression }
             .map { it as KtCallExpression }
 
-    private fun Sequence<KtCallExpression>.findFunction(fqName: String) = filter {
+    private fun Sequence<KtCallExpression>.findFunction(fqName: String) = firstOrNull {
         it.getResolvedCall(bindingContext)
             ?.resultingDescriptor
             ?.fqNameOrNull() == FqName(fqName)
-    }.firstOrNull()
+    }
 
     private fun isNonCancellableArgument(arg: KtValueArgument, context: BindingContext) =
         arg.getArgumentExpression()

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtFinallySection
 import org.jetbrains.kotlin.psi.KtValueArgument
@@ -70,7 +69,7 @@ class SuspendFunInFinallySection(config: Config) : Rule(
     }
 
     private fun KtCallExpression.isSuspendCall() =
-        (getResolvedCall(bindingContext)?.resultingDescriptor as? FunctionDescriptor)?.isSuspend == true
+        (getResolvedCall(bindingContext)?.resultingDescriptor as FunctionDescriptor).isSuspend
 
     private fun KtCallExpression.parentCallsUpTo(topParent: PsiElement) =
         generateSequence(this as PsiElement) { it.parent }
@@ -81,7 +80,8 @@ class SuspendFunInFinallySection(config: Config) : Rule(
     private fun Sequence<KtCallExpression>.findFunction(fqName: String) = firstOrNull {
         it.getResolvedCall(bindingContext)
             ?.resultingDescriptor
-            ?.fqNameOrNull() == FqName(fqName)
+            ?.fqNameOrNull()
+            ?.asString() == fqName
     }
 
     private fun isNonCancellableArgument(arg: KtValueArgument, context: BindingContext) =

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -1,0 +1,94 @@
+package io.gitlab.arturbosch.detekt.rules.coroutines
+
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.RequiresTypeResolution
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtFinallySection
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.psiUtil.forEachDescendantOfType
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+
+/**
+ * Report usage of suspending functions within a `finally` section that are not enclosed in a non-cancellable context.
+ * Without a non-cancellable context, these functions will not execute if the parent coroutine is cancelled.
+ *
+ * <noncompliant>
+ * launch {
+ *     try {
+ *         suspendingWork()
+ *     } finally {
+ *         suspendingCleanup()
+ *     }
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * launch {
+ *     try {
+ *         suspendingWork()
+ *     } finally {
+ *         withContext(NonCancellable) { suspendingCleanup() }
+ *     }
+ * }
+ * </compliant>
+ *
+ */
+@RequiresTypeResolution
+class SuspendFunInFinallySection(config: Config) : Rule(
+    config,
+    "Suspend functions should not be called from a 'finally' section without using 'NonCancellable' " +
+        "context as they won't execute if parent coroutine scope is cancelled."
+) {
+    override fun visitFinallySection(finallySection: KtFinallySection) {
+        finallySection.forEachDescendantOfType<KtCallExpression> { expression ->
+            if (shouldReport(expression, finallySection)) {
+                report(CodeSmell(Entity.from(expression.calleeExpression as PsiElement), description))
+            }
+        }
+    }
+
+    private fun shouldReport(
+        expression: KtCallExpression,
+        topParent: KtFinallySection
+    ): Boolean {
+        if (!expression.isSuspendCall()) {
+            return false
+        }
+
+        val parentCalls = expression.parentCallsUpTo(topParent)
+        val withContextFun = parentCalls.findFunction("kotlinx.coroutines.withContext") ?: return true
+        val firstArgument = withContextFun.valueArguments.first()
+        return !isNonCancellableArgument(firstArgument, bindingContext)
+    }
+
+    private fun KtCallExpression.isSuspendCall() =
+        (getResolvedCall(bindingContext)?.resultingDescriptor as? FunctionDescriptor)?.isSuspend == true
+
+    private fun KtCallExpression.parentCallsUpTo(topParent: PsiElement) =
+        generateSequence(this as PsiElement) { it.parent }
+            .takeWhile { it != topParent }
+            // .takeIf { !it.any { element -> element is KtLambdaExpression } }
+            .filter { it is KtCallExpression }
+            .map { it as KtCallExpression }
+
+    private fun Sequence<KtCallExpression>.findFunction(fqName: String) = filter {
+        it.getResolvedCall(bindingContext)
+            ?.resultingDescriptor
+            ?.fqNameOrNull() == FqName(fqName)
+    }.firstOrNull()
+
+    private fun isNonCancellableArgument(arg: KtValueArgument, context: BindingContext) =
+        arg.getArgumentExpression()
+            .getResolvedCall(context)
+            ?.resultingDescriptor
+            ?.returnType
+            .toString() == "NonCancellable"
+}

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
-
     private val subject = SuspendFunInFinallySection(Config.empty)
 
     @Test

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -67,6 +67,31 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
     }
 
     @Test
+    fun `report wrapped suspend function in finally section with different context`() {
+        val code = """
+            import kotlinx.coroutines.*
+            
+            fun main(): Unit = runBlocking {
+                launch {
+                    try {
+                        yield()
+                    } finally {
+                        withContext(Dispatchers.Default) { test() }
+                    }
+                }
+            }
+            
+            suspend fun test() { yield() }
+        """.trimIndent()
+
+        assertFindingsForSuspendCall(
+            findings = subject.compileAndLintWithContext(env, code),
+            "test".find(1)(code),
+            "withContext".find(1)(code),
+        )
+    }
+
+    @Test
     fun `does not report ordinary function in finally section`() {
         val code = """
             import kotlinx.coroutines.*

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -43,7 +43,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report wrapped suspend function in finally section`() {
         val code = """
             import kotlinx.coroutines.*
-
+            
             typealias NC = NonCancellable
             
             fun main(): Unit = runBlocking {

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -33,8 +33,8 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
 
         assertFindingsForSuspendCall(
             findings = subject.compileAndLintWithContext(env, code),
-            "test"(1)(code),
-            "test"(2)(code)
+            "test".find(1)(code),
+            "test".find(2)(code)
         )
     }
 
@@ -119,16 +119,16 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
 
         assertFindingsForSuspendCall(
             findings = subject.compileAndLintWithContext(env, code),
-            "wrapper"(2)(code),
-            "test"(1)(code),
-            "block"(2)(code),
+            "wrapper".find(2)(code),
+            "test".find(1)(code),
+            "block".find(2)(code),
         )
     }
 
     companion object {
         private val NOTHING: Array<Pair<Int, Int>> = emptyArray()
 
-        operator fun String.invoke(ordinal: Int): (String) -> Pair<Int, Int> =
+        private fun String.find(ordinal: Int): (String) -> Pair<Int, Int> =
             { code ->
                 fun String.next(string: String, start: Int): Int? = indexOf(string, start).takeIf { it != -1 }
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -1,0 +1,152 @@
+package io.gitlab.arturbosch.detekt.rules.coroutines
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
+
+    private val subject = SuspendFunInFinallySection(Config.empty)
+
+    @Test
+    fun `report unwrapped suspend function in finally section`() {
+        val code = """
+            import kotlinx.coroutines.*
+            
+            fun main(): Unit = runBlocking {
+                launch {
+                    try {
+                        yield()
+                    } finally {
+                        test()
+                        val p = test()
+                    }
+                }
+            }
+            
+            suspend fun test() { yield() }
+        """.trimIndent()
+
+        assertFindingsForSuspendCall(
+            findings = subject.compileAndLintWithContext(env, code),
+            "test"(1)(code),
+            "test"(2)(code)
+        )
+    }
+
+    @Test
+    fun `does not report wrapped suspend function in finally section`() {
+        val code = """
+            import kotlinx.coroutines.*
+
+            typealias NC = NonCancellable
+            
+            fun main(): Unit = runBlocking {
+                launch {
+                    try {
+                        yield()
+                    } finally {
+                        withContext(NonCancellable) { test() }
+                        // Alias argument
+                        withContext(NC) { test() }
+                    }
+                }
+            }
+            
+            suspend fun test() { yield() }
+        """.trimIndent()
+
+        assertFindingsForSuspendCall(
+            findings = subject.compileAndLintWithContext(env, code),
+            *NOTHING
+        )
+    }
+
+    @Test
+    fun `does not report ordinary function in finally section`() {
+        val code = """
+            import kotlinx.coroutines.*
+            
+            fun main(): Unit = runBlocking {
+                launch {
+                    try {
+                        yield()
+                    } finally {
+                        test()
+                    }
+                }
+            }
+            
+            fun test() { println(".") }
+        """.trimIndent()
+
+        assertFindingsForSuspendCall(
+            findings = subject.compileAndLintWithContext(env, code),
+            *NOTHING
+        )
+    }
+
+    @Test
+    fun `my test`() {
+        val code = """
+            import kotlinx.coroutines.*
+            import kotlin.coroutines.*
+                        
+            fun main(): Unit = runBlocking {
+                launch {
+                    try {
+                        yield()
+                    } finally {
+                        // Nested calls. I don't see a way to implement it 
+                        // (e.g. call made to external library that provides non-cancellable context)
+                        suspend fun wrapper(b: suspend () -> Unit) = withContext(NonCancellable) { b() }
+                        wrapper { test() }
+            
+                        // Lambda
+                        // New coroutine still will be cancelled if launched in cancelled context
+                        val lambda: suspend (suspend () -> Unit) -> Unit = { block -> launch { block() } } 
+                        withContext(NonCancellable) { lambda { test() } }
+                    }
+                }
+            }
+            
+            suspend fun test() { yield() }
+        """.trimIndent()
+
+        assertFindingsForSuspendCall(
+            findings = subject.compileAndLintWithContext(env, code),
+            "wrapper"(2)(code),
+            "test"(1)(code),
+            "block"(2)(code),
+        )
+    }
+
+    companion object {
+        private val NOTHING: Array<Pair<Int, Int>> = emptyArray()
+
+        operator fun String.invoke(ordinal: Int): (String) -> Pair<Int, Int> =
+            { code ->
+                fun String.next(string: String, start: Int): Int? = indexOf(string, start).takeIf { it != -1 }
+
+                val indices = generateSequence(code.next(this, 0)) { startIndex ->
+                    code.next(this, startIndex + 1)
+                }
+                val index = requireNotNull(indices.elementAtOrNull(ordinal - 1)) {
+                    "There's no $ordinal. occurrence of '$this' in '$code'"
+                }
+                index to index + this.length
+            }
+
+        private fun assertFindingsForSuspendCall(findings: List<Finding>, vararg locations: Pair<Int, Int>) {
+            assertThat(findings)
+                .hasTextLocations(
+                    *(locations.map { it.first to it.second }).toTypedArray()
+                )
+        }
+    }
+}


### PR DESCRIPTION
[WIP]

To address #7585

Visits expression call in `finally` section and determines if the call is `suspend`. Then traverses all its parents to see if one of them is `withContext(NonCancellable)`. This is the simplest case.

Should we consider the following?

```kotlin
// Nested calls. I don't see a way to implement it 
// (e.g. call made to external library that provides non-cancellable context)
suspend fun wrapper(b: suspend () -> Unit) = withContext(NonCancellable) { b() }
wrapper { test() }
```
            
```kotlin
// Lambda
// New coroutine still will be cancelled if launched in cancelled context
val lambda: suspend (suspend () -> Unit) -> Unit = { block -> launch { block() } } 
withContext(NonCancellable) { lambda { test() } }
```
