### PR TITLE
Change `Entity.signature`

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/Signatures.kt
@@ -12,16 +12,6 @@ import org.jetbrains.kotlin.psi.psiUtil.startOffsetSkippingComments
 
 private val multipleWhitespaces = Regex("\\s{2,}")
 
-/*
- * KtCompiler wrongly used Path.filename as the name for a KtFile instead of the whole path.
- * This resulted into the question "How do we get the absolute path from a KtFile?".
- * Fixing this problem, we do not need KtFile.absolutePath anymore.
- *
- * Fixing the filename will change all baseline signatures.
- * Therefore we patch the signature here to restore the old behavior.
- *
- * Fixing the baseline will need a new major release - #2680.
- */
 internal fun PsiElement.buildFullSignature(): String {
     var fullSignature = this.searchSignature()
     val parentSignatures = this.parents
@@ -33,11 +23,6 @@ internal fun PsiElement.buildFullSignature(): String {
 
     if (parentSignatures.isNotEmpty()) {
         fullSignature = "$parentSignatures\$$fullSignature"
-    }
-
-    val filename = this.containingFile.name
-    if (!fullSignature.startsWith(filename)) {
-        fullSignature = "$filename\$$fullSignature"
     }
 
     return fullSignature

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/EntitySpec.kt
@@ -26,7 +26,7 @@ class EntitySpec {
             val memberFunction = functions.first { it.name == "memberFun" }
 
             assertThat(Entity.atName(memberFunction).signature)
-                .isEqualTo("EntitySpecFixture.kt\$C\$private fun memberFun(): Int")
+                .isEqualTo("C\$private fun memberFun(): Int")
         }
 
         @Test
@@ -34,7 +34,7 @@ class EntitySpec {
             val topLevelFunction = functions.first { it.name == "topLevelFun" }
 
             assertThat(Entity.atName(topLevelFunction).signature)
-                .isEqualTo("EntitySpecFixture.kt\$fun topLevelFun(number: Int)")
+                .isEqualTo("fun topLevelFun(number: Int)")
         }
 
         @Test
@@ -43,7 +43,7 @@ class EntitySpec {
 
             assertThat(Entity.atName(memberFunction).toString())
                 .isEqualTo(
-                    "Entity(signature=EntitySpecFixture.kt\$C\$private fun memberFun(): Int, " +
+                    "Entity(signature=C\$private fun memberFun(): Int, " +
                         "location=Location(source=5:17, endSource=5:26, text=49:58, " +
                         "path=$path), " +
                         "ktElement=FUN)"
@@ -58,14 +58,14 @@ class EntitySpec {
 
         @Test
         fun `includes full class signature`() {
-            assertThat(Entity.atName(clazz).signature).isEqualTo("EntitySpecFixture.kt\$C : Any")
+            assertThat(Entity.atName(clazz).signature).isEqualTo("C : Any")
         }
 
         @Test
         fun `toString gives all details`() {
             assertThat(Entity.atName(clazz).toString())
                 .isEqualTo(
-                    "Entity(signature=EntitySpecFixture.kt\$C : Any, " +
+                    "Entity(signature=C : Any, " +
                         "location=Location(source=3:7, endSource=3:8, text=20:21, " +
                         "path=$path), " +
                         "ktElement=CLASS)"
@@ -78,7 +78,7 @@ class EntitySpec {
 
         @Test
         fun `includes package and file name in entity signature`() {
-            val expectedResult = "EntitySpecFixture.kt\$test.EntitySpecFixture.kt"
+            val expectedResult = "test.EntitySpecFixture.kt"
 
             assertThat(Entity.from(code).signature).isEqualTo(expectedResult)
             assertThat(Entity.atPackageOrFirstDecl(code).signature).isEqualTo(expectedResult)
@@ -88,7 +88,7 @@ class EntitySpec {
         fun `toString gives all details`() {
             assertThat(Entity.from(code).toString())
                 .isEqualTo(
-                    "Entity(signature=EntitySpecFixture.kt\$test.EntitySpecFixture.kt, " +
+                    "Entity(signature=test.EntitySpecFixture.kt, " +
                         "location=Location(source=1:1, endSource=9:1, text=0:109, " +
                         "path=$path), " +
                         "ktElement=KtFile: EntitySpecFixture.kt)"

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
@@ -18,6 +18,15 @@ class SignaturesSpec {
     }
 
     @Test
+    fun `function and parent`() {
+        val result = compileContentForTest("class A { fun data(): Int = 0 }")
+            .findDescendantOfType<KtNamedFunction>()!!
+            .buildFullSignature()
+
+        assertThat(result).isEqualTo("Test.kt\$A\$fun data(): Int")
+    }
+
+    @Test
     fun `function without type reference`() {
         val result = compileContentForTest("fun data() = 0")
             .findDescendantOfType<KtNamedFunction>()!!

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
@@ -4,13 +4,14 @@ import io.github.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.psiUtil.findDescendantOfType
 import org.junit.jupiter.api.Test
 
 class SignaturesSpec {
     @Test
     fun `function with type reference`() {
         val result = compileContentForTest("fun data(): Int = 0")
-            .findChildByClass(KtNamedFunction::class.java)!!
+            .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
         assertThat(result).isEqualTo("Test.kt\$fun data(): Int")
@@ -19,7 +20,7 @@ class SignaturesSpec {
     @Test
     fun `function without type reference`() {
         val result = compileContentForTest("fun data() = 0")
-            .findChildByClass(KtNamedFunction::class.java)!!
+            .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
         assertThat(result).isEqualTo("Test.kt\$fun data()")
@@ -28,7 +29,7 @@ class SignaturesSpec {
     @Test
     fun `function with comments`() {
         val result = compileContentForTest("/* comments */ fun data() = 0")
-            .findChildByClass(KtNamedFunction::class.java)!!
+            .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
         assertThat(result).isEqualTo("Test.kt\$fun data()")
@@ -38,7 +39,7 @@ class SignaturesSpec {
     fun `function throws exception`() {
         assertThatThrownBy {
             compileContentForTest("{ fun data() = 0 }")
-                .findChildByClass(KtNamedFunction::class.java)!!
+                .findDescendantOfType<KtNamedFunction>()!!
                 .buildFullSignature()
         }
             .isInstanceOf(IllegalArgumentException::class.java)

--- a/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
+++ b/detekt-api/src/test/kotlin/io/gitlab/arturbosch/detekt/api/internal/SignaturesSpec.kt
@@ -14,7 +14,7 @@ class SignaturesSpec {
             .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
-        assertThat(result).isEqualTo("Test.kt\$fun data(): Int")
+        assertThat(result).isEqualTo("fun data(): Int")
     }
 
     @Test
@@ -23,7 +23,7 @@ class SignaturesSpec {
             .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
-        assertThat(result).isEqualTo("Test.kt\$A\$fun data(): Int")
+        assertThat(result).isEqualTo("A\$fun data(): Int")
     }
 
     @Test
@@ -32,7 +32,7 @@ class SignaturesSpec {
             .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
-        assertThat(result).isEqualTo("Test.kt\$fun data()")
+        assertThat(result).isEqualTo("fun data()")
     }
 
     @Test
@@ -41,7 +41,7 @@ class SignaturesSpec {
             .findDescendantOfType<KtNamedFunction>()!!
             .buildFullSignature()
 
-        assertThat(result).isEqualTo("Test.kt\$fun data()")
+        assertThat(result).isEqualTo("fun data()")
     }
 
     @Test

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaseline.kt
@@ -7,6 +7,7 @@ import io.gitlab.arturbosch.detekt.api.Issue
 import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
 
 internal data class DefaultBaseline(
     override val manuallySuppressedIssues: FindingsIdList,
@@ -35,4 +36,4 @@ internal const val CURRENT_ISSUES = "CurrentIssues"
 internal const val ID = "ID"
 
 internal val Issue.baselineId: String
-    get() = "${ruleInstance.id}:${this.entity.signature}"
+    get() = "${ruleInstance.id}:${this.location.path.name}:${this.entity.signature}"

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -174,8 +174,8 @@ class BaselineResultMappingSpec {
                 <?xml version="1.0" ?>
                 <SmellBaseline>
                   <ManuallySuppressedIssues>
-                    <ID>LongParameterList:Signature</ID>
-                    <ID>LongMethod:Signature</ID>
+                    <ID>LongParameterList:TestFile.kt:Signature</ID>
+                    <ID>LongMethod:TestFile.kt:Signature</ID>
                   </ManuallySuppressedIssues>
                   <CurrentIssues/>
                 </SmellBaseline>
@@ -198,11 +198,11 @@ class BaselineResultMappingSpec {
                 <?xml version="1.0" ?>
                 <SmellBaseline>
                   <ManuallySuppressedIssues>
-                    <ID>LongParameterList:Signature</ID>
-                    <ID>LongMethod:Signature</ID>
+                    <ID>LongParameterList:TestFile.kt:Signature</ID>
+                    <ID>LongMethod:TestFile.kt:Signature</ID>
                   </ManuallySuppressedIssues>
                   <CurrentIssues>
-                    <ID>TestSmell/id:TestEntitySignature</ID>
+                    <ID>TestSmell/id:TestFile.kt:TestEntitySignature</ID>
                   </CurrentIssues>
                 </SmellBaseline>
             """.trimIndent()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -65,7 +65,7 @@ class BaselineResultMappingSpec {
         mapping.transformIssues(issues)
 
         val changed = DefaultBaseline.load(existingBaselineFile)
-        assertThat(existing).isEqualTo(changed)
+        assertThat(changed).isEqualTo(existing)
     }
 
     @Test
@@ -79,7 +79,7 @@ class BaselineResultMappingSpec {
         mapping.transformIssues(issues)
 
         val changed = DefaultBaseline.load(existingBaselineFile)
-        assertThat(existing).isEqualTo(changed)
+        assertThat(changed).isEqualTo(existing)
     }
 
     @Test
@@ -118,7 +118,7 @@ class BaselineResultMappingSpec {
         mapping.transformIssues(issues)
 
         val changed = DefaultBaseline.load(baselineFile)
-        assertThat(existing).isNotEqualTo(changed)
+        assertThat(changed).isNotEqualTo(existing)
     }
 
     @Test
@@ -132,7 +132,7 @@ class BaselineResultMappingSpec {
 
         val filtered = mapping.filterByBaseline(baselineFile, issues)
 
-        assertThat(issues).isNotEqualTo(filtered)
+        assertThat(filtered).isNotEqualTo(issues)
     }
 
     @Test
@@ -144,7 +144,7 @@ class BaselineResultMappingSpec {
 
         val filtered = mapping.filterByBaseline(baselineFile, issues)
 
-        assertThat(issues).isEqualTo(filtered)
+        assertThat(filtered).isEqualTo(issues)
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
@@ -7,6 +7,6 @@ import org.junit.jupiter.api.Test
 class DefaultBaselineKtTest {
     @Test
     fun `baselineId Extension`() {
-        assertThat(createIssue().baselineId).isEqualTo("TestSmell/id:TestEntitySignature")
+        assertThat(createIssue().baselineId).isEqualTo("TestSmell/id:TestFile.kt:TestEntitySignature")
     }
 }

--- a/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
+++ b/detekt-core/src/test/resources/baseline_feature/valid-baseline.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <SmellBaseline>
     <ManuallySuppressedIssues>
-        <ID>LongParameterList:Signature</ID>
-        <ID>LongMethod:Signature</ID>
+        <ID>LongParameterList:TestFile.kt:Signature</ID>
+        <ID>LongMethod:TestFile.kt:Signature</ID>
     </ManuallySuppressedIssues>
     <CurrentIssues>
-        <ID>FeatureEnvy/id:Signature</ID>
+        <ID>FeatureEnvy/id:TestFile.kt:Signature</ID>
     </CurrentIssues>
 </SmellBaseline>

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -52,7 +52,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().entity.signature).isEqualTo("Test.kt\$=")
+            assertThat(findings.first().entity.signature).isEqualTo("=")
         }
 
         @Test
@@ -65,7 +65,7 @@ class FormattingRuleSpec {
                 """.trimIndent()
             )
 
-            assertThat(findings.first().entity.signature).isEqualTo("Test.kt\$=")
+            assertThat(findings.first().entity.signature).isEqualTo("=")
         }
     }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -39,7 +39,7 @@ class MaximumLineLengthSpec {
                 "Test.kt"
             ).first()
 
-            assertThat(finding.entity.signature).isEqualTo("Test.kt\$}")
+            assertThat(finding.entity.signature).isEqualTo("}")
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -184,7 +184,7 @@ class UnusedParameterSpec {
             val lint = subject.compileAndLint(code)
 
             assertThat(lint).hasSize(1)
-            assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$unusedWithoutAnnotation: String")
+            assertThat(lint[0].message).isEqualTo("Function parameter `unusedWithoutAnnotation` is unused.")
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -316,7 +316,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.signature).isEqualTo("Test.kt\$private fun foo(): String")
+            assertThat(findings[0].message).isEqualTo("Private function `foo` is unused.")
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -486,7 +486,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
-            assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$Test\$private val bar: String")
+            assertThat(lint[0].message).isEqualTo("Private property `bar` is unused.")
         }
 
         @Test
@@ -542,7 +542,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val lint = subject.compileAndLintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
-            assertThat(lint[0].entity.signature).isEqualTo("Test.kt\$Test\$private val bar: String = \"bar\"")
+            assertThat(lint[0].message).isEqualTo("Private property `bar` is unused.")
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -229,7 +229,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.signature).isEqualTo("Test.kt\$var a = 1")
+            assertThat(findings[0].message).isEqualTo("Variable 'a' could be val.")
         }
 
         @Test
@@ -243,7 +243,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
             val findings = subject.compileAndLintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
-            assertThat(findings[0].entity.signature).isEqualTo("Test.kt\$var a = 1")
+            assertThat(findings[0].message).isEqualTo("Variable 'a' could be val.")
         }
 
         @Test


### PR DESCRIPTION
Fixes #7661 and makes #7683 a bit easier to implement.

The `Entity.signature` doesn't contains the `path`. That code was moved to the baseline.

Why? To follow this from the SARIF Spec:

> An analysis tool SHOULD NOT include in partialFingerprints information that a result management system could deduce from other information in the SARIF file, for example, file hashes. Rather, the result management would use such information, along with partialFingerprints, in its computation of fingerprints.

We want to use `Entity.signature` for more things, for example to inform the `partiralFingerprints` on SARIF and not just the Baseline.

---

This PR breaks all the `baseline`s generate on `1.x`. But it should be an easy fix: recreate the baseline after update from 1.x to 2.x.