### PR TITLE
Remove originalUriBaseIds from SARIF report output

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.sarif
 
-import io.github.detekt.sarif4k.ArtifactLocation
 import io.github.detekt.sarif4k.Run
 import io.github.detekt.sarif4k.SarifSchema210
 import io.github.detekt.sarif4k.SarifSerializer
@@ -13,8 +12,6 @@ import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import kotlin.io.path.Path
-import kotlin.io.path.invariantSeparatorsPathString
 
 const val SRCROOT = "%SRCROOT%"
 
@@ -23,14 +20,9 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     override val ending: String = "sarif"
     override val id: String = "sarif"
 
-    private lateinit var basePath: String
     private lateinit var config: Config
 
     override fun init(context: SetupContext) {
-        this.basePath = context.basePath
-            .invariantSeparatorsPathString
-            .let { if (!it.endsWith("/")) "$it/" else it }
-
         this.config = context.config
     }
 
@@ -55,7 +47,6 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
                             version = version
                         )
                     ),
-                    originalURIBaseIDS = mapOf(SRCROOT to ArtifactLocation(uri = Path(basePath).toUri().toString())),
                     results = toResults(detektion)
                 )
             )

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -18,8 +18,6 @@ import io.gitlab.arturbosch.detekt.test.yamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.junit.jupiter.api.Test
-import kotlin.io.path.Path
-import kotlin.io.path.absolute
 
 class SarifOutputReportSpec {
 
@@ -49,13 +47,11 @@ class SarifOutputReportSpec {
             )
         )
 
-        val basePath = Path("").absolute()
         val report = SarifOutputReport()
-            .apply { init(TestSetupContext(basePath = basePath)) }
+            .apply { init(TestSetupContext()) }
             .render(result)
 
         val expectedReport = readResourceContent("vanilla.sarif.json")
-            .replace("<BASE-URL>", basePath.toUri().toString())
 
         assertThat(report).isEqualToIgnoringWhitespace(expectedReport)
     }
@@ -70,13 +66,11 @@ class SarifOutputReportSpec {
 
         val testConfig = yamlConfig("config_with_rule_set_to_warning.yml")
 
-        val basePath = Path("").absolute()
         val report = SarifOutputReport()
-            .apply { init(TestSetupContext(config = testConfig, basePath = basePath)) }
+            .apply { init(TestSetupContext(config = testConfig)) }
             .render(result)
 
         val expectedReport = readResourceContent("rule_warning.sarif.json")
-            .replace("<BASE-PATH>", basePath.toUri().toString())
 
         assertThat(report).isEqualToIgnoringWhitespace(expectedReport)
     }

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -3,11 +3,6 @@
   "version": "2.1.0",
   "runs": [
     {
-      "originalUriBaseIds": {
-        "%SRCROOT%": {
-          "uri": "<BASE-PATH>"
-        }
-      },
       "results": [
         {
           "level": "error",

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -3,11 +3,6 @@
   "version": "2.1.0",
   "runs": [
     {
-      "originalUriBaseIds": {
-        "%SRCROOT%": {
-          "uri": "<BASE-URL>"
-        }
-      },
       "results": [
         {
           "level": "error",


### PR DESCRIPTION
Absolute paths are not required here. The values are ignored by GitHub. Using `%srcroot%` for `artifactLocation.uriBaseId` is sufficient as a root path reference. The SARIF 2.1.0 Errata 01 spec says at s3.4.4:

> The analysis tool and the SARIF consumers have agreed upon a convention
> whereby this indicates that the relative reference is expressed relative
> to the root of the source tree in which the file appears.

Fixes #7665

I added a commit with failures which was properly rendered by GitHub analysis to show that the merged SARIF output is still doing what's expected. I've now removed the commit so this is ready to merge.