### PR TITLE
Report mishandling of CancellationException

### DIFF
--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -301,7 +301,6 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
             "kotlinx.coroutines.CancellationException", // typealias
             "kotlin.coroutines.cancellation.CancellationException", // native
             "java.util.concurrent.CancellationException", // JVM
-            "kotlin.coroutines.cancellation", // kotlin stdlib
         ).map(::FqName)
 
         // Based on code from Kotlin project:

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -7,21 +7,32 @@ import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
 import io.gitlab.arturbosch.detekt.api.Rule
 import org.jetbrains.kotlin.builtins.StandardNames.COROUTINES_PACKAGE_FQ_NAME
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtForExpression
+import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtOperationExpression
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtThrowExpression
+import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
+import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.util.getParameterForArgument
 import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 import org.jetbrains.kotlin.name.Name as KotlinName
 
@@ -33,10 +44,10 @@ import org.jetbrains.kotlin.name.Name as KotlinName
  * * caught and propagated to external systems
  * * caught and shown to the user
  *
- * they must always be rethrown in the same context.
+ * they must always be immediately rethrown in the same context.
  *
  * Using `runCatching` increases this risk of mis-handling cancellation. If you catch and don't rethrow all the
- * `CancellationException`, your coroutines are not cancelled even if you cancel their `CoroutineScope`.
+ * `CancellationException` immediately, your coroutines are not cancelled even if you cancel their `CoroutineScope`.
  *
  * This can very easily lead to:
  * * unexpected crashes
@@ -63,6 +74,23 @@ import org.jetbrains.kotlin.name.Name as KotlinName
  *         bar(1_000L)
  *     }
  * }
+ *
+ * suspend fun baz() {
+ *     try {
+ *         bar(1_000L)
+ *     } catch (e: IllegalStateException) {
+ *         // catches CancellationException implicitly, since IllegalStateException is a super-class. Should be explicit
+ *     }
+ * }
+ *
+ * suspend fun qux() {
+ *     try {
+ *         bar(1_000L)
+ *     } catch (e: CancellationException) {
+ *         doSomeWork() // potentially long-running bit of work before propagating the cancellation
+ *         throw e
+ *     }
+ * }
  * </noncompliant>
  *
  * <compliant>
@@ -75,6 +103,8 @@ import org.jetbrains.kotlin.name.Name as KotlinName
  * suspend fun foo() {
  *     try {
  *         bar(1_000L)
+ *     } catch (e: CancellationException) {
+ *         throw e // explicitly caught and immediately re-thrown
  *     } catch (e: IllegalStateException) {
  *         // handle error
  *     }
@@ -91,7 +121,8 @@ import org.jetbrains.kotlin.name.Name as KotlinName
 @RequiresFullAnalysis
 class SuspendFunSwallowedCancellation(config: Config) : Rule(
     config,
-    "`runCatching` does not propagate `CancellationException`, don't use it with `suspend` lambda blocks."
+    description = "`CancellationException` must be specially handled and re-thrown when working with exceptions in a" +
+        " suspending context. This includes `runCatching` as well as regular try-catch blocks."
 ) {
 
     override fun visitCallExpression(expression: KtCallExpression) {
@@ -107,6 +138,46 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
         expression.anyDescendantOfType<KtExpression>(::shouldTraverseInside) { descendant ->
             descendant.hasSuspendCalls()
         }.ifTrue { report(expression) }
+    }
+
+    @Suppress("ReturnCount")
+    override fun visitTryExpression(expression: KtTryExpression) {
+        super.visitTryExpression(expression)
+
+        val function = expression.getParentOfType<KtFunction>(strict = true)
+        val functionDescriptor = bindingContext[BindingContext.FUNCTION, function]
+        if (functionDescriptor?.isSuspend != true) {
+            // Don't care about the try-catch block unless it's in a suspending context
+            return
+        }
+
+        for (catchClause in expression.catchClauses) {
+            val parameter = catchClause.catchParameter ?: continue
+            val parameterFqName = bindingContext[BindingContext.VALUE_PARAMETER, parameter]
+                ?.type
+                ?.constructor
+                ?.declarationDescriptor
+                ?.fqNameOrNull()
+
+            if (parameterFqName !in CANCELLATION_EXCEPTION_FQ_NAMES) {
+                // Should handle CancellationException first - this is a potential problem
+                report(catchClause)
+                return
+            } else if (parameterFqName in CANCELLATION_EXCEPTION_FQ_NAMES) {
+                // This is a CancellationException - we should make sure that it gets explicitly
+                // re-thrown upwards immediately
+                if (!catchClause.exceptionWasRethrown(parameter)) {
+                    report(catchClause)
+                } else if (catchClause.doesAnythingElseBeforeRethrowing()) {
+                    // it does re-throw, but a potentially long-lasting piece of code is called first. This is still a
+                    // problem!
+                    report(catchClause)
+                }
+
+                // We've found what we're looking for, so no more work to do
+                return
+            }
+        }
     }
 
     @Suppress("ReturnCount")
@@ -162,6 +233,44 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
         }
     }
 
