### PR TITLE
Remove space in the end of a description

### DIFF
--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/wrappers/AnnotationOnSeparateLine.kt
@@ -17,7 +17,7 @@ import io.gitlab.arturbosch.detekt.formatting.FormattingRule
 @ActiveByDefault(since = "1.22.0")
 class AnnotationOnSeparateLine(config: Config) : FormattingRule(
     config,
-    "Multiple annotations should be placed on separate lines. "
+    "Multiple annotations should be placed on separate lines."
 ) {
 
     override val wrapping = AnnotationRule()


### PR DESCRIPTION
Nit: This space at the end of the rule description does nothing so we can remove it.