### PR TITLE
Simplify entity

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -110,10 +110,9 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Detektion : org/
 
 public final class io/gitlab/arturbosch/detekt/api/Entity {
 	public static final field Companion Lio/gitlab/arturbosch/detekt/api/Entity$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;)V
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Location;Lorg/jetbrains/kotlin/psi/KtElement;)V
 	public final fun getKtElement ()Lorg/jetbrains/kotlin/psi/KtElement;
 	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Location;
-	public final fun getName ()Ljava/lang/String;
 	public final fun getSignature ()Ljava/lang/String;
 	public fun toString ()Ljava/lang/String;
 }

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -176,7 +176,6 @@ public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Issue$Entity {
 	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
-	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getSignature ()Ljava/lang/String;
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
 import io.gitlab.arturbosch.detekt.api.internal.buildFullSignature
-import io.gitlab.arturbosch.detekt.api.internal.searchName
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
@@ -12,13 +11,12 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
  * Stores information about a specific code fragment.
  */
 class Entity(
-    val name: String,
     val signature: String,
     val location: Location,
     val ktElement: KtElement
 ) {
     override fun toString(): String =
-        "Entity(name=$name, signature=$signature, location=$location, ktElement=$ktElement)"
+        "Entity(signature=$signature, location=$location, ktElement=$ktElement)"
 
     companion object {
         /**
@@ -55,10 +53,9 @@ class Entity(
             elementForSignature: PsiElement,
             location: Location
         ): Entity {
-            val name = elementToReport.searchName()
             val signature = elementForSignature.buildFullSignature()
             val ktElement = elementToReport.getNonStrictParentOfType<KtElement>() ?: error("KtElement expected")
-            return Entity(name, signature, location, ktElement)
+            return Entity(signature, location, ktElement)
         }
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -20,7 +20,6 @@ interface Issue {
         get() = entity.location
 
     interface Entity {
-        val name: String
         val signature: String
         val location: Location
     }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.api.internal
 
-import org.jetbrains.kotlin.asJava.namedUnwrappedElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtFile
@@ -12,8 +11,6 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffsetSkippingComments
 
 private val multipleWhitespaces = Regex("\\s{2,}")
-
-internal fun PsiElement.searchName(): String = this.namedUnwrappedElement?.name ?: "<UnknownName>"
 
 /*
  * KtCompiler wrongly used Path.filename as the name for a KtFile instead of the whole path.

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmellSpec.kt
@@ -13,7 +13,6 @@ class CodeSmellSpec {
     fun `toString contains all information`() {
         val codeSmell = CodeSmell(
             entity = Entity(
-                name = "TestEntity",
                 signature = "TestEntitySignature",
                 location = Location(
                     source = SourceLocation(1, 1),
@@ -28,7 +27,7 @@ class CodeSmellSpec {
         )
 
         assertThat(codeSmell.toString()).isEqualTo(
-            "CodeSmell(entity=Entity(name=TestEntity, signature=TestEntitySignature, " +
+            "CodeSmell(entity=Entity(signature=TestEntitySignature, " +
                 "location=Location(source=1:1, endSource=1:1, text=0:0, path=${codeSmell.location.path}), " +
                 "ktElement=FakeKtElement), message=TestMessage, references=[], suppressReasons=[Baseline])"
         )

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -43,7 +43,7 @@ class EntitySpec {
 
             assertThat(Entity.atName(memberFunction).toString())
                 .isEqualTo(
-                    "Entity(name=memberFun, signature=EntitySpecFixture.kt\$C\$private fun memberFun(): Int, " +
+                    "Entity(signature=EntitySpecFixture.kt\$C\$private fun memberFun(): Int, " +
                         "location=Location(source=5:17, endSource=5:26, text=49:58, " +
                         "path=$path), " +
                         "ktElement=FUN)"
@@ -65,7 +65,7 @@ class EntitySpec {
         fun `toString gives all details`() {
             assertThat(Entity.atName(clazz).toString())
                 .isEqualTo(
-                    "Entity(name=C, signature=EntitySpecFixture.kt\$C : Any, " +
+                    "Entity(signature=EntitySpecFixture.kt\$C : Any, " +
                         "location=Location(source=3:7, endSource=3:8, text=20:21, " +
                         "path=$path), " +
                         "ktElement=CLASS)"
@@ -88,7 +88,7 @@ class EntitySpec {
         fun `toString gives all details`() {
             assertThat(Entity.from(code).toString())
                 .isEqualTo(
-                    "Entity(name=EntitySpecFixture.kt, signature=EntitySpecFixture.kt\$test.EntitySpecFixture.kt, " +
+                    "Entity(signature=EntitySpecFixture.kt\$test.EntitySpecFixture.kt, " +
                         "location=Location(source=1:1, endSource=9:1, text=0:109, " +
                         "path=$path), " +
                         "ktElement=KtFile: EntitySpecFixture.kt)"

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -70,7 +70,6 @@ fun createEntity(
     signature: String = "TestEntitySignature",
     location: Issue.Location = createLocation(),
 ): Issue.Entity = IssueImpl.Entity(
-    name = "TestEntity",
     signature = signature,
     location = location,
 )
@@ -99,7 +98,6 @@ private data class IssueImpl(
     override val suppressReasons: List<String>
 ) : Issue {
     data class Entity(
-        override val name: String,
         override val signature: String,
         override val location: Issue.Location,
     ) : Issue.Entity

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -196,7 +196,7 @@ private fun Finding.toIssue(rule: RuleInstance, severity: Severity, basePath: Pa
     }
 
 private fun Entity.toIssue(basePath: Path): Issue.Entity =
-    IssueImpl.Entity(name, signature, location.toIssue(basePath))
+    IssueImpl.Entity(signature, location.toIssue(basePath))
 
 private fun Location.toIssue(basePath: Path): Issue.Location =
     IssueImpl.Location(source, endSource, text, basePath.relativize(path))
@@ -213,7 +213,6 @@ private data class IssueImpl(
     override val suppressReasons: List<String>,
 ) : Issue {
     data class Entity(
-        override val name: String,
         override val signature: String,
         override val location: Issue.Location,
     ) : Issue.Entity

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Builders.kt
@@ -18,7 +18,6 @@ internal fun buildFinding(element: KtElement?): Finding = CodeSmell(
 )
 
 private fun buildEmptyEntity(): Entity = Entity(
-    name = "",
     signature = "",
     location = Location(
         source = SourceLocation(1, 1),

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationName.kt
@@ -78,7 +78,7 @@ class MatchingDeclarationName(config: Config) : Rule(
                 val entity = Entity.atName(declaration)
                 report(
                     CodeSmell(
-                        Entity(entity.name, entity.signature, entity.location, file),
+                        Entity(entity.signature, entity.location, file),
                         "The file name '$filename' " +
                             "does not match the name of the single top-level declaration '$declarationName'."
                     )


### PR DESCRIPTION
We never use the `entity.name` property so we can remove it.