### PR TITLE
SARIF: Don't set level in reportingDescriptor if not set on rule

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -29,15 +29,17 @@ private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor =
         id = "detekt.$ruleSetId.$ruleName",
         name = ruleName.value,
         shortDescription = MultiformatMessageString(text = description),
-        defaultConfiguration = ReportingConfiguration(
-            level = computeSeverity().toResultLevel()
-        )
+        defaultConfiguration = computeSeverity()?.let {
+            ReportingConfiguration(
+                level = it.toResultLevel()
+            )
+        }
     )
 
-private fun Rule.computeSeverity(): Severity {
+private fun Rule.computeSeverity(): Severity? {
     val configValue: String = config.valueOrNull(Config.SEVERITY_KEY)
         ?: config.parent?.valueOrNull(Config.SEVERITY_KEY)
-        ?: return Severity.Error
+        ?: return null
     return parseToSeverity(configValue)
 }
 

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -95,9 +95,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellB",
               "name": "TestSmellB",
               "shortDescription": {
@@ -105,9 +102,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellC",
               "name": "TestSmellC",
               "shortDescription": {
@@ -115,9 +109,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellD",
               "name": "TestSmellD",
               "shortDescription": {

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -85,9 +85,6 @@
           "organization": "detekt",
           "rules": [
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet1.TestSmellA",
               "name": "TestSmellA",
               "shortDescription": {
@@ -95,9 +92,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellB",
               "name": "TestSmellB",
               "shortDescription": {
@@ -105,9 +99,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellC",
               "name": "TestSmellC",
               "shortDescription": {
@@ -115,9 +106,6 @@
               }
             },
             {
-              "defaultConfiguration": {
-                "level": "error"
-              },
               "id": "detekt.RuleSet2.TestSmellD",
               "name": "TestSmellD",
               "shortDescription": {


### PR DESCRIPTION
Error is too strong a default for a linter in the context of other tools that output SARIF reports. The SARIF spec says "error" level is used when the rule was evaluated and "a serious problem was found".

If a severity is set explicitly in detekt config for a ruleset or rule then this will be set explicitly in SARIF report as well so they're aligned.

EDIT: Should our default be "note" instead? That's used when the rule finds "a minor problem or an opportunity to improve the code" which is much more aligned to what detekt is doing.

EDIT 2: Tagging as a notable change, as depending on what users are doing, some downstream uses of SARIF output that might have included a lot of "error" level messages will change to report warnings instead.