### PR TITLE
`ExpressionBodySyntax`: don't report if multiple returns in when expressions (Closes #7829)

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntax.kt
@@ -74,7 +74,7 @@ class ExpressionBodySyntax(config: Config) : Rule(
 
     private fun KtReturnExpression.containsReturnInWhenExpressions(): Boolean =
         anyDescendantOfType<KtReturnExpression> {
-            (it.parent as? KtWhenEntry) != null
+            it.parent is KtWhenEntry
         }
 
     private fun KtReturnExpression.containsReturnStmtsInNullableArguments(): Boolean =

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -164,6 +164,32 @@ class ExpressionBodySyntaxSpec {
     }
 
     @Nested
+    inner class `multiple return in when expression` {
+        val code = """
+            fun stuff(): Pair<String, String>? {
+                return Pair(
+                    first = "",
+                    second = when {
+                        true -> ""
+                        else -> return null 
+                    }
+                )
+            }
+        """.trimIndent()
+
+        @Test
+        fun `does not report with the default configuration`() {
+            assertThat(subject.compileAndLint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report with includeLineWrapping = true configuration`() {
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
+            assertThat(ExpressionBodySyntax(config).compileAndLint(code)).isEmpty()
+        }
+    }
+
+    @Nested
     inner class `several return statements with multiline if expression` {
 
         val code = """


### PR DESCRIPTION
This PR fixes #7829, not reporting a `ExpressionBodySyntax` if there are multiple return expressions in `when` statements.

This code is now compliant:
```kotlin
    fun stuff(): Pair<String, String>? {
        return Pair(
            first = "",
            second = when {
                true -> ""
                else -> return null 
            }
        )
    }
```