### PR TITLE
Fix wrong baseline path in website documentation

### DIFF
--- a/website/docs/introduction/baseline.md
+++ b/website/docs/introduction/baseline.md
@@ -75,7 +75,7 @@ task detektProjectBaseline(type: io.gitlab.arturbosch.detekt.DetektCreateBaselin
 subprojects {
     detekt {
         // ...
-        baseline.set(file("${rootProject.projectDir}/config/baseline.xml"))
+        baseline.set(file("${rootProject.projectDir}/config/detekt/baseline.xml"))
         // ...
     }
 }

--- a/website/versioned_docs/version-1.23.7/introduction/baseline.md
+++ b/website/versioned_docs/version-1.23.7/introduction/baseline.md
@@ -41,7 +41,7 @@ a custom meta baseline task:
 subprojects {
     detekt {
         // ...
-        baseline = file("${rootProject.projectDir}/config/baseline.xml")
+        baseline = file("${rootProject.projectDir}/config/detekt/baseline.xml")
         // ...
     }
 }
@@ -66,7 +66,7 @@ task detektProjectBaseline(type: io.gitlab.arturbosch.detekt.DetektCreateBaselin
 subprojects {
     detekt {
         // ...
-        baseline = file("${rootProject.projectDir}/config/baseline.xml")
+        baseline = file("${rootProject.projectDir}/config/detekt/baseline.xml")
         // ...
     }
 }


### PR DESCRIPTION
When I read the docs, my baseline was generated but not taken into account with `./gradlew detekt`. 
Changing the path fixed my issue.