### PR TITLE
Updating custom rules pitfalls.

### DIFF
--- a/website/docs/introduction/extensions.md
+++ b/website/docs/introduction/extensions.md
@@ -239,3 +239,4 @@ after your extension sub project is built.
 you created a pure kotlin module which has no Android dependencies. `apply plugin: "kotlin"` is enough to make it work.
 - Sometimes when you run detekt task, you may not see the violations detected by your custom rules. In this case open a terminal and run
 `./gradlew --stop` to stop gradle daemons and run the task again.
+- If you are configuring a custom detekt task at the root project level, you will need to apply the detektPlugins at the root project as well (not subprojects). See [this issue](https://github.com/detekt/detekt/issues/3989#issuecomment-890331512) for more.

--- a/website/versioned_docs/version-1.23.7/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.7/introduction/extensions.md
@@ -247,6 +247,7 @@ after your extension sub project is built.
 you created a pure kotlin module which has no Android dependencies. `apply plugin: "kotlin"` is enough to make it work.
 - Sometimes when you run detekt task, you may not see the violations detected by your custom rules. In this case open a terminal and run
 `./gradlew --stop` to stop gradle daemons and run the task again.
+- If you are configuring a custom detekt task at the root project level, you will need to apply the detektPlugins at the root project as well (not subprojects). See [this issue](https://github.com/detekt/detekt/issues/3989#issuecomment-890331512) for more.
 
 #### autoCorrect property
 


### PR DESCRIPTION
When configuring a custom `detektAll` parallel task at the project root, custom detekt plugins must also be applied as dependencies on the root project, not sub modules.

This was covered in an [issue](https://github.com/detekt/detekt/issues/3989#issuecomment-890331512) that I found in my search, but hopefully adding it to the pitfalls notes means it could save the next person a little bit of time. 

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
