### PR TITLE
Fix versions on our versioned docs

### DIFF
--- a/website/versioned_docs/version-1.21.0/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.21.0/gettingstarted/cli.mdx
@@ -31,9 +31,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.21.0/detekt-cli-1.21.0.zip
+unzip detekt-cli-1.21.0.zip
+./detekt-cli-1.21.0/bin/detekt-cli --help
 ```
 
 ## Use the cli

--- a/website/versioned_docs/version-1.21.0/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.21.0/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.21.0"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.21.0")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.21.0"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of Detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.21.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of Detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.21.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.21.0/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.21.0/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.21.0'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.21.0")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.21.0/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.21.0/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.21.0</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.21.0/intro.mdx
+++ b/website/versioned_docs/version-1.21.0/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.21.0"
 }
 
 repositories {
@@ -48,7 +48,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.21.0"
     config = files("config/detekt/detekt.yml")
     buildUponDefaultConfig = true
 }
@@ -91,7 +91,7 @@ which can be easily added to the gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0"
 }
 ```
 

--- a/website/versioned_docs/version-1.21.0/introduction/extensions.md
+++ b/website/versioned_docs/version-1.21.0/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.21.0")
 }
 ```
 

--- a/website/versioned_docs/version-1.22.0/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.22.0-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.22.0/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.22.0/detekt-cli-1.22.0.zip
+unzip detekt-cli-1.22.0.zip
+./detekt-cli-1.22.0/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.22.0-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.22.0/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.22.0"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.22.0"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.22.0")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.22.0"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.22.0"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of Detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.22.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of Detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.22.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.22.0/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.22.0'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.22.0")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.22.0/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.22.0/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.22.0</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.22.0/intro.mdx
+++ b/website/versioned_docs/version-1.22.0/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.22.0"
 }
 
 repositories {
@@ -48,7 +48,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.22.0"
     config = files("config/detekt/detekt.yml")
     buildUponDefaultConfig = true
 }
@@ -91,7 +91,7 @@ which can be easily added to the gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]"
+    detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0"
 }
 ```
 

--- a/website/versioned_docs/version-1.22.0/introduction/extensions.md
+++ b/website/versioned_docs/version-1.22.0/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.22.0")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.0/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.0-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.0/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.0/detekt-cli-1.23.0.zip
+unzip detekt-cli-1.23.0.zip
+./detekt-cli-1.23.0/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.0-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.0/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.0"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.0")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.0/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.0"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.0"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.0")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.0"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.0"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.0"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.0/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.0'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.0")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.0/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.0/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.0</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.0/intro.mdx
+++ b/website/versioned_docs/version-1.23.0/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.0")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.0"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.0")
 }
 ```

--- a/website/versioned_docs/version-1.23.0/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.0/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.0")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.1/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.1-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.1/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.1/detekt-cli-1.23.1.zip
+unzip detekt-cli-1.23.1.zip
+./detekt-cli-1.23.1/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.1-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.1/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.1"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.1/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.1"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.1"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.1"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.1")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.1"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.1"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.1"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.1"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.1/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.1'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.1")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.1/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.1/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.1</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.1/intro.mdx
+++ b/website/versioned_docs/version-1.23.1/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.1")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.1"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
 }
 ```

--- a/website/versioned_docs/version-1.23.1/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.1/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.1")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.3/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.3-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.3/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.3/detekt-cli-1.23.3.zip
+unzip detekt-cli-1.23.3.zip
+./detekt-cli-1.23.3/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.3-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.3/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.3"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.3")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.3/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.3"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.3"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.3")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.3"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.3"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.3"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.3"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.3/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.3'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.3")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.3/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.3/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.3</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.3/intro.mdx
+++ b/website/versioned_docs/version-1.23.3/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.3")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.3"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.3")
 }
 ```

--- a/website/versioned_docs/version-1.23.3/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.3/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.3")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.4/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.4-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.4/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.4/detekt-cli-1.23.4.zip
+unzip detekt-cli-1.23.4.zip
+./detekt-cli-1.23.4/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.4-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.4/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.4"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.4")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.4/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.4"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.4"
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.4"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.4")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.4"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.4"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.4"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.4"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.4/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.4'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.4")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.4/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.4/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.4</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.4/intro.mdx
+++ b/website/versioned_docs/version-1.23.4/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.4")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.4"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.4")
 }
 ```

