### PR TITLE
Stop Renovate from grouping Poko & Kotlin updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,14 +5,5 @@
   "extends": [
     "config:base",
     "helpers:pinGitHubActionDigests"
-  ],
-  "packageRules" : [
-    {
-      "groupName": "Kotlin",
-      "matchPackageNames": [
-        "org.jetbrains.kotlin:**",
-        "dev.drewhamilton.poko**"
-      ]
-    }
   ]
 }


### PR DESCRIPTION
Reverts the behavior change from #7574

See https://github.com/detekt/detekt/pull/7736#issuecomment-2424571250
