### PR TITLE
Fixed Broken links to the Kotlin hidden costs benchmarking page

### DIFF
--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRange.kt
@@ -19,7 +19,10 @@ import org.jetbrains.kotlin.psi2ir.deparenthesize
  * Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
  * simple for loops. Hence, in most contexts, a simple for loop should be used instead.
  * See more details here:
- * https://web.archive.org/web/20230514162525/https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+ *
  * To solve this CodeSmell, the forEach usage should be replaced by a for loop.
  *
  * <noncompliant>

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperator.kt
@@ -18,7 +18,9 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
 /**
  * In most cases using a spread operator causes a full copy of the array to be created before calling a method.
  * This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
- * https://web.archive.org/web/20230514162525/https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
  *
  * The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
  * function is used to create the arguments that are passed to the vararg parameter. This case will not be flagged

--- a/website/versioned_docs/version-1.21.0/rules/performance.md
+++ b/website/versioned_docs/version-1.21.0/rules/performance.md
@@ -74,7 +74,14 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here: 
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,7 +114,12 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.22.0/rules/performance.md
+++ b/website/versioned_docs/version-1.22.0/rules/performance.md
@@ -74,7 +74,14 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here: 
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,7 +114,10 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.0/rules/performance.md
+++ b/website/versioned_docs/version-1.23.0/rules/performance.md
@@ -74,7 +74,14 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here:
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,7 +114,12 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.1/rules/performance.md
+++ b/website/versioned_docs/version-1.23.1/rules/performance.md
@@ -74,7 +74,12 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here: 
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,7 +112,10 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.3/rules/performance.md
+++ b/website/versioned_docs/version-1.23.3/rules/performance.md
@@ -74,7 +74,13 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here: 
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,7 +113,10 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.4/rules/performance.md
+++ b/website/versioned_docs/version-1.23.4/rules/performance.md
@@ -74,7 +74,12 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here:
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+ 
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,8 +112,11 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
 
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+ 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in
 detekt this case will not be flagged by the rule since it doesn't suffer the performance penalty of an array copy.

--- a/website/versioned_docs/version-1.23.5/rules/performance.md
+++ b/website/versioned_docs/version-1.23.5/rules/performance.md
@@ -74,7 +74,12 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details here: 
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
@@ -107,8 +112,11 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
 
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+ 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in
 detekt this case will not be flagged by the rule since it doesn't suffer the performance penalty of an array copy.

--- a/website/versioned_docs/version-1.23.6/rules/performance.md
+++ b/website/versioned_docs/version-1.23.6/rules/performance.md
@@ -74,8 +74,13 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
-To solve this CodeSmell, the forEach usage should be replaced by a for loop.
+See more details here: 
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
+ 
+ To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -107,7 +112,10 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+ * [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+ * [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+ * [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.7/rules/performance.md
+++ b/website/versioned_docs/version-1.23.7/rules/performance.md
@@ -74,13 +74,14 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
+
 See more details with this blog series:
 
--https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
 
--https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
 
--https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 

--- a/website/versioned_docs/version-1.23.7/rules/performance.md
+++ b/website/versioned_docs/version-1.23.7/rules/performance.md
@@ -81,6 +81,7 @@ See more details with this blog series:
 -https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70
 
 -https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4
+
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0

--- a/website/versioned_docs/version-1.23.7/rules/performance.md
+++ b/website/versioned_docs/version-1.23.7/rules/performance.md
@@ -115,7 +115,12 @@ for (i in 1..10) {
 
 In most cases using a spread operator causes a full copy of the array to be created before calling a method.
 This has a very high performance penalty. Benchmarks showing this performance penalty can be seen here:
-https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+
+* [Exploring Kotlin Hidden Costs - Part 1](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62)
+
+* [Exploring Kotlin Hidden Costs - Part 2](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70)
+
+* [Exploring Kotlin Hidden Costs - Part 3](https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4)
 
 The Kotlin compiler since v1.1.60 has an optimization that skips the array copy when an array constructor
 function is used to create the arguments that are passed to the vararg parameter. When type resolution is enabled in

--- a/website/versioned_docs/version-1.23.7/rules/performance.md
+++ b/website/versioned_docs/version-1.23.7/rules/performance.md
@@ -75,8 +75,11 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
 See more details with this blog series:
+
 -https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62
+
 -https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70
+
 -https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 

--- a/website/versioned_docs/version-1.23.7/rules/performance.md
+++ b/website/versioned_docs/version-1.23.7/rules/performance.md
@@ -74,7 +74,10 @@ Using the forEach method on ranges has a heavy performance cost. Prefer using si
 
 Benchmarks have shown that using forEach on a range can have a huge performance cost in comparison to
 simple for loops. Hence, in most contexts, a simple for loop should be used instead.
-See more details here: https://sites.google.com/a/athaydes.com/renato-athaydes/posts/kotlinshiddencosts-benchmarks
+See more details with this blog series:
+-https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-1-fbb9935d9b62
+-https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-2-324a4a50b70
+-https://bladecoder.medium.com/exploring-kotlins-hidden-costs-part-3-3bf6e0dbf0a4
 To solve this CodeSmell, the forEach usage should be replaced by a for loop.
 
 **Active by default**: Yes - Since v1.0.0


### PR DESCRIPTION
Fixed Documentation issue stated on https://github.com/detekt/detekt/issues/7696 with broken link on performance tab and replaced it with blog series as stated on the issue comments

Fixes #7696