### PR TITLE
Warn for rules used with multiInstance when no bindingContext

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -143,15 +143,27 @@ internal class Analyzer(
             .filter { (_, ruleSetConfig) -> ruleSetConfig.isActiveOrDefault(true) }
             .map { (provider, ruleSetConfig) -> provider.instance() to ruleSetConfig }
             .flatMap { (ruleSet, ruleSetConfig) ->
-                ruleSet.rules
+                ruleSetConfig.subConfigKeys()
                     .asSequence()
-                    .map { (ruleName, ruleProvider) -> ruleProvider to ruleSetConfig.subConfig(ruleName.value) }
-                    .filter { (_, config) -> config.isActiveOrDefault(false) }
-                    .map { (ruleProvider, config) -> ruleProvider(config) }
+                    .mapNotNull { ruleId -> extractRuleName(ruleId)?.let { ruleName -> ruleId to ruleName } }
+                    .mapNotNull { (ruleId, ruleName) ->
+                        ruleSet.rules[ruleName]?.let { ruleProvider ->
+                            RuleDescriptor(
+                                ruleProvider = ruleProvider,
+                                config = ruleSetConfig.subConfig(ruleId),
+                                ruleId = ruleId,
+                            )
+                        }
+                    }
+                    .filter { (_, config, _) -> config.isActiveOrDefault(false) }
+                    .map { (ruleProvider, config, ruleId) ->
+                        val rule = ruleProvider(config)
+                        rule.toRuleInstance(ruleId, ruleSet.id) to rule
+                    }
             }
-            .filter { rule -> rule::class.hasAnnotation<RequiresFullAnalysis>() }
-            .forEach { rule ->
-                settings.debug { "The rule '${rule.ruleName}' requires type resolution but it was run without it." }
+            .filter { (_, rule) -> rule::class.hasAnnotation<RequiresFullAnalysis>() }
+            .forEach { (ruleInstance, _) ->
+                settings.debug { "The rule '${ruleInstance.id}' requires type resolution but it was run without it." }
             }
     }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -93,7 +93,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
                           MaxLineLength:
                             active: true
                             maxLineLength: 120
-                          RequiresFullAnalysisMaxLineLength:
+                          RequiresFullAnalysisMaxLineLength/foo:
                             active: true
                             maxLineLength: 120
                     """.trimIndent()
@@ -104,7 +104,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
 
             assertThat(settings.use { analyzer.run(listOf(compileForTest(testFile))) }).isEmpty()
             assertThat(output.toString()).isEqualTo(
-                "The rule 'RequiresFullAnalysisMaxLineLength' requires type resolution but it was run without it.\n"
+                "The rule 'RequiresFullAnalysisMaxLineLength/foo' requires type resolution but it was run without it.\n"
             )
         }
 


### PR DESCRIPTION
We have a warning for when a user runs detekt without type solving but with type solving rules enabled. This was broken with the introduction of multiple instances for the same rule. This PR fixees that.

Also this PR goes in the line of reduce the usages of `name` where it is not needed because I think that we can remove it from `Rule`.