### PR TITLE
Fix error in paths filtering for detekt-cli

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Spec.kt
@@ -26,14 +26,14 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         project {
             basePath = args.basePath.absolute()
             val pathFilters = PathFilters.of(
-                args.excludes?.let(::asPatterns).orEmpty(),
-                args.includes?.let(::asPatterns).orEmpty(),
+                includes = args.includes?.let(::asPatterns).orEmpty(),
+                excludes = args.excludes?.let(::asPatterns).orEmpty(),
             )
             val absoluteBasePath = basePath.absolute()
             inputPaths = args.inputPaths.walk()
                 .filter { path -> path.isKotlinFile() }
                 .map { path -> path.absolute().relativeTo(absoluteBasePath) }
-                .filter { path -> pathFilters?.isIgnored(path) != false }
+                .filter { path -> pathFilters?.isIgnored(path) != true }
                 .map { path -> absoluteBasePath.resolve(path).normalize() }
                 .toSet()
             analysisMode = args.analysisMode

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgsSpec.kt
@@ -122,10 +122,7 @@ internal class CliArgsSpec {
                 val spec = parseArguments(input + arrayOf("--excludes", "**/test/**", "--includes", "**/test/**"))
                     .toSpec()
 
-                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
-                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
-                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
-                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+                assertThat(spec.projectSpec.inputPaths).isEmpty()
             }
 
             @Test
@@ -139,8 +136,64 @@ internal class CliArgsSpec {
             }
 
             @Test
+            fun `includes and excludes with overlapping patterns - include specific files`() {
+                val spec = parseArguments(input + arrayOf("--includes", "**/*.kt", "--excludes", "**/test/**")).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathAnalyzer)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgsSpec)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathBuildGradle)
+            }
+
+            @Test
+            fun `includes and excludes with overlapping patterns - path matches both`() {
+                val spec = parseArguments(
+                    input + arrayOf(
+                        "--includes",
+                        "**/*.kt",
+                        "--excludes",
+                        "**/main/**"
+                    )
+                ).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @Test
+            fun `path does not match includes but matches excludes`() {
+                val spec = parseArguments(
+                    input + arrayOf(
+                        "--includes",
+                        "**/not_matching/**",
+                        "--excludes",
+                        "**/test/**"
+                    )
+                ).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).isEmpty()
+            }
+
+            @Test
+            fun `path does not match includes or excludes`() {
+                val spec = parseArguments(
+                    input + arrayOf(
+                        "--includes",
+                        "**/not_matching/**",
+                        "--excludes",
+                        "**/also_not_matching/**"
+                    )
+                ).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).isEmpty()
+            }
+
+            @Test
             fun `doesn't take into account absolute path`() {
-                val spec = parseArguments(input + arrayOf("--excludes", "/home/**,/Users/**")).toSpec()
+                val spec =
+                    parseArguments(input + arrayOf("--excludes", "/home/**,/Users/**")).toSpec()
 
                 assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
                 assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
@@ -153,10 +206,7 @@ internal class CliArgsSpec {
                 val spec = parseArguments(input + arrayOf("--excludes", "**/main/**", "--includes", "**/CliArgs.kt"))
                     .toSpec()
 
-                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
-                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
-                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
-                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+                assertThat(spec.projectSpec.inputPaths).isEmpty()
             }
 
             @Test

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
@@ -33,7 +33,7 @@ class PathFilters internal constructor(
             if (includes.isEmpty() && excludes.isEmpty()) {
                 return null
             }
-            return PathFilters(parse(includes), parse(excludes))
+            return PathFilters(includes = parse(includes), excludes = parse(excludes))
         }
 
         private fun parse(value: List<String>): Set<PathMatcher>? =


### PR DESCRIPTION
Fixed errors in path filtering for gitlab-cli.

Changes made according to comments in [PathFilters.kt](https://github.com/detekt/detekt/blob/main/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt)
```
    /**
     * - If [includes] and [excludes] are not specified,
     *   return false.
     * - If [includes] is specified but [excludes] is not,
     *   return false iff [path] matches any [includes].
     * - If [includes] is not specified but [excludes] is,
     *   return true iff [path] matches any [excludes].
     * - If [includes] and [excludes] are both specified,
     *   return false iff [path] matches any [includes] and [path] does not match any [excludes].
     */
    fun isIgnored(path: Path): Boolean
```
