### PR TITLE
[UnnecessaryParentheses] Allow float/double without integer part

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Configuration
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
+import org.jetbrains.kotlin.KtNodeTypes
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -69,6 +70,8 @@ class UnnecessaryParentheses(config: Config) : Rule(
         if (allowForUnclearPrecedence && inner.isBinaryOperationPrecedenceUnclearWithParent()) return
 
         if (allowForUnclearPrecedence && expression.isUnaryOperationPrecedenceUnclear()) return
+
+        if (allowForUnclearPrecedence && expression.isFloatWithOutIntegerPartAroundRange()) return
 
         val message = "Parentheses in ${expression.text} are unnecessary and can be replaced with: " +
             KtPsiUtil.deparenthesize(expression)?.text
@@ -174,6 +177,24 @@ class UnnecessaryParentheses(config: Config) : Rule(
                 KtTokens.PLUSPLUS,
                 KtTokens.MINUSMINUS,
             )
+        }
+
+        /**
+         * Determines whether this is decimal without integer part present in ranges
+         */
+        @Suppress("ReturnCount")
+        private fun KtParenthesizedExpression.isFloatWithOutIntegerPartAroundRange(): Boolean {
+            val parentExpression = this.parent
+            if (parentExpression !is KtBinaryExpression) return false
+
+            if (
+                parentExpression.operationToken != KtTokens.RANGE ||
+                (this.expression as? KtConstantExpression)?.elementType != KtNodeTypes.FLOAT_CONSTANT
+            ) {
+                return false
+            }
+
+            return this.expression?.run { text.startsWith(".") } == true
         }
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParentheses.kt
@@ -189,7 +189,8 @@ class UnnecessaryParentheses(config: Config) : Rule(
 
             if (
                 parentExpression.operationToken != KtTokens.RANGE ||
-                (this.expression as? KtConstantExpression)?.elementType != KtNodeTypes.FLOAT_CONSTANT
+                (this.expression as? KtConstantExpression)?.elementType != KtNodeTypes.FLOAT_CONSTANT ||
+                parentExpression.right != this
             ) {
                 return false
             }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -368,6 +368,16 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
+    fun `integer literal range operator`(testCase: RuleTestCase) {
+        val code = """
+            val a = (1)..(2)
+            val b = (1)..<(2)
+        """.trimIndent()
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
     fun `does not report unary operator with value when precedence is clear`(testCase: RuleTestCase) {
         val code = """
             class Foo(val value: Int) {
@@ -581,7 +591,9 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `float closed range without integer part`(testCase: RuleTestCase) {
+    fun `float literals closed range without integer part with braces on the right side - #7640`(
+        testCase: RuleTestCase
+    ) {
         val code = """
             val a = .1F..(.2F)
         """.trimIndent()
@@ -590,16 +602,28 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `float open range without integer part`(testCase: RuleTestCase) {
+    fun `float literals closed range without integer part with braces on the left side`(testCase: RuleTestCase) {
         val code = """
-            val a = .1F..<(.2F)
+            val a = (.1F)..0.2F
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 1 else 1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
     }
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `double closed range without integer part`(testCase: RuleTestCase) {
+    fun `float literals open range`(testCase: RuleTestCase) {
+        val code = """
+            val a = .1F..<(.2F)
+            val b = .1F..<(0.2F)
+            val c = (.1F)..<.2F
+            val d = (.1F)..<.2F
+        """.trimIndent()
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `double literals closed range without integer part`(testCase: RuleTestCase) {
         val code = """
             val a = .1..(.2)
         """.trimIndent()
@@ -609,12 +633,26 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `double open range without integer part`(testCase: RuleTestCase) {
+    fun `double literals open range`(testCase: RuleTestCase) {
         val code = """
             val a = .1..<(.2)
+            val b = .1..<(0.2)
+            val c = (.1)..<0.2
+            val d = (0.1)..<0.2
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 1 else 1)
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `double variable open range `(testCase: RuleTestCase) {
+        val code = """
+            val a = 0.2
+            val b = 0.3
+            val range = (a)..(b)
+        """.trimIndent()
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(2)
     }
 
     companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -153,7 +153,9 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `should not report call to function with two lambda parameters with one as block body`(testCase: RuleTestCase) {
+    fun `should not report call to function with two lambda parameters with one as block body`(
+        testCase: RuleTestCase
+    ) {
         val code = """
             class Clazz {
                 fun test(first: (Int) -> Unit, second: (Int) -> Unit) {
@@ -453,7 +455,9 @@ class UnnecessaryParenthesesSpec {
 
     @ParameterizedTest
     @MethodSource("cases")
-    fun `does report unnecessary parens in case of constant literal when using inc operator`(testCase: RuleTestCase) {
+    fun `does report unnecessary parens in case of constant literal when using inc operator`(
+        testCase: RuleTestCase
+    ) {
         val code = """
             class Foo(var value: Int) {
                 operator fun inc() = Foo(value + 1)
@@ -490,7 +494,9 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.compileAndLint(code)).hasSize(3)
+        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.compileAndLint(code)).hasSize(
+            3
+        )
     }
 
     @Test
@@ -511,7 +517,9 @@ class UnnecessaryParenthesesSpec {
                 val violation3 = ++((a.value))
             }
         """.trimIndent()
-        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.compileAndLint(code)).hasSize(5)
+        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.compileAndLint(code)).hasSize(
+            5
+        )
     }
 
     @ParameterizedTest
@@ -571,6 +579,44 @@ class UnnecessaryParenthesesSpec {
         assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
     }
 
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `float closed range without integer part`(testCase: RuleTestCase) {
+        val code = """
+            val a = .1F..(.2F)
+        """.trimIndent()
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `float open range without integer part`(testCase: RuleTestCase) {
+        val code = """
+            val a = .1F..<(.2F)
+        """.trimIndent()
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 1 else 1)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `double closed range without integer part`(testCase: RuleTestCase) {
+        val code = """
+            val a = .1..(.2)
+        """.trimIndent()
+
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+    }
+
+    @ParameterizedTest
+    @MethodSource("cases")
+    fun `double open range without integer part`(testCase: RuleTestCase) {
+        val code = """
+            val a = .1..<(.2)
+        """.trimIndent()
+
+        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 1 else 1)
+    }
+
     companion object {
         class RuleTestCase(val allowForUnclearPrecedence: Boolean) {
             val rule = UnnecessaryParentheses(
@@ -582,10 +628,16 @@ class UnnecessaryParenthesesSpec {
         fun cases(): List<Arguments> =
             listOf(
                 Arguments.of(
-                    Named.of("Without allow for unclear precedence", RuleTestCase(allowForUnclearPrecedence = false))
+                    Named.of(
+                        "Without allow for unclear precedence",
+                        RuleTestCase(allowForUnclearPrecedence = false)
+                    )
                 ),
                 Arguments.of(
-                    Named.of("With allow for unclear precedence", RuleTestCase(allowForUnclearPrecedence = true))
+                    Named.of(
+                        "With allow for unclear precedence",
+                        RuleTestCase(allowForUnclearPrecedence = true)
+                    )
                 ),
             )
     }


### PR DESCRIPTION
Fixes: https://github.com/detekt/detekt/issues/7640
