### PR TITLE
Fix `ThrowingExceptionsWithoutMessageOrCause` false positive

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -60,9 +60,7 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config) : Rule(
         super.visitCallExpression(expression)
         val calleeExpressionText = expression.calleeExpression?.text ?: return
 
-        if (exceptions.any { calleeExpressionText.equals(it, ignoreCase = true) } &&
-            expression.valueArguments.isEmpty()
-        ) {
+        if (exceptions.any { calleeExpressionText == it } && expression.valueArguments.isEmpty()) {
             report(CodeSmell(Entity.from(expression), description))
         }
     }

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCause.kt
@@ -57,12 +57,13 @@ class ThrowingExceptionsWithoutMessageOrCause(config: Config) : Rule(
     )
 
     override fun visitCallExpression(expression: KtCallExpression) {
-        val calleeExpressionText = expression.calleeExpression?.text
-        if (exceptions.any { calleeExpressionText?.equals(it, ignoreCase = true) == true } &&
+        super.visitCallExpression(expression)
+        val calleeExpressionText = expression.calleeExpression?.text ?: return
+
+        if (exceptions.any { calleeExpressionText.equals(it, ignoreCase = true) } &&
             expression.valueArguments.isEmpty()
         ) {
             report(CodeSmell(Entity.from(expression), description))
         }
-        super.visitCallExpression(expression)
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -44,4 +44,18 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
         """.trimIndent()
         assertThat(subject.compileAndLint(code)).isEmpty()
     }
+
+    @Test
+    fun `don't raise an issue when only matches ignoring cases`() {
+        val code = """
+            fun illegalArgumentException() {
+                // no-op
+            }
+
+            fun test() {
+                illegalArgumentException()
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
+    }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -7,10 +7,9 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class ThrowingExceptionsWithoutMessageOrCauseSpec {
-    val subject =
-        ThrowingExceptionsWithoutMessageOrCause(
-            TestConfig("exceptions" to listOf("IllegalArgumentException"))
-        )
+    val subject = ThrowingExceptionsWithoutMessageOrCause(
+        TestConfig("exceptions" to listOf("IllegalArgumentException"))
+    )
 
     @Nested
     inner class `several exception calls` {
@@ -36,17 +35,13 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
         }
     }
 
-    @Nested
-    inner class `a test code which asserts an exception` {
-
-        @Test
-        fun `does not report a call to this exception`() {
-            val code = """
-                fun test() {
-                    org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
-                }
-            """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
-        }
+    @Test
+    fun `a test code which asserts an exception does not report a call to this exception`() {
+        val code = """
+            fun test() {
+                org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
+            }
+        """.trimIndent()
+        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 }


### PR DESCRIPTION
Fixes #7448

I searched why we had the `ignoreCase = true` and it doesn't seem intentional. We were using `SplitPattern` on this rule before. And that function had the `ignoreCase = true` but I guess that was not intentional for this rule. I can't think of a good reason for it.

Another solution would be to move this rule to `@RequiresFullAnalysis` so we can be sure if we are calling the constructor or not. But I think that it's not needed right now.