### PR TITLE
Remove `open` from `CodeSmell`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -11,13 +11,13 @@ public final class io/gitlab/arturbosch/detekt/api/AutocorrectKt {
 	public static final fun setModifiedText (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/lang/String;)V
 }
 
-public class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/detekt/api/Finding {
+public final class io/gitlab/arturbosch/detekt/api/CodeSmell : io/gitlab/arturbosch/detekt/api/Finding {
 	public fun <init> (Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
 	public synthetic fun <init> (Lio/gitlab/arturbosch/detekt/api/Entity;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
-	public final fun getMessage ()Ljava/lang/String;
-	public final fun getReferences ()Ljava/util/List;
-	public final fun getSuppressReasons ()Ljava/util/List;
+	public fun getEntity ()Lio/gitlab/arturbosch/detekt/api/Entity;
+	public fun getMessage ()Ljava/lang/String;
+	public fun getReferences ()Ljava/util/List;
+	public fun getSuppressReasons ()Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CodeSmell.kt
@@ -7,11 +7,11 @@ package io.gitlab.arturbosch.detekt.api
  * If the design problem manifests by different source locations, references to these
  * locations can be stored in additional [Entity]'s.
  */
-open class CodeSmell(
-    final override val entity: Entity,
-    final override val message: String,
-    final override val references: List<Entity> = emptyList(),
-    final override val suppressReasons: List<String> = emptyList(),
+class CodeSmell(
+    override val entity: Entity,
+    override val message: String,
+    override val references: List<Entity> = emptyList(),
+    override val suppressReasons: List<String> = emptyList(),
 ) : Finding {
     init {
         require(message.isNotBlank()) { "The message should not be empty" }


### PR DESCRIPTION
Now we don't need different types of `CodeSmell`s.