+    /**
+     * Checking for a [KtThrowExpression] which throws the same element as we received from the [KtCatchClause]. This
+     * returns false if another exception with the same shadowed name as [cancellationException] is thrown.
+     */
+    private fun KtCatchClause.exceptionWasRethrown(cancellationException: KtParameter): Boolean {
+        val thrownElements = catchBody
+            ?.getChildrenOfType<KtThrowExpression>()
+            .orEmpty()
+            .asSequence()
+            .map { expr -> expr.thrownExpression }
+            .filterIsInstance<KtNameReferenceExpression>()
+            .map { expr -> bindingContext[BindingContext.REFERENCE_TARGET, expr] }
+            .filterIsInstance<DeclarationDescriptorWithSource>()
+            .map { descriptor -> descriptor.source.getPsi() }
+            .toList()
+
+        // Returns false if thrownElements is empty, i.e. nothing was thrown
+        return thrownElements.firstOrNull() == cancellationException
+    }
+
+    private fun KtCatchClause.doesAnythingElseBeforeRethrowing(): Boolean {
+        /**
+         * We expect a minimum of two elements in this list:
+         *  1) reference to the caught exception parameter
+         *  2) throw expression where we throw it
+         *
+         * Anything before these means that some other work is being performed, which means the exception isn't being
+         * immediately passed up the chain (and is therefore an issue). Anything afterwards won't be reached anyway
+         * because we're throwing an exception, so it can be detected/handled by another rule.
+         */
+        val elements = catchBody?.collectDescendantsOfType<KtElement>().orEmpty()
+        if (elements.size < 2) {
+            return true
+        }
+
+        return elements[0] !is KtNameReferenceExpression || elements[1] !is KtThrowExpression
+    }
+
     private fun report(
         expression: KtCallExpression,
     ) {
@@ -175,8 +284,28 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
         )
     }
 
+    private fun report(catchClause: KtCatchClause) {
+        report(
+            CodeSmell(
+                entity = Entity.from(catchClause),
+                message = "You should always catch and re-throw CancellationExceptions in" +
+                    " a try block from a suspending function. The exception should be re-thrown" +
+                    "immediately after catching it - it's intended to completely kill any" +
+                    "running jobs in your coroutine.",
+            )
+        )
+    }
+
     companion object {
         private val RUN_CATCHING_FQ = FqName("kotlin.runCatching")
+
+        // Pulled from https://github.com/search?q=repo%3AKotlin%2Fkotlinx.coroutines+%22actual+typealias+CancellationException%22&type=code
+        private val CANCELLATION_EXCEPTION_FQ_NAMES = listOf(
+            "kotlinx.coroutines.CancellationException", // typealias
+            "kotlin.coroutines.cancellation.CancellationException", // native
+            "java.util.concurrent.CancellationException", // JVM
+            "kotlin.coroutines.cancellation", // kotlin stdlib
+        ).map(::FqName)
 
         // Based on code from Kotlin project:
         // https://github.com/JetBrains/kotlin/commit/87bbac9d43e15557a2ff0dc3254fd41a9d5639e1

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -261,12 +261,10 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
          * because we're throwing an exception, so it can be detected/handled by another rule.
          */
         val elements = catchBody?.collectDescendantsOfType<KtElement>().orEmpty()
-        if (elements.size < 2) {
-            return true
-        }
 
         // Don't need to check the contents of the KtNameReferenceExpression, that's done as part of
-        // exceptionWasRethrown()
+        // exceptionWasRethrown(). It also verifies that something was thrown, which means we'll have a minimum of
+        // two elements in the catch clause
         return elements[0] !is KtNameReferenceExpression || elements[1] !is KtThrowExpression
     }
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -152,13 +152,8 @@ class SuspendFunSwallowedCancellation(config: Config) : Rule(
         }
 
         // CancellationException should be the first case to catch - so we only want to check the first catch clause
