### PR TITLE
Remove version references from SARIF output

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/SarifOutputReport.kt
@@ -11,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.OutputReport
 import io.gitlab.arturbosch.detekt.api.SetupContext
 import io.gitlab.arturbosch.detekt.api.internal.BuiltInOutputReport
-import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 
 const val SRCROOT = "%SRCROOT%"
 
@@ -27,7 +26,6 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
     }
 
     override fun render(detektion: Detektion): String {
-        val version = whichDetekt()
         val sarifSchema210 = SarifSchema210(
             schema = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json",
             version = Version.The210,
@@ -35,16 +33,12 @@ class SarifOutputReport : BuiltInOutputReport, OutputReport() {
                 Run(
                     tool = Tool(
                         driver = ToolComponent(
-                            downloadURI = "https://github.com/detekt/detekt/releases/download/v$version/detekt",
-                            fullName = "detekt",
                             guid = "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
                             informationURI = "https://detekt.dev",
                             language = "en",
                             name = "detekt",
                             rules = toReportingDescriptors(config),
                             organization = "detekt",
-                            semanticVersion = version,
-                            version = version
                         )
                     ),
                     results = toResults(detektion)

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -76,8 +76,6 @@
       ],
       "tool": {
         "driver": {
-          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.16.0/detekt",
-          "fullName": "detekt",
           "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
           "informationUri": "https://detekt.dev",
           "language": "en",
@@ -95,9 +93,7 @@
                 "text": ""
               }
             }
-          ],
-          "semanticVersion": "1.16.0",
-          "version": "1.16.0"
+          ]
         }
       }
     }

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -76,8 +76,6 @@
       ],
       "tool": {
         "driver": {
-          "downloadUri": "https://github.com/detekt/detekt/releases/download/v1.16.0/detekt",
-          "fullName": "detekt",
           "guid": "022ca8c2-f6a2-4c95-b107-bb72c43263f3",
           "informationUri": "https://detekt.dev",
           "language": "en",
@@ -95,9 +93,7 @@
                 "text": ""
               }
             }
-          ],
-          "semanticVersion": "1.16.0",
-          "version": "1.16.0"
+          ]
         }
       }
     }


### PR DESCRIPTION
* Version is not correct when using a snapshot version of detekt
* fullName should include version, according to spec, so removing it as adding an incorrect version does not make sense. It's also ignored by GitHub.
* downloadUri URI is broken and leads to 404. It's also ignored by GitHub.
* version & semanticVersion are not required by GitHub.

These properties "MAY" be included in SARIF output reports so removing them does not impact spec compliance ([spec](https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html)).

If correct values can be provided then that can be added in a new PR.