### PR TITLE
Decouple DGP compilation version from the rest of the project

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -3,7 +3,8 @@
 @file:Suppress("StringLiteralDuplication")
 
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import java.net.URI
 
 plugins {
@@ -31,6 +32,11 @@ detekt {
     buildUponDefaultConfig = true
     baseline = file("config/gradle-plugin-baseline.xml")
     config.setFrom("config/gradle-plugin-detekt.yml")
+}
+
+kotlin {
+    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
+    compilerVersion = "2.0.10"
 }
 
 testing {
@@ -212,12 +218,13 @@ with(components["java"] as AdhocComponentWithVariants) {
 
 kotlin {
     compilerOptions {
-        @Suppress("DEPRECATION")
-        apiVersion = KotlinVersion.KOTLIN_1_4
         suppressWarnings = true
         // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
         //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
         allWarningsAsErrors = false
+        // The apiVersion Gradle property cannot be used here, so set api version using free compiler args.
+        // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
+        freeCompilerArgs.addAll("-api-version", "1.4")
     }
 }
 

--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -1,2 +1,3 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
+kotlin.compiler.runViaBuildToolsApi=true


### PR DESCRIPTION
Required for Kotlin 2.1.0. Gradle's Kotlin build scripts are compiled with Kotlin 1.9.x as of Gradle 8.3: https://docs.gradle.org/8.10.1/userguide/compatibility.html#kotlin

If DGP is compiled with Kotlin 2.1.0 the metadata version is not readable by Kotlin 1.9.x. Kotlin is only forward compatible with +1 version of Kotlin, see https://kotlinlang.org/docs/kotlin-evolution-principles.html#evolving-the-binary-format

> the binary format is mostly forwards compatible with the next language
> release, but not later ones (in the cases when new features are not used,
> for example, 1.9 can understand most binaries from 2.0, but not 2.1)

To mitigate this issue we switch to the Build Tools API available in newer Kotlin versions. This allows applying one version of KGP and compiling with a different version of Kotlin.

If this approach does not work out (it requires two opt ins!) then we can explore other approaches, however this works for now.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
