### PR TITLE
Duration prints the units itself

### DIFF
--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
@@ -31,7 +31,7 @@ class Generator(
             printer.print(collector.items)
         }
 
-        outPrinter.println("\nGenerated all detekt documentation in $time ms.")
+        outPrinter.println("\nGenerated all detekt documentation in $time.")
     }
 
     fun executeCustomRuleConfig() {
@@ -51,7 +51,7 @@ class Generator(
                 }
         }
 
-        outPrinter.println("\nGenerated custom rules config in $time ms.")
+        outPrinter.println("\nGenerated custom rules config in $time.")
     }
 }
 


### PR DESCRIPTION
Before:
> Generated all detekt documentation in 889.526333ms ms.

After:
> Generated all detekt documentation in 889.526333ms.

`$time` is a `Duration` and not an `Int`. And `Duration` already prints the units in its `toString`.