### PR TITLE
Add `RuleInstance` url

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -303,12 +303,12 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
-	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Rule$Name;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
-	public final fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
+	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -303,13 +303,13 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
-	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Severity;)V
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/net/URI;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Severity;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 	public final fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
-	public final fun getUrl ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/net/URI;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -1,6 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 import dev.drewhamilton.poko.Poko
+import java.net.URI
 import java.nio.file.Path
 
 /**
@@ -46,7 +47,7 @@ val Issue.suppressed: Boolean
 class RuleInstance(
     val id: String,
     val ruleSetId: RuleSet.Id,
-    val url: String?,
+    val url: URI?,
     val description: String,
     val severity: Severity,
 )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -45,7 +45,7 @@ val Issue.suppressed: Boolean
 @Poko
 class RuleInstance(
     val id: String,
-    val name: Rule.Name,
     val ruleSetId: RuleSet.Id,
+    val url: String?,
     val description: String,
 )

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -59,15 +59,13 @@ fun createRuleInstance(
     url: String? = null,
     description: String = "Description ${id.split("/", limit = 2).first()}",
     severity: Severity = Severity.Error,
-): RuleInstance {
-    return RuleInstance(
-        id = id,
-        ruleSetId = RuleSet.Id(ruleSetId),
-        url = url?.let(::URI),
-        description = description,
-        severity = severity,
-    )
-}
+): RuleInstance = RuleInstance(
+    id = id,
+    ruleSetId = RuleSet.Id(ruleSetId),
+    url = url?.let(::URI),
+    description = description,
+    severity = severity,
+)
 
 fun createEntity(
     signature: String = "TestEntitySignature",

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -6,6 +6,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.TextLocation
+import java.net.URI
 import kotlin.io.path.Path
 
 fun createIssue(
@@ -62,7 +63,7 @@ fun createRuleInstance(
     return RuleInstance(
         id = id,
         ruleSetId = RuleSet.Id(ruleSetId),
-        url = url,
+        url = url?.let(::URI),
         description = description,
         severity = severity,
     )

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
 import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleInstance
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
@@ -56,16 +55,14 @@ fun createIssue(
 fun createRuleInstance(
     id: String = "TestSmell/id",
     ruleSetId: String = "RuleSet${id.split("/", limit = 2).first()}",
+    url: String? = null,
     description: String = "Description ${id.split("/", limit = 2).first()}",
-): RuleInstance {
-    val split = id.split("/", limit = 2)
-    return RuleInstance(
-        id = id,
-        name = Rule.Name(split.first()),
-        ruleSetId = RuleSet.Id(ruleSetId),
-        description = description
-    )
-}
+): RuleInstance = RuleInstance(
+    id = id,
+    ruleSetId = RuleSet.Id(ruleSetId),
+    url = url,
+    description = description
+)
 
 fun createEntity(
     signature: String = "TestEntitySignature",

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -26,6 +26,7 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
+import java.net.URI
 import java.nio.file.Path
 import kotlin.reflect.full.hasAnnotation
 
@@ -215,7 +216,7 @@ private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance
     RuleInstance(
         id = id,
         ruleSetId = ruleSetId,
-        url = "https://detekt.dev/docs/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}",
+        url = URI("https://detekt.dev/docs/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}"),
         description = description,
         severity = computeSeverity(),
     )

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -212,7 +212,12 @@ private fun Location.toIssue(basePath: Path): Issue.Location =
     Issue.Location(source, endSource, text, basePath.relativize(path))
 
 private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance =
-    RuleInstance(id, ruleName, ruleSetId, description)
+    RuleInstance(
+        id = id,
+        ruleSetId = ruleSetId,
+        url = "https://detekt.dev/docs/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}",
+        description = description,
+    )
 
 /**
  * Compute severity in the priority order:

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import java.net.URI
 import kotlin.io.path.Path
 
 @KotlinCoreEnvironmentTest
@@ -142,7 +143,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
                         ruleInstance = RuleInstance(
                             id = "MaxLineLength/foo",
                             ruleSetId = RuleSet.Id("custom"),
-                            url = "https://detekt.dev/docs/rules/custom#maxlinelength",
+                            url = URI("https://detekt.dev/docs/rules/custom#maxlinelength"),
                             description = "TestDescription",
                             severity = Severity.Error,
                         ),

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -141,8 +141,8 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
                     Issue(
                         ruleInstance = RuleInstance(
                             id = "MaxLineLength/foo",
-                            name = Rule.Name("MaxLineLength"),
                             ruleSetId = RuleSet.Id("custom"),
+                            url = "https://detekt.dev/docs/rules/custom#maxlinelength",
                             description = "TestDescription"
                         ),
                         entity = Issue.Entity(

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -131,7 +131,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
             }
 
             if (ruleInstance.url != null) {
-                a(ruleInstance.url) { +"Documentation" }
+                a(ruleInstance.url.toString()) { +"Documentation" }
             }
 
             ul {

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -44,8 +44,6 @@ private const val PLACEHOLDER_COMPLEXITY_REPORT = "@@@complexity@@@"
 private const val PLACEHOLDER_VERSION = "@@@version@@@"
 private const val PLACEHOLDER_DATE = "@@@date@@@"
 
-private const val DETEKT_WEBSITE_BASE_URL = "https://detekt.dev"
-
 /**
  * Contains rule violations and metrics formatted in a human friendly way, so that it can be inspected in a web browser.
  * See: https://detekt.dev/configurations.html#output-reports
@@ -123,8 +121,6 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
 
     private fun FlowContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>) {
         val ruleId = ruleInstance.id
-        val ruleName = ruleInstance.name.value
-        val ruleSetId = ruleInstance.ruleSetId.value
         details {
             id = ruleId
             open = true
@@ -134,8 +130,8 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
                 span("description") { text(ruleInstance.description) }
             }
 
-            a("$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleName.lowercase()}") {
-                +"Documentation"
+            if (ruleInstance.url != null) {
+                a(ruleInstance.url) { +"Documentation" }
             }
 
             ul {
@@ -171,7 +167,7 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
         val absoluteFile = basePath.resolve(issue.location.path).toFile()
         if (absoluteFile.exists()) {
             absoluteFile.useLines {
-                snippetCode(issue.ruleInstance.name, it, issue.location.source, issue.location.text.length())
+                snippetCode(issue.ruleInstance.id, it, issue.location.source, issue.location.text.length())
             }
         }
     }

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlUtils.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.html
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import kotlinx.html.FlowContent
@@ -19,7 +18,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 internal fun FlowContent.snippetCode(
-    ruleName: Rule.Name,
+    id: String,
     lines: Sequence<String>,
     location: SourceLocation,
     length: Int,
@@ -48,7 +47,7 @@ internal fun FlowContent.snippetCode(
             }
         }
     } catch (@Suppress("TooGenericExceptionCaught") ex: Throwable) {
-        showError(ruleName, ex)
+        showError(id, ex)
     }
 }
 
@@ -67,15 +66,15 @@ private fun FlowContent.writeErrorLine(line: String, errorStarts: Int, length: I
     return errorEnds - errorStarts
 }
 
-private fun FlowContent.showError(ruleName: Rule.Name, throwable: Throwable) {
+private fun FlowContent.showError(id: String, throwable: Throwable) {
     div("exception") {
         h4 {
             text("Error showing the code snippet")
         }
 
         p {
-            text("This seems to be an error in the rule $ruleName, please ")
-            a(createReportUrl(ruleName, throwable)) {
+            text("This seems to be an error in the rule $id, please ")
+            a(createReportUrl(id, throwable)) {
                 text("report this issue")
             }
             text(".")
@@ -83,15 +82,15 @@ private fun FlowContent.showError(ruleName: Rule.Name, throwable: Throwable) {
     }
 }
 
-private fun createReportUrl(ruleName: Rule.Name, throwable: Throwable): String {
-    val title = URLEncoder.encode("HtmlReport error in rule: $ruleName", "UTF8")
+private fun createReportUrl(ruleId: String, throwable: Throwable): String {
+    val title = URLEncoder.encode("HtmlReport error in rule: $ruleId", "UTF8")
     val stackTrace = throwable.printStackTraceString()
         .lineSequence()
         .take(STACK_TRACE_LINES_TO_SHOW)
         .joinToString("\n")
     val bodyMessage = """
         |I found an error in the html report:
-        |- Rule: $ruleName
+        |- Rule: $ruleId
         |- detekt version: ${whichDetekt()}"}
         |- Stacktrace:
         |```

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -102,20 +102,6 @@ class HtmlOutputReportSpec {
     }
 
     @Test
-    fun `renders the right documentation links for the rules`() {
-        val detektion = TestDetektion(
-            createIssue(createRuleInstance("ValCouldBeVar", "Style")),
-            createIssue(createRuleInstance("EmptyBody", "empty")),
-            createIssue(createRuleInstance("EmptyIf", "empty")),
-        )
-
-        val result = htmlReport.render(detektion)
-        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/style#valcouldbevar\">Documentation</a>")
-        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/empty#emptybody\">Documentation</a>")
-        assertThat(result).contains("<a href=\"https://detekt.dev/docs/rules/empty#emptyif\">Documentation</a>")
-    }
-
-    @Test
     fun `renders a metric report correctly`() {
         val detektion = TestDetektion(
             metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2))
@@ -182,9 +168,21 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return TestDetektion(
-        createIssue(createRuleInstance("rule_a/id", "RuleSet1"), entity1, "Issue message 1"),
-        createIssue(createRuleInstance("rule_a/id", "RuleSet1"), entity2, "Issue message 2"),
-        createIssue(createRuleInstance("rule_b", "RuleSet2"), entity3, "Issue message 3"),
+        createIssue(
+            createRuleInstance("rule_a/id", "RuleSet1", url = "https://example.org/"),
+            entity1,
+            "Issue message 1"
+        ),
+        createIssue(
+            createRuleInstance("rule_a/id", "RuleSet1", url = "https://example.org/"),
+            entity2,
+            "Issue message 2"
+        ),
+        createIssue(
+            createRuleInstance("rule_b", "RuleSet2", url = null),
+            entity3,
+            "Issue message 3"
+        ),
         createIssue(
             createRuleInstance("rule_c", "RuleSet2"),
             entity3,

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlUtilsSpec.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.report.html
 
-import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import kotlinx.html.div
 import kotlinx.html.stream.createHTML
@@ -31,7 +30,7 @@ class HtmlUtilsSpec {
     @Test
     fun `all line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 1), 34)
+            snippetCode("ruleId", code, SourceLocation(7, 1), 34)
         }
 
         assertThat(snippet).isEqualTo(
@@ -54,7 +53,7 @@ class HtmlUtilsSpec {
     @Test
     fun `part of line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 7), 26)
+            snippetCode("ruleId", code, SourceLocation(7, 7), 26)
         }
 
         assertThat(snippet).isEqualTo(
@@ -77,7 +76,7 @@ class HtmlUtilsSpec {
     @Test
     fun `more than one line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 7), 66)
+            snippetCode("ruleId", code, SourceLocation(7, 7), 66)
         }
 
         assertThat(snippet).isEqualTo(
@@ -100,7 +99,7 @@ class HtmlUtilsSpec {
     @Test
     fun `first line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(1, 1), 1)
+            snippetCode("ruleId", code, SourceLocation(1, 1), 1)
         }
 
         assertThat(snippet).contains((1..4).map { "  $it " })
@@ -109,7 +108,7 @@ class HtmlUtilsSpec {
     @Test
     fun `second line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(2, 1), 1)
+            snippetCode("ruleId", code, SourceLocation(2, 1), 1)
         }
 
         assertThat(snippet).contains((1..5).map { "  $it " })
@@ -118,7 +117,7 @@ class HtmlUtilsSpec {
     @Test
     fun `penultimate line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(15, 1), 1)
+            snippetCode("ruleId", code, SourceLocation(15, 1), 1)
         }
 
         assertThat(snippet).contains((12..16).map { "  $it " })
@@ -127,7 +126,7 @@ class HtmlUtilsSpec {
     @Test
     fun `last line`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(16, 1), 1)
+            snippetCode("ruleId", code, SourceLocation(16, 1), 1)
         }
 
         assertThat(snippet).contains((13..16).map { "  $it " })
@@ -136,7 +135,7 @@ class HtmlUtilsSpec {
     @Test
     fun `when we provide an invalid source location the exception div is shown`() {
         val snippet = createHTML().div {
-            snippetCode(Rule.Name("ruleName"), code, SourceLocation(7, 100), 1)
+            snippetCode("ruleId", code, SourceLocation(7, 100), 1)
         }
 
         assertThat(snippet).contains("""<div class="exception">""")

--- a/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
+++ b/detekt-report-html/src/test/resources/HtmlOutputFormatTest.html
@@ -172,7 +172,7 @@
   <h3>RuleSet1: 2</h3>
   <details id="rule_a/id" open="open">
     <summary class="rule-container"><span class="rule">rule_a/id: 2 </span><span class="description">Description rule_a</span></summary>
-<a href="https://detekt.dev/docs/rules/ruleset1#rule_a">Documentation</a>
+<a href="https://example.org/">Documentation</a>
     <ul>
       <li><span class="location">src/main/com/sample/Sample1.kt:11:1</span><span class="message">Issue message 1</span>
         <pre><code><span class="lineno">   8 </span>val val8 = 8
@@ -199,7 +199,6 @@
   <h3>RuleSet2: 1</h3>
   <details id="rule_b" open="open">
     <summary class="rule-container"><span class="rule">rule_b: 1 </span><span class="description">Description rule_b</span></summary>
-<a href="https://detekt.dev/docs/rules/ruleset2#rule_b">Documentation</a>
     <ul>
       <li><span class="location">src/main/com/sample/Sample3.kt:33:3</span><span class="message">Issue message 3</span>
         <pre><code><span class="lineno">  30 </span>val val30 = 30

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -105,7 +105,7 @@ private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<
     h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
     paragraph { ruleInstance.description }
 
-    ruleInstance.url?.let { paragraph { link("Documentation", it) } }
+    ruleInstance.url?.let { paragraph { link("Documentation", it.toString()) } }
 
     list {
         issues

--- a/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
+++ b/detekt-report-md/src/main/kotlin/io/github/detekt/report/md/MdOutputReport.kt
@@ -101,17 +101,11 @@ private fun MarkdownContent.renderGroup(issues: List<Issue>, basePath: Path) {
 
 private fun MarkdownContent.renderRule(ruleInstance: RuleInstance, issues: List<Issue>, basePath: Path) {
     val ruleId = ruleInstance.id
-    val ruleName = ruleInstance.name.value
     val ruleSetId = ruleInstance.ruleSetId.value
     h3 { "$ruleSetId, $ruleId (%,d)".format(Locale.ROOT, issues.size) }
     paragraph { ruleInstance.description }
 
-    paragraph {
-        link(
-            "Documentation",
-            "$DETEKT_WEBSITE_BASE_URL/docs/rules/${ruleSetId.lowercase()}#${ruleName.lowercase()}"
-        )
-    }
+    ruleInstance.url?.let { paragraph { link("Documentation", it) } }
 
     list {
         issues

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -69,7 +69,7 @@ class MdOutputReportSpec {
                 
                 Description rule_a
                 
-                [Documentation](https://detekt.dev/docs/rules/section-1#rule_a)
+                [Documentation](https://example.org/)
                 
                 * src/main/com/sample/Sample1.kt:9:17
                 ```
@@ -106,8 +106,6 @@ class MdOutputReportSpec {
                 ### Section-2, rule_b (1)
                 
                 Description rule_b
-                
-                [Documentation](https://detekt.dev/docs/rules/section-2#rule_b)
                 
                 * src/main/com/sample/Sample3.kt:14:16
                 ```
@@ -182,20 +180,6 @@ class MdOutputReportSpec {
     }
 
     @Test
-    fun `renders the right documentation links for the rules`() {
-        val detektion = TestDetektion(
-            createIssue(createRuleInstance("ValCouldBeVar", "Style")),
-            createIssue(createRuleInstance("EmptyBody", "empty")),
-            createIssue(createRuleInstance("EmptyIf", "empty")),
-        )
-
-        val result = mdReport.render(detektion)
-        assertThat(result).contains("[Documentation](https://detekt.dev/docs/rules/style#valcouldbevar)")
-        assertThat(result).contains("[Documentation](https://detekt.dev/docs/rules/empty#emptybody)")
-        assertThat(result).contains("[Documentation](https://detekt.dev/docs/rules/empty#emptyif)")
-    }
-
-    @Test
     fun `asserts that the generated md is the same even if we change the order of the issues`() {
         val issues = issues()
         val reversedIssues = issues.reversedArray()
@@ -222,9 +206,21 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     )
 
     return createMdDetektion(
-        createIssue(createRuleInstance("rule_a/id", "Section-1"), entity1, "Issue message 1"),
-        createIssue(createRuleInstance("rule_a/id", "Section-1"), entity2, "Issue message 2"),
-        createIssue(createRuleInstance("rule_b", "Section-2"), entity3, "Issue message 3"),
+        createIssue(
+            createRuleInstance("rule_a/id", "Section-1", url = "https://example.org/"),
+            entity1,
+            "Issue message 1"
+        ),
+        createIssue(
+            createRuleInstance("rule_a/id", "Section-1", url = "https://example.org/"),
+            entity2,
+            "Issue message 2"
+        ),
+        createIssue(
+            createRuleInstance("rule_b", "Section-2", url = null),
+            entity3,
+            "Issue message 3"
+        ),
         createIssue(
             createRuleInstance("rule_c", "Section-2"),
             entity3,


### PR DESCRIPTION
This PR goes in the line to implement #7717 but it's not yet that.

But this simplifies `RuleInstance` a lot. It had `ruleId` and `ruleName`. That was *really* confusing. With this change we don't need `ruleName` in the `RuleInstance` anymore. The only place where we were using the `name` was to construct the `url` of each rule. Now, instead of having the `ruleName` we have the `url` itself. And now that we have the `url` itself on the `RuleInstance` we can implement #7717 and allow each rule to provide it's own `url`. This way we allow to configure this to custom rules.