### PR TITLE
Don't use multiple targets of the same type in tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -103,13 +103,8 @@ class DetektMultiplatformSpec {
                     buildFileContent = joinGradleBlocks(
                         KMM_PLUGIN_BLOCK,
                         """
-                            val targetType = Attribute.of("com.example.target.type", String::class.java)
-                            
                             kotlin {
-                                jvm("jvmBackend") {
-                                    attributes.attribute(targetType, "jvmBackend")
-                                }
-                                jvm("jvmEmbedded")
+                                jvm()
                             }
                         """.trimIndent(),
                         DETEKT_BLOCK,
@@ -117,8 +112,7 @@ class DetektMultiplatformSpec {
                     srcDirs = listOf(
                         "src/commonMain/kotlin",
                         "src/commonTest/kotlin",
-                        "src/jvmBackendMain/kotlin",
-                        "src/jvmEmbeddedMain/kotlin",
+                        "src/jvmMain/kotlin",
                     ),
                     baselineFiles = listOf("detekt-baseline.xml", "detekt-baseline-main.xml")
                 )
@@ -126,26 +120,15 @@ class DetektMultiplatformSpec {
 
         @Test
         fun `configures baseline task`() {
-            gradleRunner.runTasks(":shared:detektBaselineMainJvmBackend")
-            gradleRunner.runTasks(":shared:detektBaselineTestJvmBackend")
-            gradleRunner.runTasks(":shared:detektBaselineMainJvmEmbedded")
-            gradleRunner.runTasks(":shared:detektBaselineTestJvmEmbedded")
+            gradleRunner.runTasks(":shared:detektBaselineMainJvm")
+            gradleRunner.runTasks(":shared:detektBaselineTestJvm")
         }
 
         @Test
         fun `configures detekt task with type resolution backend`() {
-            gradleRunner.runTasksAndCheckResult(":shared:detektMainJvmBackend") {
+            gradleRunner.runTasksAndCheckResult(":shared:detektMainJvm") {
                 assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
-                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]mainJvmBackend.xml""")
-                assertDetektWithClasspath(it)
-            }
-        }
-
-        @Test
-        fun `configures detekt task with type resolution embedded`() {
-            gradleRunner.runTasksAndCheckResult(":shared:detektMainJvmEmbedded") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
-                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]mainJvmEmbedded.xml""")
+                assertThat(it.output).containsPattern("""--report xml:\S*[/\\]mainJvm.xml""")
                 assertDetektWithClasspath(it)
             }
         }


### PR DESCRIPTION
This is an error in Kotlin 2.1.0:
https://youtrack.jetbrains.com/issue/KT-69412/Change-KotlinTargetAlreadyDeclaredCheckers-severity-from-warning-to-error

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