--- a/website/versioned_docs/version-1.23.4/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.4/introduction/extensions.md
@@ -232,7 +232,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.4")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.5/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.5-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.5/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.5/detekt-cli-1.23.5.zip
+unzip detekt-cli-1.23.5.zip
+./detekt-cli-1.23.5/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.5-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.5/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.5"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.5")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.5/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.5"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt").version("1.23.5")
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.5"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.5")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.5"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.5"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.5"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.5"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.5/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.5'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.5")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.5/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.5/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.5</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.5/intro.mdx
+++ b/website/versioned_docs/version-1.23.5/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.5")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.5"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.5")
 }
 ```

--- a/website/versioned_docs/version-1.23.5/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.5/introduction/extensions.md
@@ -230,7 +230,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.5")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.6/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.6-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.6/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.6/detekt-cli-1.23.6.zip
+unzip detekt-cli-1.23.6.zip
+./detekt-cli-1.23.6/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.6-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.6/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/compilerplugin.mdx
@@ -22,7 +22,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.6"
 }
 ```
 
@@ -81,7 +81,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.6/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.6"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt").version("1.23.6")
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.6")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.6"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.6"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.6"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.6"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.6/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.6'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.6")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.6/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.6/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.6</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.6/intro.mdx
+++ b/website/versioned_docs/version-1.23.6/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.6")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.6"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
 }
 ```

--- a/website/versioned_docs/version-1.23.6/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.6/introduction/extensions.md
@@ -230,7 +230,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.6")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.7/gettingstarted/_cli-generator-options.md
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/_cli-generator-options.md
@@ -1,5 +1,5 @@
 ```
-Usage: java -jar detekt-generator-[detekt_version]-all.jar [options]
+Usage: java -jar detekt-generator-1.23.7-all.jar [options]
   Options:
     --generate-custom-rule-config, -gcrc
       Generate custom rules configuration files. The files will be

--- a/website/versioned_docs/version-1.23.7/gettingstarted/cli.mdx
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/cli.mdx
@@ -32,9 +32,9 @@ detekt [options]
 ### Any OS:
 
 ```sh
-curl -sSLO https://github.com/detekt/detekt/releases/download/v[detekt_version]/detekt-cli-[detekt_version].zip
-unzip detekt-cli-[detekt_version].zip
-./detekt-cli-[detekt_version]/bin/detekt-cli --help
+curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.7/detekt-cli-1.23.7.zip
+unzip detekt-cli-1.23.7.zip
+./detekt-cli-1.23.7/bin/detekt-cli --help
 ```
 
 ### NixOS
@@ -65,5 +65,5 @@ The following parameters are shown when `--help` is entered.
 <CliGeneratorOptions />
 
 ```sh
-java -jar detekt-generator-[detekt_version]-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
+java -jar detekt-generator-1.23.7-all.jar -gcrc -i /path/to/rule1, /path/to/rule2
 ```

--- a/website/versioned_docs/version-1.23.7/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/compilerplugin.mdx
@@ -24,7 +24,7 @@ To use the detekt Compiler Plugin, you will have to add the following Gradle Plu
 
 ```kotlin
 plugins {
-  id("io.github.detekt.gradle.compiler-plugin") version "[detekt_version]"
+  id("io.github.detekt.gradle.compiler-plugin") version "1.23.7"
 }
 ```
 
@@ -83,7 +83,7 @@ As for the Detekt Gradle Plugin, you can add third party plugins to the Compiler
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
 }
 ```
 

--- a/website/versioned_docs/version-1.23.7/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/gradle.mdx
@@ -64,7 +64,7 @@ Using the plugins DSL:
 
 ```groovy
 plugins {
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.7"
 }
 
 repositories {
@@ -76,7 +76,7 @@ repositories {
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt").version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt").version("1.23.7")
 }
 
 repositories {
@@ -94,7 +94,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]"
+        classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7"
     }
 }
 
