### PR TITLE
Move Issue from interface to class

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -159,35 +159,40 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Finding {
 	public abstract fun getSuppressReasons ()Ljava/util/List;
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Issue {
-	public abstract fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Issue$Entity;
-	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
-	public abstract fun getMessage ()Ljava/lang/String;
-	public abstract fun getReferences ()Ljava/util/List;
-	public abstract fun getRuleInstance ()Lio/gitlab/arturbosch/detekt/api/RuleInstance;
-	public abstract fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
-	public abstract fun getSuppressReasons ()Ljava/util/List;
+public final class io/gitlab/arturbosch/detekt/api/Issue {
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/RuleInstance;Lio/gitlab/arturbosch/detekt/api/Issue$Entity;Ljava/util/List;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Severity;Ljava/util/List;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Issue$Entity;
+	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getReferences ()Ljava/util/List;
+	public final fun getRuleInstance ()Lio/gitlab/arturbosch/detekt/api/RuleInstance;
+	public final fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
+	public final fun getSuppressReasons ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/gitlab/arturbosch/detekt/api/Issue$DefaultImpls {
-	public static fun getLocation (Lio/gitlab/arturbosch/detekt/api/Issue;)Lio/gitlab/arturbosch/detekt/api/Issue$Location;
+public final class io/gitlab/arturbosch/detekt/api/Issue$Entity {
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Issue$Location;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
+	public final fun getSignature ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/Issue$Entity {
-	public abstract fun getLocation ()Lio/gitlab/arturbosch/detekt/api/Issue$Location;
-	public abstract fun getSignature ()Ljava/lang/String;
-}
-
-public abstract interface class io/gitlab/arturbosch/detekt/api/Issue$Location : java/lang/Comparable {
-	public abstract fun compareTo (Lio/gitlab/arturbosch/detekt/api/Issue$Location;)I
-	public abstract fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public abstract fun getPath ()Ljava/nio/file/Path;
-	public abstract fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
-	public abstract fun getText ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Issue$Location$DefaultImpls {
-	public static fun compareTo (Lio/gitlab/arturbosch/detekt/api/Issue$Location;Lio/gitlab/arturbosch/detekt/api/Issue$Location;)I
+public final class io/gitlab/arturbosch/detekt/api/Issue$Location : java/lang/Comparable {
+	public fun <init> (Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/SourceLocation;Lio/gitlab/arturbosch/detekt/api/TextLocation;Ljava/nio/file/Path;)V
+	public fun compareTo (Lio/gitlab/arturbosch/detekt/api/Issue$Location;)I
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
+	public final fun getPath ()Ljava/nio/file/Path;
+	public final fun getSource ()Lio/gitlab/arturbosch/detekt/api/SourceLocation;
+	public final fun getText ()Lio/gitlab/arturbosch/detekt/api/TextLocation;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/IssueKt {
@@ -297,11 +302,15 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/gitlab/arturbosch/detekt/api/RuleInstance {
-	public abstract fun getDescription ()Ljava/lang/String;
-	public abstract fun getId ()Ljava/lang/String;
-	public abstract fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
-	public abstract fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
+public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Rule$Name;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleSet {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.api
 
+import dev.drewhamilton.poko.Poko
 import java.nio.file.Path
 
 /**
@@ -8,28 +9,32 @@ import java.nio.file.Path
  * An Issue has information about the rule that detected the problem, a severity and an entity with information
  * about the position. Entity references can also be considered for deeper characterization.
  */
-interface Issue {
-    val ruleInstance: RuleInstance
-    val entity: Entity
-    val references: List<Entity>
-    val message: String
-    val severity: Severity
-    val suppressReasons: List<String>
+@Poko
+class Issue(
+    val ruleInstance: RuleInstance,
+    val entity: Entity,
+    val references: List<Entity>,
+    val message: String,
+    val severity: Severity,
+    val suppressReasons: List<String>,
+) {
 
     val location: Location
         get() = entity.location
 
-    interface Entity {
-        val signature: String
-        val location: Location
-    }
+    @Poko
+    class Entity(
+        val signature: String,
+        val location: Location,
+    )
 
-    interface Location : Comparable<Location> {
-        val source: SourceLocation
-        val endSource: SourceLocation
-        val text: TextLocation
-        val path: Path
-
+    @Poko
+    class Location(
+        val source: SourceLocation,
+        val endSource: SourceLocation,
+        val text: TextLocation,
+        val path: Path,
+    ) : Comparable<Location> {
         override fun compareTo(other: Location): Int = compareValuesBy(this, other, { it.path }, { it.source })
     }
 }
@@ -37,9 +42,10 @@ interface Issue {
 val Issue.suppressed: Boolean
     get() = suppressReasons.isNotEmpty()
 
-interface RuleInstance {
-    val id: String
-    val name: Rule.Name
-    val ruleSetId: RuleSet.Id
-    val description: String
-}
+@Poko
+class RuleInstance(
+    val id: String,
+    val name: Rule.Name,
+    val ruleSetId: RuleSet.Id,
+    val description: String,
+)

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
-import java.nio.file.Path
 import kotlin.io.path.Path
 
 fun createIssue(
@@ -30,9 +29,10 @@ fun createIssue(
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     suppressReasons: List<String> = emptyList(),
-): Issue = IssueImpl(
+): Issue = Issue(
     ruleInstance = ruleInstance,
     entity = entity,
+    references = emptyList(),
     message = message,
     severity = severity,
     suppressReasons = suppressReasons,
@@ -44,9 +44,10 @@ fun createIssue(
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     suppressReasons: List<String> = emptyList(),
-): Issue = IssueImpl(
+): Issue = Issue(
     ruleInstance = ruleInstance,
     entity = createEntity(location = location),
+    references = emptyList(),
     message = message,
     severity = severity,
     suppressReasons = suppressReasons,
@@ -58,7 +59,7 @@ fun createRuleInstance(
     description: String = "Description ${id.split("/", limit = 2).first()}",
 ): RuleInstance {
     val split = id.split("/", limit = 2)
-    return RuleInstanceImpl(
+    return RuleInstance(
         id = id,
         name = Rule.Name(split.first()),
         ruleSetId = RuleSet.Id(ruleSetId),
@@ -69,7 +70,7 @@ fun createRuleInstance(
 fun createEntity(
     signature: String = "TestEntitySignature",
     location: Issue.Location = createLocation(),
-): Issue.Entity = IssueImpl.Entity(
+): Issue.Entity = Issue.Entity(
     signature = signature,
     location = location,
 )
@@ -81,42 +82,10 @@ fun createLocation(
     text: IntRange = 0..0,
 ): Issue.Location {
     require(!path.startsWith("/")) { "The path shouldn't start with '/'" }
-    return IssueImpl.Location(
+    return Issue.Location(
         source = SourceLocation(position.first, position.second),
         endSource = SourceLocation(endPosition.first, endPosition.second),
         text = TextLocation(text.first, text.last),
         path = Path(path),
     )
 }
-
-private data class IssueImpl(
-    override val ruleInstance: RuleInstance,
-    override val entity: Issue.Entity,
-    override val message: String,
-    override val severity: Severity = Severity.Error,
-    override val references: List<Issue.Entity> = emptyList(),
-    override val suppressReasons: List<String>
-) : Issue {
-    data class Entity(
-        override val signature: String,
-        override val location: Issue.Location,
-    ) : Issue.Entity
-
-    data class Location(
-        override val source: SourceLocation,
-        override val endSource: SourceLocation,
-        override val text: TextLocation,
-        override val path: Path
-    ) : Issue.Location {
-        init {
-            require(!path.isAbsolute) { "Path should be always relative" }
-        }
-    }
-}
-
-private data class RuleInstanceImpl(
-    override val id: String,
-    override val name: Rule.Name,
-    override val ruleSetId: RuleSet.Id,
-    override val description: String,
-) : RuleInstance


### PR DESCRIPTION
When I created this interface I thought that it will be good to make it an interface. This way someone could create it's own implementation to add extra information on it and then get that information at a reporter. But this was a naive idea for multiple reasons:

- If we serialize `Issue` that extra information would be lost
- We have extension points where you can change the `Issue`s. For example, adding a suppersion. In that case you need to create a new `Issue` so that information in your custom implementation would be lost.

And also it had other issues like it is a nightmare to compare `Issue`s on tests. They are two different implementation of `Issue` so compare them is not trivial. An example of this is the tests at #7775

So, for that reason I'm making `Issue` a class (and all their related interfaces).