### PR TITLE
Update build-logic versions

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 object Versions {
 
-    const val DETEKT: String = "1.23.6"
+    const val DETEKT: String = "1.23.7"
     const val SNAPSHOT_NAME: String = "main"
     val JVM_TARGET: JvmTarget = JvmTarget.JVM_1_8
 

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -9,7 +9,6 @@ import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.test.TestDetektion
 import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.createEntity
@@ -27,7 +26,7 @@ class MdOutputReportSpec {
     private val detektion = createTestDetektionWithMultipleSmells()
     private val result = mdReport.render(detektion)
         .replace("""\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d UTC""".toRegex(), "2024-07-21 21:34:16 UTC")
-        .replace("""\[detekt version \d+\.\d+.\d+]""".toRegex(), "[detekt version 1.23.6]")
+        .replace("""\[detekt version \d+\.\d+.\d+]""".toRegex(), "[detekt version 9.9.9]")
 
     @Suppress("LongMethod")
     @Test
@@ -125,7 +124,7 @@ class MdOutputReportSpec {
                 
                 ```
                 
-                generated with [detekt version 1.23.6](https://detekt.dev/) on 2024-07-21 21:34:16 UTC
+                generated with [detekt version 9.9.9](https://detekt.dev/) on 2024-07-21 21:34:16 UTC
                 
             """.trimIndent()
         )
@@ -152,7 +151,7 @@ class MdOutputReportSpec {
 
     @Test
     fun `renders the 'generated with' text correctly`() {
-        val header = "generated with [detekt version ${whichDetekt()}](https://detekt.dev/) on "
+        val header = "generated with [detekt version 9.9.9](https://detekt.dev/) on "
 
         assertThat(result).contains(header)
     }


### PR DESCRIPTION
I think that this change should be done with the last release but seems that it was not pushed.