### PR TITLE
Replace deprecated toUpperCase() with uppercase()

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -279,7 +279,7 @@ class IgnoredReturnValueSpec {
                 
                 fun foo() : Int {
                     val hello = "world "
-                    hello.toUpperCase()
+                    hello.uppercase()
                         .trim()
                         .listOfChecked()
                         .isEmpty()
@@ -303,7 +303,7 @@ class IgnoredReturnValueSpec {
                 
                 fun foo() : Int {
                     val hello = "world "
-                    hello.toUpperCase()
+                    hello.uppercase()
                         .trim()
                         .listOfChecked()
                     return 42
@@ -629,7 +629,7 @@ class IgnoredReturnValueSpec {
                 
                 fun foo() : Int {
                     val hello = "world "
-                    hello.toUpperCase()
+                    hello.uppercase()
                         .trim()
                         .listOfChecked()
                         .print()


### PR DESCRIPTION
This has been deprecated since Kotlin 1.5.20 but the deprecation was not previously reported when compiling test snippets. This has changed in Kotlin 2.1.0 which now reports the deprecation leading to failing tests.