### PR TITLE
[UnusedPrivateClass] - Check the right of `::` even when LHS is missing

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClass.kt
@@ -51,7 +51,12 @@ class UnusedPrivateClass(config: Config) : Rule(
         root.accept(classVisitor)
 
         classVisitor.getUnusedClasses().forEach {
-            report(CodeSmell(Entity.from(it), "Private class ${it.nameAsSafeName.identifier} is unused."))
+            report(
+                CodeSmell(
+                    Entity.from(it),
+                    "Private class ${it.nameAsSafeName.identifier} is unused."
+                )
+            )
         }
     }
 
@@ -163,12 +168,10 @@ class UnusedPrivateClass(config: Config) : Rule(
 
         override fun visitDoubleColonExpression(expression: KtDoubleColonExpression) {
             checkReceiverForClassUsage(expression.receiverExpression)
-            if (expression.isEmptyLHS) {
-                (expression as? KtCallableReferenceExpression)
-                    ?.callableReference
-                    ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
-                    ?.let { namedClasses.add(it.getReferencedName()) }
-            }
+            (expression as? KtCallableReferenceExpression)
+                ?.callableReference
+                ?.takeIf { looksLikeAClassName(it.getReferencedName()) }
+                ?.let { namedClasses.add(it.getReferencedName()) }
             super.visitDoubleColonExpression(expression)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -457,5 +457,71 @@ class UnusedPrivateClassSpec {
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(10, 5)
         }
+
+        @Test
+        fun `should not report when callable ref for constructor is used`() {
+            val code = """
+                private class A
+
+                private val listOfConstructors = listOf(::A)
+            """.trimIndent()
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not report when callable ref for inner private class constructor is used with parent name`() {
+            val code = """
+                class Parent {
+                    private class Foo
+
+                    private val list = listOf(Parent::Foo)
+                }
+            """.trimIndent()
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not report callable ref for inner private child class constructor is used with parent private class name`() {
+            val code = """
+                class Parent {
+                    private class Foo {
+                        private class Bar
+                        private val list = listOf(Foo::Bar)
+                    }
+                }
+            """.trimIndent()
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not report when callable ref for inner private class constructor is used without parent name`() {
+            val code = """
+                class Parent {
+                    private class Foo
+
+                    private val list = listOf(::Foo)
+                }
+            """.trimIndent()
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should not report when callable ref for inner private class secondary constructor is used`() {
+            val code = """
+                class Parent {
+                    private class Foo {
+                        constructor(a: Int)
+                    }
+
+                    private val list = listOf(1).map(::Foo)
+                }
+            """.trimIndent()
+            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            assertThat(findings).isEmpty()
+        }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/detekt/detekt/issues/7660

Earlier we were only checking the RHS of `::` when there was empty LHS, so case when we use `::Foo` in `Parent class` like `Parent::Foo` we were skipping the usage of `Foo`
