### PR TITLE
Severity on `RuleInstance`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -303,12 +303,13 @@ public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
-	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Rule$Name;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Rule$Name;Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/Severity;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDescription ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
+	public final fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Issue.kt
@@ -48,4 +48,5 @@ class RuleInstance(
     val name: Rule.Name,
     val ruleSetId: RuleSet.Id,
     val description: String,
+    val severity: Severity,
 )

--- a/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/test/TestFactory.kt
@@ -57,13 +57,15 @@ fun createRuleInstance(
     id: String = "TestSmell/id",
     ruleSetId: String = "RuleSet${id.split("/", limit = 2).first()}",
     description: String = "Description ${id.split("/", limit = 2).first()}",
+    severity: Severity = Severity.Error,
 ): RuleInstance {
     val split = id.split("/", limit = 2)
     return RuleInstance(
         id = id,
         name = Rule.Name(split.first()),
         ruleSetId = RuleSet.Id(ruleSetId),
-        description = description
+        description = description,
+        severity = severity,
     )
 }
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -131,7 +131,7 @@ internal class Analyzer(
                     it.entity.ktElement.isSuppressedBy(ruleInstance.id, rule.aliases, ruleInstance.ruleSetId)
                 }
                 .filterSuppressedFindings(rule, bindingContext)
-                .map { it.toIssue(ruleInstance, rule.computeSeverity(), settings.spec.projectSpec.basePath) }
+                .map { it.toIssue(ruleInstance, ruleInstance.severity, settings.spec.projectSpec.basePath) }
         }
     }
 
@@ -212,7 +212,13 @@ private fun Location.toIssue(basePath: Path): Issue.Location =
     Issue.Location(source, endSource, text, basePath.relativize(path))
 
 private fun Rule.toRuleInstance(id: String, ruleSetId: RuleSet.Id): RuleInstance =
-    RuleInstance(id, ruleName, ruleSetId, description)
+    RuleInstance(
+        id = id,
+        name = ruleName,
+        ruleSetId = ruleSetId,
+        description = description,
+        severity = computeSeverity(),
+    )
 
 /**
  * Compute severity in the priority order:

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -143,7 +143,8 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
                             id = "MaxLineLength/foo",
                             name = Rule.Name("MaxLineLength"),
                             ruleSetId = RuleSet.Id("custom"),
-                            description = "TestDescription"
+                            description = "TestDescription",
+                            severity = Severity.Error,
                         ),
                         entity = Issue.Entity(
                             "AnAnnotation$@Target(AnnotationTarget.FILE, AnnotationTarget.FUNCTION)",


### PR DESCRIPTION
This was a blocker for #7684. A `RuleInstance` didn't have a `Severity` so the rules didn't have a "default" severity for a rule. We only have the `Severity` at `Issue` level.

This makes that now we have two severities one on the `Issue` and another on the `RuleInstance`. The `Issue` contains a `RuleInstance` so now a `Issue` could have two "different" severities. I'm leaving it on the `Issue` for now but maybe we could remove it from there.