@@ -113,7 +113,7 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:[detekt_version]")
+        classpath("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.23.7")
     }
 }
 
@@ -147,7 +147,7 @@ buildscript {
 plugins {
     id "com.android.application"
     id "org.jetbrains.kotlin.android" version "<kotlin_version>"
-    id "io.gitlab.arturbosch.detekt" version "[detekt_version]"
+    id "io.gitlab.arturbosch.detekt" version "1.23.7"
 }
 
 repositories {
@@ -172,7 +172,7 @@ buildscript {
 plugins {
     id("com.android.application")
     kotlin("android") version "<kotlin_version>"
-    id("io.gitlab.arturbosch.detekt") version "[detekt_version]"
+    id("io.gitlab.arturbosch.detekt") version "1.23.7"
 }
 
 repositories {
@@ -188,7 +188,7 @@ repositories {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.7"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.
@@ -246,7 +246,7 @@ detekt {
 detekt {
     // Version of detekt that will be used. When unspecified the latest detekt
     // version found will be used. Override to stay on the same version.
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.7"
     
     // The directories where detekt looks for source files. 
     // Defaults to `files("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")`.

--- a/website/versioned_docs/version-1.23.7/gettingstarted/gradletask.md
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/gradletask.md
@@ -34,7 +34,7 @@ def detektTask = tasks.register("detekt", JavaExec) {
 }
 
 dependencies {
-	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]'
+	detekt 'io.gitlab.arturbosch.detekt:detekt-cli:1.23.7'
 }
 
 // Remove this line if you don't want to run detekt on every build
@@ -62,7 +62,7 @@ val detektTask = tasks.register<JavaExec>("detekt") {
 }
 
 dependencies {
-    detekt("io.gitlab.arturbosch.detekt:detekt-cli:[detekt_version]")
+    detekt("io.gitlab.arturbosch.detekt:detekt-cli:1.23.7")
 }
 
 // Remove this block if you don't want to run detekt on every build

--- a/website/versioned_docs/version-1.23.7/gettingstarted/mavenanttask.md
+++ b/website/versioned_docs/version-1.23.7/gettingstarted/mavenanttask.md
@@ -48,7 +48,7 @@ sidebar_position: 4
                 <dependency>
                     <groupId>io.gitlab.arturbosch.detekt</groupId>
                     <artifactId>detekt-cli</artifactId>
-                    <version>[detekt_version]</version>
+                    <version>1.23.7</version>
                 </dependency>
             </dependencies>
         </plugin>

--- a/website/versioned_docs/version-1.23.7/intro.mdx
+++ b/website/versioned_docs/version-1.23.7/intro.mdx
@@ -26,7 +26,7 @@ Apply the following configuration to your Gradle project build file:
 
 ```kotlin
 plugins {
-    id("io.gitlab.arturbosch.detekt") version("[detekt_version]")
+    id("io.gitlab.arturbosch.detekt") version("1.23.7")
 }
 
 repositories {
@@ -47,7 +47,7 @@ slim down the configuration file to only the changes from the default configurat
 
 ```kotlin
 detekt {
-    toolVersion = "[detekt_version]"
+    toolVersion = "1.23.7"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
 }
@@ -90,6 +90,6 @@ which can be easily added to the Gradle configuration:
 
 ```gradle
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
 }
 ```

--- a/website/versioned_docs/version-1.23.7/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.7/introduction/extensions.md
@@ -230,7 +230,7 @@ To enable it, we add the published dependency to `detekt` via the `detektPlugins
 
 ```kotlin
 dependencies {
-    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:[detekt_version]")
+    detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.7")
 }
 ```
 


### PR DESCRIPTION
Related with #7720

Now that we have versioned docs the `detektVersionReplace.js` script doesn't work correctly because it always points to the last version when it shouldn't.

We should change the way that we generated the versioned docs to avoid this issue but this PR should fix all our docs for now. I'm going to open an issue about this.