### PR TITLE
Remove helpUri from SARIF output

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -24,20 +24,15 @@ internal fun toReportingDescriptors(config: Config): List<ReportingDescriptor> =
             }
         }
 
-private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor {
-    val formattedRuleSetId = ruleSetId.value.lowercase()
-    val formattedRuleName = ruleName.value.lowercase()
-
-    return ReportingDescriptor(
+private fun Rule.toDescriptor(ruleSetId: RuleSet.Id): ReportingDescriptor =
+    ReportingDescriptor(
         id = "detekt.$ruleSetId.$ruleName",
         name = ruleName.value,
         shortDescription = MultiformatMessageString(text = description),
-        helpURI = "https://detekt.dev/$formattedRuleSetId.html#$formattedRuleName",
         defaultConfiguration = ReportingConfiguration(
             level = computeSeverity().toResultLevel()
         )
     )
-}
 
 private fun Rule.computeSeverity(): Severity {
     val configValue: String = config.valueOrNull(Config.SEVERITY_KEY)

--- a/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
+++ b/detekt-report-sarif/src/test/resources/rule_warning.sarif.json
@@ -88,7 +88,6 @@
               "defaultConfiguration": {
                 "level": "warning"
               },
-              "helpUri": "https://detekt.dev/ruleset1.html#testsmella",
               "id": "detekt.RuleSet1.TestSmellA",
               "name": "TestSmellA",
               "shortDescription": {
@@ -99,7 +98,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmellb",
               "id": "detekt.RuleSet2.TestSmellB",
               "name": "TestSmellB",
               "shortDescription": {
@@ -110,7 +108,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmellc",
               "id": "detekt.RuleSet2.TestSmellC",
               "name": "TestSmellC",
               "shortDescription": {
@@ -121,7 +118,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmelld",
               "id": "detekt.RuleSet2.TestSmellD",
               "name": "TestSmellD",
               "shortDescription": {

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -88,7 +88,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset1.html#testsmella",
               "id": "detekt.RuleSet1.TestSmellA",
               "name": "TestSmellA",
               "shortDescription": {
@@ -99,7 +98,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmellb",
               "id": "detekt.RuleSet2.TestSmellB",
               "name": "TestSmellB",
               "shortDescription": {
@@ -110,7 +108,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmellc",
               "id": "detekt.RuleSet2.TestSmellC",
               "name": "TestSmellC",
               "shortDescription": {
@@ -121,7 +118,6 @@
               "defaultConfiguration": {
                 "level": "error"
               },
-              "helpUri": "https://detekt.dev/ruleset2.html#testsmelld",
               "id": "detekt.RuleSet2.TestSmellD",
               "name": "TestSmellD",
               "shortDescription": {


### PR DESCRIPTION
This is unversioned, creating a couple of issues:
* 404 when rules are removed
* Incorrect information provided when a rule is run and the helpUri either leads to a page which shows new behaviour not included in the rule that was executed, or doesn't show behaviour that has since been removed.

This property is not used by GitHub and report output "MAY" include it according to v2.1.0 of the SARIF spec.