### PR TITLE
Revert "chore(deps): update jamesives/github-pages-deploy-action digest to a96ffa2"

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -50,7 +50,7 @@ jobs:
         run: yarn build
 
       - name: Deploy GitHub Pages (only on main)
-        uses: JamesIves/github-pages-deploy-action@a96ffa23204731ec64e3e1316072197d98bfbaea # v4
+        uses: JamesIves/github-pages-deploy-action@920cbb300dcd3f0568dbc42700c61e2fd9e6139c # v4
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
           branch: gh-pages


### PR DESCRIPTION
Reverts detekt/detekt#7680.

Reason: https://github.com/detekt/detekt/actions/runs/11077673195/job/30783459115#step:9:22

Don't merge new versions of this action until these are addressed:
* https://github.com/JamesIves/github-pages-deploy-action/issues/1698
* https://github.com/JamesIves/github-pages-deploy-action/issues/1697

[v4.6.4](https://github.com/JamesIves/github-pages-deploy-action/releases/tag/v4.6.4) is the last known good version.