### PR TITLE
Enable Isolated Projects for Gradle tests by default

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -38,7 +38,7 @@ class DetektMultiplatformSpec {
                     srcDirs = listOf("src/commonMain/kotlin", "src/commonTest/kotlin"),
                     baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-metadataMain.xml")
                 )
-            }
+            }.apply { disableIP = true }
 
         @Test
         fun `configures baseline task`() {
@@ -122,7 +122,7 @@ class DetektMultiplatformSpec {
                     ),
                     baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml")
                 )
-            }
+            }.apply { disableIP = true }
 
         @Test
         fun `configures baseline task`() {
@@ -203,7 +203,7 @@ class DetektMultiplatformSpec {
                         "detekt-baseline-release.xml"
                     )
                 )
-            }
+            }.apply { disableIP = true }
 
         @Test
         fun `configures baseline task`() {
@@ -260,7 +260,7 @@ class DetektMultiplatformSpec {
                     ),
                     baselineFiles = listOf("detekt-baseline.xml")
                 )
-            }
+            }.apply { disableIP = true }
 
         @Test
         fun `configures baseline task`() {
@@ -316,7 +316,7 @@ class DetektMultiplatformSpec {
                     ),
                     baselineFiles = listOf("detekt-baseline.xml")
                 )
-            }
+            }.apply { disableIP = true }
 
         @Test
         fun `configures baseline task`() {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektReportMergeSpec.kt
@@ -52,6 +52,7 @@ class DetektReportMergeSpec {
             builder.gradleBuildName,
             buildFileContent,
             settingsFile,
+            disableIP = true,
         )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
@@ -122,6 +123,7 @@ class DetektReportMergeSpec {
             builder.gradleBuildName,
             buildFileContent,
             settingsFile,
+            disableIP = true,
         )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "xmlReportMerge", "--continue") { result ->

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskMultiModuleSpec.kt
@@ -42,6 +42,7 @@ class DetektTaskMultiModuleSpec {
             builder.gradleBuildName,
             mainBuildFileContent,
             settingsFile,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()
@@ -92,6 +93,7 @@ class DetektTaskMultiModuleSpec {
             builder.gradleBuildName,
             mainBuildFileContent,
             settingsFile,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()
@@ -142,6 +144,7 @@ class DetektTaskMultiModuleSpec {
             builder.gradleBuildName,
             mainBuildFileContent,
             settingsFile,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()
@@ -199,6 +202,7 @@ class DetektTaskMultiModuleSpec {
             builder.gradleBuildName,
             mainBuildFileContent,
             settingsFile,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -68,6 +68,7 @@ class ReportMergeSpec {
             buildFileName = builder.gradleBuildName,
             mainBuildFileContent = mainBuildFileContent,
             settingsContent = settingsFile,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()
@@ -183,7 +184,8 @@ class ReportMergeSpec {
             buildFileName = builder.gradleBuildName,
             mainBuildFileContent = mainBuildFileContent,
             settingsContent = settingsFile,
-            jvmArgs = jvmArgs
+            jvmArgs = jvmArgs,
+            disableIP = true,
         )
 
         gradleRunner.setupProject()

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -22,6 +22,7 @@ constructor(
     val baselineFiles: List<String> = emptyList(),
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
+    var disableIP: Boolean = false,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
     val gradleProperties: Map<String, String> = emptyMap(),
     val customPluginClasspath: List<File> = emptyList(),
@@ -138,6 +139,9 @@ constructor(
             add("-Dorg.gradle.jvmargs=$jvmArgs")
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
+            }
+            if (!disableIP) {
+                add("-Dorg.gradle.unsafe.isolated-projects=true")
             }
             addAll(gradleProperties.toList().map { (key, value) -> "-P$key=$value" })
             addAll(tasks)


### PR DESCRIPTION
IP must be disabled on multiple tests at the moment.

For the tests where IP is disabled:
* Kotlin 2.1.0 fixes a couple of multiplatform issues
* We need to rework how report merging works in our plugin
* The tests in DetektTaskMultiModuleSpec will never be compatible with IP. When everything else eventually becomes IP compatible I think we should remove these tests - there should be no need to specifically test that poor practice in build files still works.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