-        val catchClause = expression.catchClauses.first()
-        val parameter = catchClause.catchParameter
-        if (parameter == null) {
-            // Not sure exactly what would cause this, but just in case?
-            report(catchClause)
-            return
-        }
+        val catchClause = expression.catchClauses.firstOrNull()
+        val parameter = catchClause?.catchParameter ?: return
 
         val parameterFqName = bindingContext[BindingContext.VALUE_PARAMETER, parameter]
             ?.type

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
@@ -45,7 +45,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
 
             fun foo() {
                 try {
-                    delay(1000L)
+                    Thread.sleep(1000L)
                 } catch (e: IllegalStateException) {
                     throw e
                 }
@@ -264,6 +264,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
     @Test
     fun `does report if CancellationException is caught but a different exception is re-thrown`() {
         val code = """
+            import kotlinx.coroutines.CancellationException
             import kotlinx.coroutines.delay
 
             class WrapperException(val e: CancellationException) : Exception()
@@ -278,8 +279,8 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
         """.trimIndent()
         assertOneFindingAt(
             code = code,
-            start = SourceLocation(line = 8, column = 7), // start of CancellationException block
-            end = SourceLocation(line = 10, column = 6), // end of CancellationException block
+            start = SourceLocation(line = 9, column = 7), // start of CancellationException block
+            end = SourceLocation(line = 11, column = 6), // end of CancellationException block
         )
     }
 


### PR DESCRIPTION
# Summary
This is a functional extension and slight reworking of the behaviour of the `SuspendFunSwallowedCancellation` rule [from this PR](https://github.com/detekt/detekt/pull/5666). That PR mentioned that this kind of thing could be done in future, but I haven't seen anyone else give it a go, so here it is!

In summary, the change is that you now need to explicitly catch CancellationException when using a try-catch block in a suspending context, then immediately re-throw it without doing anything else (logging, etc.) in that catch block.

I can't find a way of making the patch coverage any higher than it currently is, so that step won't give us a nice green tick unless someone else can suggest something. A few parameters are nullable although I don't think Kotlin supports missing them out, which means a few lines are yellow in the coverage report.

# Clarification
One area where I'm specifically interested in feedback is the case where we have a potentially long-running bit of code being called in a `finally` block after catching a cancellation. I'm not sure whether this should be counted as an issue or not, since other catch blocks might want to make use of a finally block E.g.:
```kotlin
suspend fun foo() {
    try {
        delay(1000L)
    } catch (e: CancellationException) {
        throw e
    } catch (e: SomeOtherException {
        // whatever
    } finally {
        // do some work to tidy up - won't finish the coroutine immediately
    }
}
```
Right now this isn't being checked for at all.

# Behavioural change
The behavioural change is that previously, the test case like below would pass because IllegalStateException is a superclass of CancellationException:
```kotlin
suspend fun foo() {
    try {
        check(1 + 2 == 3) { "Some actual illegal state checking" }
        delay(1000L)
    } catch (e: IllegalStateException) {
        // handle error - which one?
    }
}
```

whereas now (at least in my opinion), handling of CancellationException should be more explicit, like:

```kotlin
suspend fun foo() {
    try {
        check(1 + 2 == 3) { "Some actual illegal state checking" }
        delay(1000L)
    } catch (e: CancellationException) {
        throw e
    } catch (e: IllegalStateException) {
        // handle other actual error cases
    }
}
```

Happy to take feedback on this though, of course (and the rest too :smile:).