### PR TITLE
Reduce duplication on Analyzer

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -107,14 +107,15 @@ internal class Analyzer(
                                 ruleProvider = ruleProvider,
                                 config = ruleSetConfig.subConfig(ruleId),
                                 ruleId = ruleId,
+                                ruleSetId = ruleSet.id,
                             )
                         }
                     }
-                    .filter { (_, config, _) -> config.isActiveOrDefault(false) }
-                    .filter { (_, config, _) -> config.shouldAnalyzeFile(file, settings.spec.projectSpec.basePath) }
-                    .map { (ruleProvider, config, ruleId) ->
+                    .filter { (_, config, _, _) -> config.isActiveOrDefault(false) }
+                    .filter { (_, config, _, _) -> config.shouldAnalyzeFile(file, settings.spec.projectSpec.basePath) }
+                    .map { (ruleProvider, config, ruleId, ruleSetId) ->
                         val rule = ruleProvider(config)
-                        rule.toRuleInstance(ruleId, ruleSet.id) to rule
+                        rule.toRuleInstance(ruleId, ruleSetId) to rule
                     }
             }
             .filterNot { (ruleInstance, rule) ->
@@ -150,13 +151,14 @@ internal class Analyzer(
                                 ruleProvider = ruleProvider,
                                 config = ruleSetConfig.subConfig(ruleId),
                                 ruleId = ruleId,
+                                ruleSetId = ruleSet.id,
                             )
                         }
                     }
-                    .filter { (_, config, _) -> config.isActiveOrDefault(false) }
-                    .map { (ruleProvider, config, ruleId) ->
+                    .filter { (_, config, _, _) -> config.isActiveOrDefault(false) }
+                    .map { (ruleProvider, config, ruleId, ruleSetId) ->
                         val rule = ruleProvider(config)
-                        rule.toRuleInstance(ruleId, ruleSet.id) to rule
+                        rule.toRuleInstance(ruleId, ruleSetId) to rule
                     }
             }
             .filter { (_, rule) -> rule::class.hasAnnotation<RequiresFullAnalysis>() }
@@ -169,7 +171,12 @@ internal class Analyzer(
 internal fun extractRuleName(key: String): Rule.Name? =
     runCatching { Rule.Name(key.split("/", limit = 2).first()) }.getOrNull()
 
-private data class RuleDescriptor(val ruleProvider: (Config) -> Rule, val config: Config, val ruleId: String)
+private data class RuleDescriptor(
+    val ruleProvider: (Config) -> Rule,
+    val config: Config,
+    val ruleId: String,
+    val ruleSetId: RuleSet.Id,
+)
 
 private fun List<Finding>.filterSuppressedFindings(rule: Rule, bindingContext: BindingContext): List<Finding> {
     val suppressors = buildSuppressors(rule, bindingContext)

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import java.util.concurrent.CompletionException
 
 @KotlinCoreEnvironmentTest
 class AnalyzerSpec(val env: KotlinCoreEnvironment) {
@@ -74,7 +75,8 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             val analyzer = Analyzer(settings, listOf(CustomRuleSetProvider()), emptyList())
 
             assertThatThrownBy { settings.use { analyzer.run(listOf(compileForTest(testFile))) } }
-                .isInstanceOf(IllegalStateException::class.java)
+                .isInstanceOf(CompletionException::class.java)
+                .hasCauseInstanceOf(IllegalStateException::class.java)
         }
     }
 


### PR DESCRIPTION
We had two functions and they did more less the same: select which rules should be executed. But one of them was for execute them and the other was just to log some information. That was bad because it was easy to get them unaligned and because we were executing the same thing twice. This PR removes that. Now we have one single function that provides the rules that should be executed.

Also, now that we have this logic centralized we can use it to export this information to `Detektion` so the reporters can know all the rules that detekt knows about and which ones were executed.