### PR TITLE
Simplify test api

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/FormattingRuleSpec.kt
@@ -4,7 +4,6 @@ import io.github.detekt.test.utils.compileForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ChainWrapping
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoLineBreakBeforeAssignment
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
@@ -28,7 +27,7 @@ class FormattingRuleSpec {
 
         @Test
         fun `support suppression on node level`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     @Suppress("NoLineBreakBeforeAssignment")
                     fun main()
@@ -45,7 +44,7 @@ class FormattingRuleSpec {
 
         @Test
         fun `in a file without package name`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun main()
                     = Unit
@@ -57,7 +56,7 @@ class FormattingRuleSpec {
 
         @Test
         fun `with a file with package name`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     package test.test.test
                     fun main()

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -33,7 +33,7 @@ class IndentationSpec {
 
             @Test
             fun `places finding location to the indentation`() {
-                assertThat(subject.compileAndLint(code))
+                assertThat(subject.lint(code))
                     .hasStartSourceLocation(2, 1)
                     .hasTextLocations(13 to 14)
             }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/MaximumLineLengthSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -57,7 +57,7 @@ class MaximumLineLengthSpec {
 
     @Test
     fun `reports correct line numbers`() {
-        val findings = subject.compileAndLint(longLines)
+        val findings = subject.lint(longLines)
 
         // Note that KtLint's MaximumLineLength rule, in contrast to detekt's MaxLineLength rule, does not report
         // exceeded lines in block comments.

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoUnusedImports
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NoUnusedImportsSpec {
@@ -28,7 +28,7 @@ class NoUnusedImportsSpec {
             fun f() = 5
         """.trimIndent()
 
-        val findings = NoUnusedImports(Config.empty).compileAndLint(code)
+        val findings = NoUnusedImports(Config.empty).lint(code)
 
         assertThat(findings)
             .hasSize(3)

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrapperSmokeTestSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrapperSmokeTestSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.github.classgraph.ClassGraph
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
@@ -11,7 +11,7 @@ class WrapperSmokeTestSpec {
     @ParameterizedTest(name = "for rule: {0}")
     @MethodSource("formattingRules")
     fun `smoke test`(subject: FormattingRule) {
-        val result = subject.compileAndLint(
+        val result = subject.lint(
             """
                 fun main() {
                     println("hello world!")

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.formatting
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Wrapping
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
@@ -29,7 +29,7 @@ class WrappingSpec {
             
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code))
+        assertThat(subject.lint(code))
             .hasSize(1)
             .hasStartSourceLocation(1, 12)
             .hasTextLocations(11 to 12)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class CognitiveComplexMethodSpec {
@@ -27,7 +27,7 @@ class CognitiveComplexMethodSpec {
                 return total
             }
         """.trimIndent()
-        val findings = CognitiveComplexMethod(testConfig).compileAndLint(code)
+        val findings = CognitiveComplexMethod(testConfig).lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocations(SourceLocation(1, 5))
     }
@@ -42,7 +42,7 @@ class CognitiveComplexMethodSpec {
                 return 0
             }
         """.trimIndent()
-        val findings = CognitiveComplexMethod(testConfig).compileAndLint(code)
+        val findings = CognitiveComplexMethod(testConfig).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -53,7 +53,7 @@ class CognitiveComplexMethodSpec {
                 return a + b
             }
         """.trimIndent()
-        val findings = CognitiveComplexMethod(testConfig).compileAndLint(code)
+        val findings = CognitiveComplexMethod(testConfig).lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexConditionSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class ComplexConditionSpec {
@@ -20,7 +20,7 @@ class ComplexConditionSpec {
            }
         """.trimIndent()
 
-        val actual = ComplexCondition(testConfig).compileAndLint(code)
+        val actual = ComplexCondition(testConfig).lint(code)
 
         assertThat(actual).hasSize(1)
     }
@@ -35,7 +35,7 @@ class ComplexConditionSpec {
             }
         """.trimIndent()
 
-        val actual = ComplexCondition(testConfig).compileAndLint(code)
+        val actual = ComplexCondition(testConfig).lint(code)
 
         assertThat(actual).isEmpty()
     }
@@ -51,7 +51,7 @@ class ComplexConditionSpec {
              }
         """.trimIndent()
 
-        val actual = ComplexCondition(testConfig).compileAndLint(code)
+        val actual = ComplexCondition(testConfig).lint(code)
 
         assertThat(actual).isEmpty()
     }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ComplexInterfaceSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -31,13 +31,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `reports complex interface`() {
-                assertThat(subject.compileAndLint(code)).hasSize(1)
+                assertThat(subject.lint(code)).hasSize(1)
             }
 
             @Test
             fun `reports complex interface with includeStaticDeclarations config`() {
                 val rule = ComplexInterface(staticDeclarationsConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
         }
 
@@ -56,13 +56,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `reports complex interface`() {
-                assertThat(subject.compileAndLint(code)).hasSize(1)
+                assertThat(subject.lint(code)).hasSize(1)
             }
 
             @Test
             fun `reports complex interface with includeStaticDeclarations config`() {
                 val rule = ComplexInterface(staticDeclarationsConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
         }
 
@@ -81,13 +81,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `does not report static declarations per default`() {
-                assertThat(subject.compileAndLint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
             }
 
             @Test
             fun `reports complex interface with includeStaticDeclarations config`() {
                 val rule = ComplexInterface(staticDeclarationsConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
         }
 
@@ -104,13 +104,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `does not report complex interface`() {
-                assertThat(subject.compileAndLint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
             }
 
             @Test
             fun `does report complex interface with includePrivateDeclarations config`() {
                 val rule = ComplexInterface(privateDeclarationsConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
         }
 
@@ -128,13 +128,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `does not report complex interface`() {
-                assertThat(subject.compileAndLint(code)).isEmpty()
+                assertThat(subject.lint(code)).isEmpty()
             }
 
             @Test
             fun `does report complex interface with includePrivateDeclarations config`() {
                 val rule = ComplexInterface(privateDeclarationsConfig)
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
         }
 
@@ -151,13 +151,13 @@ class ComplexInterfaceSpec {
 
             @Test
             fun `reports complex interface with overloaded methods`() {
-                assertThat(subject.compileAndLint(code)).hasSize(1)
+                assertThat(subject.lint(code)).hasSize(1)
             }
 
             @Test
             fun `does not report simple interface with ignoreOverloaded`() {
                 val rule = ComplexInterface(ignoreOverloadedConfig)
-                assertThat(rule.compileAndLint(code)).isEmpty()
+                assertThat(rule.lint(code)).isEmpty()
             }
 
             @Test
@@ -171,7 +171,7 @@ class ComplexInterfaceSpec {
                     }
                 """.trimIndent()
                 val rule = ComplexInterface(ignoreOverloadedConfig)
-                assertThat(rule.compileAndLint(interfaceWithExtension)).hasSize(1)
+                assertThat(rule.lint(interfaceWithExtension)).hasSize(1)
             }
 
             @Test
@@ -185,7 +185,7 @@ class ComplexInterfaceSpec {
                     }
                 """.trimIndent()
                 val rule = ComplexInterface(ignoreOverloadedConfig)
-                assertThat(rule.compileAndLint(interfaceWithOverloadedExtensions)).isEmpty()
+                assertThat(rule.lint(interfaceWithOverloadedExtensions)).isEmpty()
             }
         }
     }
@@ -206,7 +206,7 @@ class ComplexInterfaceSpec {
                     // a comment shouldn't be detected
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -221,13 +221,13 @@ class ComplexInterfaceSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `does not report an empty interface`() {
             val code = "interface Empty"
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -239,7 +239,7 @@ class ComplexInterfaceSpec {
                     fun func3()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts different loops`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).lint(
                 """
                     fun test() {
                         for (i in 1..10) {}
@@ -34,7 +34,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts catch blocks`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).lint(
                 """
                     fun test() {
                         try {} catch(e: IllegalArgumentException) {} catch(e: Exception) {} finally {}
@@ -47,7 +47,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts nested conditional statements`() {
-            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).compileAndLint(
+            val findings = CyclomaticComplexMethod(TestConfig(defaultAllowedComplexity)).lint(
                 """
                     fun test() {
                         try {
@@ -167,7 +167,7 @@ class CyclomaticComplexMethodSpec {
             )
             val subject = CyclomaticComplexMethod(config)
 
-            assertThat(subject.compileAndLint(code)).hasStartSourceLocations(SourceLocation(39, 5))
+            assertThat(subject.lint(code)).hasStartSourceLocations(SourceLocation(39, 5))
         }
 
         @Test
@@ -175,7 +175,7 @@ class CyclomaticComplexMethodSpec {
             val config = TestConfig("allowedComplexity" to "4")
             val subject = CyclomaticComplexMethod(config)
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(5)
             assertThat(findings).hasStartSourceLocations(
@@ -205,7 +205,7 @@ class CyclomaticComplexMethodSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -233,7 +233,7 @@ class CyclomaticComplexMethodSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -291,13 +291,13 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `should not count these overridden functions to base functions complexity`() {
-            assertThat(CyclomaticComplexMethod(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(CyclomaticComplexMethod(Config.empty).lint(code)).isEmpty()
         }
     }
 }
 
 private fun assertExpectedComplexityValue(code: String, config: TestConfig, expectedValue: Int) {
-    val findings = CyclomaticComplexMethod(config).compileAndLint(code)
+    val findings = CyclomaticComplexMethod(config).lint(code)
 
     assertThat(findings).hasStartSourceLocations(SourceLocation(1, 5))
 

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class LabeledExpressionSpec {
@@ -22,7 +22,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 
     @Test
@@ -36,7 +36,7 @@ class LabeledExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 28)
@@ -52,7 +52,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -71,7 +71,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 
     @Test
@@ -85,7 +85,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -100,7 +100,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -114,7 +114,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -135,7 +135,7 @@ class LabeledExpressionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -146,7 +146,7 @@ class LabeledExpressionSpec {
             }
         """.trimIndent()
         val config = TestConfig("ignoredLabels" to listOf("loop"))
-        val findings = LabeledExpression(config).compileAndLint(code)
+        val findings = LabeledExpression(config).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -158,7 +158,7 @@ class LabeledExpressionSpec {
             }
         """.trimIndent()
         val config = TestConfig("ignoredLabels" to listOf("*loop*", "other"))
-        val findings = LabeledExpression(config).compileAndLint(code)
+        val findings = LabeledExpression(config).lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LargeClassSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 private fun subject(allowedLines: Int) = LargeClass(TestConfig("allowedLines" to allowedLines))
@@ -36,7 +36,7 @@ class LargeClassSpec {
              */
             val aTopLevelPropertyOfNestedClasses = 0
         """.trimIndent()
-        val findings = subject(allowedLines = 4).compileAndLint(code)
+        val findings = subject(allowedLines = 4).lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocations(SourceLocation(7, 15))
     }
@@ -52,7 +52,7 @@ class LargeClassSpec {
             }
         """.trimIndent()
         val rule = subject(allowedLines = 2)
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -68,7 +68,7 @@ class LargeClassSpec {
 
         val rule = subject(allowedLines = 6)
 
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -83,6 +83,6 @@ class LargeClassSpec {
 
         val rule = subject(allowedLines = 6)
 
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongMethodSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class LongMethodSpec {
@@ -26,7 +26,7 @@ class LongMethodSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(2)
         assertThat(findings).hasTextLocations("longMethod", "nestedLongMethod")
@@ -44,7 +44,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -58,7 +58,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -74,7 +74,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(1)
     }
@@ -97,7 +97,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(1)
     }
@@ -124,7 +124,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings)
             .hasSize(2)
@@ -152,7 +152,7 @@ class LongMethodSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings)
             .hasSize(1)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/MethodOverloadingSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ class MethodOverloadingSpec {
                     fun x(i: Int, j: Int) {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0].message).isEqualTo("The method 'x' is overloaded 3 times.")
         }
@@ -36,12 +36,12 @@ class MethodOverloadingSpec {
                 fun x(i: Int) {}
                 fun x(i: Int, j: Int) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `does not report overloaded methods which do not exceed the threshold`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     class Test {
                         fun x() { }
@@ -58,7 +58,7 @@ class MethodOverloadingSpec {
 
         @Test
         fun `does not report extension methods with a different receiver`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun Boolean.foo() {}
                     fun Int.foo() {}
@@ -70,7 +70,7 @@ class MethodOverloadingSpec {
 
         @Test
         fun `reports extension methods with the same receiver`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun Int.foo() {}
                     fun Int.foo(i: Int) {}
@@ -95,7 +95,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -111,7 +111,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -127,7 +127,7 @@ class MethodOverloadingSpec {
                     fun f(i: Int, j: Int) {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -138,7 +138,7 @@ class MethodOverloadingSpec {
                     fun f(i: Int) {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -152,7 +152,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -165,7 +165,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -181,7 +181,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -197,7 +197,7 @@ class MethodOverloadingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -221,7 +221,7 @@ class MethodOverloadingSpec {
                     abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -235,7 +235,7 @@ class MethodOverloadingSpec {
                     fun f() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -249,14 +249,14 @@ class MethodOverloadingSpec {
                     fun f(i: Int, j: Int) {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
     @Test
     fun `does not report a class without a body`() {
         val code = "class A"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -267,7 +267,7 @@ class MethodOverloadingSpec {
                  fun f(i: Int, j: Int) {}
              }
         """.trimIndent()
-        val actual = subject.compileAndLint(code)
+        val actual = subject.lint(code)
 
         assertThat(actual).isEmpty()
     }
@@ -281,6 +281,6 @@ class MethodOverloadingSpec {
                 fun f(i: Int, j: Int) {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedBlockDepthSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NestedBlockDepthSpec {
@@ -53,7 +53,7 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(1)
     }
@@ -72,7 +72,7 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings)
             .hasSize(1)
@@ -91,7 +91,7 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -107,7 +107,7 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -125,6 +125,6 @@ class NestedBlockDepthSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Nested
@@ -30,13 +30,13 @@ class StringLiteralDuplicationSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `does not report 2 equal hardcoded strings`() {
             val code = """val str = "lorem" + "lorem" + "ipsum""""
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -54,7 +54,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `does not report strings in annotations`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -71,7 +71,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `does not report strings with 4 characters`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -125,7 +125,7 @@ class StringLiteralDuplicationSpec {
         fun `should fail with invalid regex`() {
             val config = TestConfig(IGNORE_STRINGS_REGEX to "*lorem")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                StringLiteralDuplication(config).compileAndLint(regexTestingCode)
+                StringLiteralDuplication(config).lint(regexTestingCode)
             }
         }
     }
@@ -143,7 +143,7 @@ class StringLiteralDuplicationSpec {
                     }
                 }
             """.trimIndent()
-            val finding = subject.compileAndLint(code)[0]
+            val finding = subject.lint(code)[0]
             val locations = finding.references.map { it.location } + finding.entity.location
             assertThat(locations).hasSize(3)
         }
@@ -162,7 +162,7 @@ class StringLiteralDuplicationSpec {
                     |
                     ""${'"'}
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -179,11 +179,11 @@ class StringLiteralDuplicationSpec {
             }
         """.trimIndent()
 
-        assertThat(StringLiteralDuplication(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(StringLiteralDuplication(Config.empty).lint(code)).isEmpty()
     }
 }
 
 private fun assertFindingWithConfig(code: String, config: TestConfig, expected: Int) {
-    val findings = StringLiteralDuplication(config).compileAndLint(code)
+    val findings = StringLiteralDuplication(config).lint(code)
     assertThat(findings).hasSize(expected)
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -37,7 +37,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(6 to 7)
     }
@@ -51,7 +51,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(7 to 8)
     }
@@ -65,7 +65,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(10 to 11)
     }
@@ -80,7 +80,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(11 to 12)
     }
@@ -92,7 +92,7 @@ class TooManyFunctionsSpec {
             fun g() = Unit
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).hasSize(1)
+        assertThat(rule.lint(code)).hasSize(1)
     }
 
     @Test
@@ -107,7 +107,7 @@ class TooManyFunctionsSpec {
             fun f3() = Unit
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).hasSize(1)
+        assertThat(rule.lint(code)).hasSize(1)
     }
 
     @Test
@@ -121,7 +121,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(20 to 21)
     }
@@ -148,7 +148,7 @@ class TooManyFunctionsSpec {
 
         @Test
         fun `finds all deprecated functions per default`() {
-            assertThat(rule.compileAndLint(code)).hasSize(2)
+            assertThat(rule.lint(code)).hasSize(2)
         }
 
         @Test
@@ -160,7 +160,7 @@ class TooManyFunctionsSpec {
                     IGNORE_DEPRECATED to "true",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
     }
 
@@ -176,7 +176,7 @@ class TooManyFunctionsSpec {
 
         @Test
         fun `finds the private function per default`() {
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
@@ -188,7 +188,7 @@ class TooManyFunctionsSpec {
                     IGNORE_PRIVATE to "true",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
     }
 
@@ -204,7 +204,7 @@ class TooManyFunctionsSpec {
 
         @Test
         fun `finds the internal function per default`() {
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
@@ -215,7 +215,7 @@ class TooManyFunctionsSpec {
                     IGNORE_INTERNAL to "true",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
 
         @Test
@@ -232,7 +232,7 @@ class TooManyFunctionsSpec {
                     private fun g() {}
                 }
             """.trimIndent()
-            assertThat(configuredRule.compileAndLint(code)).hasSize(1)
+            assertThat(configuredRule.lint(code)).hasSize(1)
         }
     }
 
@@ -268,7 +268,7 @@ class TooManyFunctionsSpec {
                     IGNORE_OVERRIDDEN to "true",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
     }
 
@@ -296,7 +296,7 @@ class TooManyFunctionsSpec {
                     IGNORE_OVERRIDDEN to "true",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
 
         @Test
@@ -308,7 +308,7 @@ class TooManyFunctionsSpec {
                     IGNORE_OVERRIDDEN to "false",
                 )
             )
-            assertThat(configuredRule.compileAndLint(code)).hasSize(1)
+            assertThat(configuredRule.lint(code)).hasSize(1)
         }
     }
 
@@ -337,7 +337,7 @@ class TooManyFunctionsSpec {
                 }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -367,7 +367,7 @@ class TooManyFunctionsSpec {
                 }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -381,7 +381,7 @@ class TooManyFunctionsSpec {
             }
         """.trimIndent()
 
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
 
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/GlobalCoroutineUsageSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class GlobalCoroutineUsageSpec {
                 GlobalScope.launch { delay(1_000L) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -36,7 +36,7 @@ class GlobalCoroutineUsageSpec {
                 GlobalScope.async { delay(1_000L) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -51,7 +51,7 @@ class GlobalCoroutineUsageSpec {
                 bar(GlobalScope)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -67,6 +67,6 @@ class GlobalCoroutineUsageSpec {
                 bar(scope)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivateMethodSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class CommentOverPrivateMethodSpec {
                 private fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -29,7 +29,7 @@ class CommentOverPrivateMethodSpec {
              */
             fun f() {}
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -42,6 +42,6 @@ class CommentOverPrivateMethodSpec {
                 fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/CommentOverPrivatePropertiesSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,7 +16,7 @@ class CommentOverPrivatePropertiesSpec {
              */
             private val v = 1
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -27,7 +27,7 @@ class CommentOverPrivatePropertiesSpec {
              */
             val v = 1
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -40,7 +40,7 @@ class CommentOverPrivatePropertiesSpec {
                 private val v = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -53,6 +53,6 @@ class CommentOverPrivatePropertiesSpec {
                 val v = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/DeprecatedBlockTagSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class DeprecatedBlockTagSpec {
              */
             val v = 2
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Nested
@@ -35,7 +35,7 @@ class DeprecatedBlockTagSpec {
 
         @Test
         fun `correct message`() {
-            assertThat(subject.compileAndLint(code)).singleElement().hasMessage(
+            assertThat(subject.lint(code)).singleElement().hasMessage(
                 "@deprecated tag block does not properly report " +
                     "deprecation in Kotlin, use @Deprecated annotation instead"
             )
@@ -55,7 +55,7 @@ class DeprecatedBlockTagSpec {
                  */
                 class Thing { }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -70,7 +70,7 @@ class DeprecatedBlockTagSpec {
                     val doNotUseMe = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -83,7 +83,7 @@ class DeprecatedBlockTagSpec {
                  */
                 annotation class Thing()
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -98,7 +98,7 @@ class DeprecatedBlockTagSpec {
                     constructor(something: String)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -115,7 +115,7 @@ class DeprecatedBlockTagSpec {
                         set(value) { println(value) }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -132,7 +132,7 @@ class DeprecatedBlockTagSpec {
                         set(value) { println(value) }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -145,7 +145,7 @@ class DeprecatedBlockTagSpec {
                  */
                 typealias VeryString = String
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -27,7 +27,7 @@ class EndOfSentenceFormatSpec {
             fun f(x: Int, y: Int, z: Int) =
                 if (x == 0) y + z else x + y
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -38,7 +38,7 @@ class EndOfSentenceFormatSpec {
                 val test = 3
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -47,7 +47,7 @@ class EndOfSentenceFormatSpec {
             /** Some doc */
             fun test() = 3
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -58,7 +58,7 @@ class EndOfSentenceFormatSpec {
                 fun test() = 3
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -69,7 +69,7 @@ class EndOfSentenceFormatSpec {
                 fun test() = 3
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -81,7 +81,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -95,7 +95,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -106,7 +106,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -120,7 +120,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -140,7 +140,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -155,7 +155,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -167,7 +167,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -179,7 +179,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -191,7 +191,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -203,7 +203,7 @@ class EndOfSentenceFormatSpec {
             class Test {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -218,7 +218,7 @@ class EndOfSentenceFormatSpec {
             class Test2 {
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Nested
@@ -233,7 +233,7 @@ class EndOfSentenceFormatSpec {
                  * This sentence counts too, because it doesn't know where the other ends */
                 fun test() = 3
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
                 .hasStartSourceLocation(2, 2)
                 .hasEndSourceLocation(4, 75)
         }
@@ -247,7 +247,7 @@ class EndOfSentenceFormatSpec {
                     val test = 3
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
                 .hasStartSourceLocation(2, 8)
                 .hasEndSourceLocation(3, 80)
         }
@@ -262,7 +262,7 @@ class EndOfSentenceFormatSpec {
                  */
                 class Test
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
                 .hasStartSourceLocation(2, 2)
                 .hasEndSourceLocation(4, 74)
         }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/KDocReferencesNonPublicPropertySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class KDocReferencesNonPublicPropertySpec {
@@ -22,7 +22,7 @@ class KDocReferencesNonPublicPropertySpec {
                 val prop2 = 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -39,7 +39,7 @@ class KDocReferencesNonPublicPropertySpec {
                 val prop2: Int = 0,
             )
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -56,7 +56,7 @@ class KDocReferencesNonPublicPropertySpec {
                 val prop2 = 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -85,7 +85,7 @@ class KDocReferencesNonPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(4)
+        assertThat(subject.lint(code)).hasSize(4)
     }
 
     @Test
@@ -96,7 +96,7 @@ class KDocReferencesNonPublicPropertySpec {
                 val prop2 = 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -109,7 +109,7 @@ class KDocReferencesNonPublicPropertySpec {
                 val prop2 = 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -122,7 +122,7 @@ class KDocReferencesNonPublicPropertySpec {
             private val prop1 = 0
             val prop2 = 0
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -147,7 +147,7 @@ class KDocReferencesNonPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -172,7 +172,7 @@ class KDocReferencesNonPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -195,7 +195,7 @@ class KDocReferencesNonPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -220,6 +220,6 @@ class KDocReferencesNonPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentationSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -17,7 +17,7 @@ class OutdatedDocumentationSpec {
             val withoutDoc = """
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(withoutDoc)).isEmpty()
+            assertThat(subject.lint(withoutDoc)).isEmpty()
         }
 
         @Test
@@ -28,7 +28,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(docWithoutParamAndPropertyTags)).isEmpty()
+            assertThat(subject.lint(docWithoutParamAndPropertyTags)).isEmpty()
         }
     }
 
@@ -42,7 +42,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctParam)).isEmpty()
+            assertThat(subject.lint(correctParam)).isEmpty()
         }
 
         @Test
@@ -53,7 +53,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectParamName)).hasSize(1)
         }
 
         @Test
@@ -65,7 +65,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectListOfParams)).hasSize(1)
+            assertThat(subject.lint(incorrectListOfParams)).hasSize(1)
         }
 
         @Test
@@ -77,7 +77,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String, someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectParamOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectParamOrder)).hasSize(1)
         }
 
         @Test
@@ -89,7 +89,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctParamAndProp)).isEmpty()
+            assertThat(subject.lint(correctParamAndProp)).isEmpty()
         }
 
         @Test
@@ -101,7 +101,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val otherProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctParamIncorrectProp)).hasSize(1)
+            assertThat(subject.lint(correctParamIncorrectProp)).hasSize(1)
         }
 
         @Test
@@ -113,7 +113,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectParamCorrectProp)).hasSize(1)
+            assertThat(subject.lint(incorrectParamCorrectProp)).hasSize(1)
         }
 
         @Test
@@ -126,7 +126,7 @@ class OutdatedDocumentationSpec {
                     constructor(otherParam: String)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectConstructorDoc)).hasSize(1)
+            assertThat(subject.lint(incorrectConstructorDoc)).hasSize(1)
         }
 
         @Test
@@ -138,7 +138,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(propertyAsParam)).hasSize(1)
+            assertThat(subject.lint(propertyAsParam)).hasSize(1)
         }
 
         @Test
@@ -150,7 +150,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
         }
 
         @Test
@@ -162,7 +162,7 @@ class OutdatedDocumentationSpec {
                  */
                 class A internal constructor(val b: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).isEmpty()
+            assertThat(subject.lint(incorrectDeclarationsOrder)).isEmpty()
         }
 
         @Test
@@ -174,7 +174,7 @@ class OutdatedDocumentationSpec {
                  */
                 class A private constructor(val b: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).isEmpty()
+            assertThat(subject.lint(incorrectDeclarationsOrder)).isEmpty()
         }
 
         @Test
@@ -189,7 +189,7 @@ class OutdatedDocumentationSpec {
             assertThat(
                 OutdatedDocumentation(
                     TestConfig("allowParamOnConstructorProperties" to "true")
-                ).compileAndLint(incorrectDeclarationsOrder)
+                ).lint(incorrectDeclarationsOrder)
             ).isEmpty()
         }
 
@@ -202,7 +202,7 @@ class OutdatedDocumentationSpec {
                  */
                 class A internal constructor(val a: String, val b: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
         }
 
         @Test
@@ -215,7 +215,7 @@ class OutdatedDocumentationSpec {
                  */
                 class A internal constructor(val a: String, val b: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
         }
 
         @Test
@@ -232,7 +232,7 @@ class OutdatedDocumentationSpec {
                     c: Int,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
         }
 
         @Test
@@ -248,7 +248,7 @@ class OutdatedDocumentationSpec {
                     c: Int,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
         }
 
         @Test
@@ -262,7 +262,7 @@ class OutdatedDocumentationSpec {
                     private val a: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -278,7 +278,7 @@ class OutdatedDocumentationSpec {
                     protected val b: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -292,7 +292,7 @@ class OutdatedDocumentationSpec {
                     private val a: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -308,7 +308,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
+            assertThat(subject.lint(correctTypeParam)).isEmpty()
         }
 
         @Test
@@ -320,7 +320,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
+            assertThat(subject.lint(correctTypeParam)).isEmpty()
         }
 
         @Test
@@ -331,7 +331,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(missingTypeParam)).hasSize(1)
+            assertThat(subject.lint(missingTypeParam)).hasSize(1)
         }
 
         @Test
@@ -343,7 +343,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectTypeParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamName)).hasSize(1)
         }
 
         @Test
@@ -355,7 +355,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T, S>(someParam: String)
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectTypeParamList)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamList)).hasSize(1)
         }
     }
 
@@ -370,7 +370,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctDoc)).isEmpty()
+            assertThat(subject.lint(correctDoc)).isEmpty()
         }
 
         @Test
@@ -381,7 +381,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun myFun(otherParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectParamName)).hasSize(1)
         }
     }
 
@@ -397,7 +397,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctTypeParam)).isEmpty()
+            assertThat(subject.lint(correctTypeParam)).isEmpty()
         }
 
         @Test
@@ -408,7 +408,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(missingTypeParam)).hasSize(1)
+            assertThat(subject.lint(missingTypeParam)).hasSize(1)
         }
 
         @Test
@@ -420,7 +420,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectTypeParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamName)).hasSize(1)
         }
 
         @Test
@@ -432,7 +432,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectTypeParamList)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamList)).hasSize(1)
         }
 
         @Test
@@ -445,7 +445,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectTypeParamsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamsOrder)).hasSize(1)
         }
     }
 
@@ -465,7 +465,7 @@ class OutdatedDocumentationSpec {
                     fun myFun(someParam: String) {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(correctClassWithFunction)).isEmpty()
+            assertThat(subject.lint(correctClassWithFunction)).isEmpty()
         }
 
         @Test
@@ -489,7 +489,7 @@ class OutdatedDocumentationSpec {
                     class MyNestedClass(otherParam: String)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(incorrectClassWithTwoIncorrectFunctions)).hasSize(4)
+            assertThat(subject.lint(incorrectClassWithTwoIncorrectFunctions)).hasSize(4)
         }
     }
 
@@ -506,7 +506,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T, S>(someParam: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(incorrectClassTypeParams)).isEmpty()
+            assertThat(configuredSubject.lint(incorrectClassTypeParams)).isEmpty()
         }
 
         @Test
@@ -517,7 +517,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(incorrectFunctionTypeParams)).isEmpty()
+            assertThat(configuredSubject.lint(incorrectFunctionTypeParams)).isEmpty()
         }
     }
 
@@ -535,7 +535,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String, someParam: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrder)).isEmpty()
+            assertThat(configuredSubject.lint(incorrectDeclarationsOrder)).isEmpty()
         }
 
         @Test
@@ -549,7 +549,7 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(otherParam: String, someParam: String) {}
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(incorrectDeclarationsOrderWithType)).isEmpty()
+            assertThat(configuredSubject.lint(incorrectDeclarationsOrderWithType)).isEmpty()
         }
     }
 
@@ -568,7 +568,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            assertThat(configuredSubject.lint(propertyAsParam)).isEmpty()
         }
 
         @Test
@@ -580,7 +580,7 @@ class OutdatedDocumentationSpec {
                  */
                 open class MyClass(internal val a: String, protected val b: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            assertThat(configuredSubject.lint(propertyAsParam)).isEmpty()
         }
 
         @Test
@@ -592,7 +592,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            assertThat(configuredSubject.lint(propertyAsParam)).isEmpty()
         }
     }
 
@@ -614,7 +614,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            assertThat(configuredSubject.lint(propertyAsParam)).isEmpty()
         }
 
         @Test
@@ -626,7 +626,7 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(configuredSubject.compileAndLint(propertyAsParam)).isEmpty()
+            assertThat(configuredSubject.lint(propertyAsParam)).isEmpty()
         }
 
         @Test
@@ -640,7 +640,7 @@ class OutdatedDocumentationSpec {
                     private val a: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicClassSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -64,62 +64,62 @@ class UndocumentedPublicClassSpec {
 
     @Test
     fun `should report inner classes by default`() {
-        assertThat(subject.compileAndLint(inner)).hasSize(1)
+        assertThat(subject.lint(inner)).hasSize(1)
     }
 
     @Test
     fun `should report inner object by default`() {
-        assertThat(subject.compileAndLint(innerObject)).hasSize(1)
+        assertThat(subject.lint(innerObject)).hasSize(1)
     }
 
     @Test
     fun `should report inner interfaces by default`() {
-        assertThat(subject.compileAndLint(innerInterface)).hasSize(1)
+        assertThat(subject.lint(innerInterface)).hasSize(1)
     }
 
     @Test
     fun `should report nested classes by default`() {
-        assertThat(subject.compileAndLint(nested)).hasSize(1)
+        assertThat(subject.lint(nested)).hasSize(1)
     }
 
     @Test
     fun `should report explicit public nested classes by default`() {
-        assertThat(subject.compileAndLint(nestedPublic)).hasSize(1)
+        assertThat(subject.lint(nestedPublic)).hasSize(1)
     }
 
     @Test
     fun `should not report internal classes`() {
-        assertThat(subject.compileAndLint(internalClass)).isEmpty()
+        assertThat(subject.lint(internalClass)).isEmpty()
     }
 
     @Test
     fun `should not report private classes`() {
-        assertThat(subject.compileAndLint(privateClass)).isEmpty()
+        assertThat(subject.lint(privateClass)).isEmpty()
     }
 
     @Test
     fun `should not report nested private classes`() {
-        assertThat(subject.compileAndLint(nestedPrivate)).isEmpty()
+        assertThat(subject.lint(nestedPrivate)).isEmpty()
     }
 
     @Test
     fun `should not report inner classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_CLASS to "false")).compileAndLint(inner)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_CLASS to "false")).lint(inner)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner objects when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_OBJECT to "false")).compileAndLint(innerObject)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_OBJECT to "false")).lint(innerObject)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner interfaces when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_INTERFACE to "false")).compileAndLint(
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_INTERFACE to "false")).lint(
                 innerInterface
             )
         assertThat(findings).isEmpty()
@@ -128,13 +128,13 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `should not report nested classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_NESTED_CLASS to "false")).compileAndLint(nested)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_NESTED_CLASS to "false")).lint(nested)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report missing doc over object declaration`() {
-        assertThat(subject.compileAndLint("object o")).hasSize(1)
+        assertThat(subject.lint("object o")).hasSize(1)
     }
 
     @Test
@@ -145,7 +145,7 @@ class UndocumentedPublicClassSpec {
                 inner class Inner
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -155,7 +155,7 @@ class UndocumentedPublicClassSpec {
                 interface Inner
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -165,7 +165,7 @@ class UndocumentedPublicClassSpec {
                 object Inner
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -185,7 +185,7 @@ class UndocumentedPublicClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -198,7 +198,7 @@ class UndocumentedPublicClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -214,7 +214,7 @@ class UndocumentedPublicClassSpec {
                 fun onComplete()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -228,7 +228,7 @@ class UndocumentedPublicClassSpec {
                 fun abstractMethod()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -241,7 +241,7 @@ class UndocumentedPublicClassSpec {
                 protected class ProtectedClass
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -255,7 +255,7 @@ class UndocumentedPublicClassSpec {
             }
         """.trimIndent()
         val subject = UndocumentedPublicClass(TestConfig(SEARCH_IN_PROTECTED_CLASS to "true"))
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -267,7 +267,7 @@ class UndocumentedPublicClassSpec {
                 public companion object
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 
     @Test
@@ -301,7 +301,7 @@ class UndocumentedPublicClassSpec {
         assertThat(
             UndocumentedPublicClass(
                 TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
-            ).compileAndLint(code)
+            ).lint(code)
         ).isEmpty()
     }
 
@@ -336,7 +336,7 @@ class UndocumentedPublicClassSpec {
         assertThat(
             UndocumentedPublicClass(
                 TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
-            ).compileAndLint(code)
+            ).lint(code)
         ).hasSize(4)
     }
 
@@ -363,7 +363,7 @@ class UndocumentedPublicClassSpec {
         assertThat(
             UndocumentedPublicClass(
                 TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
-            ).compileAndLint(code)
+            ).lint(code)
         ).hasSize(3)
     }
 
@@ -378,7 +378,7 @@ class UndocumentedPublicClassSpec {
                 private companion object
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Nested
@@ -394,7 +394,7 @@ class UndocumentedPublicClassSpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -405,7 +405,7 @@ class UndocumentedPublicClassSpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -421,7 +421,7 @@ class UndocumentedPublicClassSpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicFunctionSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -17,7 +17,7 @@ class UndocumentedPublicFunctionSpec {
         val code = """
             fun noComment1() {}
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -27,7 +27,7 @@ class UndocumentedPublicFunctionSpec {
                 fun noComment1() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -39,7 +39,7 @@ class UndocumentedPublicFunctionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -52,7 +52,7 @@ class UndocumentedPublicFunctionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -62,7 +62,7 @@ class UndocumentedPublicFunctionSpec {
                 fun noComment1()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -73,7 +73,7 @@ class UndocumentedPublicFunctionSpec {
              */
             fun commented1() {}
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -86,7 +86,7 @@ class UndocumentedPublicFunctionSpec {
                 fun commented() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -97,7 +97,7 @@ class UndocumentedPublicFunctionSpec {
                 private fun no2(){}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -110,7 +110,7 @@ class UndocumentedPublicFunctionSpec {
                 fun iDontNeedDoc() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -121,7 +121,7 @@ class UndocumentedPublicFunctionSpec {
                 public fun nope2() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -132,7 +132,7 @@ class UndocumentedPublicFunctionSpec {
                 public fun nope2() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -142,7 +142,7 @@ class UndocumentedPublicFunctionSpec {
                 fun noComment1() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -152,7 +152,7 @@ class UndocumentedPublicFunctionSpec {
                 protected fun noComment1() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -163,7 +163,7 @@ class UndocumentedPublicFunctionSpec {
             }
         """.trimIndent()
         val subject = UndocumentedPublicFunction(TestConfig(SEARCH_PROTECTED_FUN to "true"))
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Nested
@@ -178,7 +178,7 @@ class UndocumentedPublicFunctionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -193,7 +193,7 @@ class UndocumentedPublicFunctionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -206,7 +206,7 @@ class UndocumentedPublicFunctionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.documentation
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class UndocumentedPublicPropertySpec {
     @Test
     fun `reports undocumented public property`() {
         val code = "val a = 1"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -25,7 +25,7 @@ class UndocumentedPublicPropertySpec {
                 val a = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -37,7 +37,7 @@ class UndocumentedPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -50,7 +50,7 @@ class UndocumentedPublicPropertySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -60,19 +60,19 @@ class UndocumentedPublicPropertySpec {
                 val a: Int
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `reports undocumented public properties in a primary constructor`() {
         val code = "class Test(val a: Int)"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `reports undocumented public property in a primary constructor`() {
         val code = "/* comment */ class Test(val a: Int)"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -83,7 +83,7 @@ class UndocumentedPublicPropertySpec {
              */
             val a = 1
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -96,7 +96,7 @@ class UndocumentedPublicPropertySpec {
                 val a = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -113,7 +113,7 @@ class UndocumentedPublicPropertySpec {
                 override val a = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -124,7 +124,7 @@ class UndocumentedPublicPropertySpec {
                 private val b = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -134,7 +134,7 @@ class UndocumentedPublicPropertySpec {
                 var a = x
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -145,7 +145,7 @@ class UndocumentedPublicPropertySpec {
                 val b = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -156,7 +156,7 @@ class UndocumentedPublicPropertySpec {
                 val b = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -166,7 +166,7 @@ class UndocumentedPublicPropertySpec {
                 constructor(a: Int) : this()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -175,13 +175,13 @@ class UndocumentedPublicPropertySpec {
             class Test1(internal val a: Int)
             class Test2(b: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `does not report undocumented public properties in a primary constructor for an internal class`() {
         val code = "internal class Test(val a: Int)"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -204,7 +204,7 @@ class UndocumentedPublicPropertySpec {
                 val e: Int
             )
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -214,7 +214,7 @@ class UndocumentedPublicPropertySpec {
                 val a = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -224,7 +224,7 @@ class UndocumentedPublicPropertySpec {
                 protected val a = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -235,7 +235,7 @@ class UndocumentedPublicPropertySpec {
             }
         """.trimIndent()
         val subject = UndocumentedPublicProperty(TestConfig(SEARCH_PROTECTED_PROPERTY to "true"))
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -250,7 +250,7 @@ class UndocumentedPublicPropertySpec {
                 val bar = 2
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -265,7 +265,7 @@ class UndocumentedPublicPropertySpec {
                 val bar = 2
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Nested
@@ -284,7 +284,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -296,7 +296,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -308,7 +308,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -326,7 +326,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .singleElement()
                 .hasSourceLocation(9, 13)
@@ -347,7 +347,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .singleElement()
                 .hasSourceLocation(2, 9)
@@ -362,7 +362,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -374,7 +374,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -390,7 +390,7 @@ class UndocumentedPublicPropertySpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(3)
+            assertThat(subject.lint(code)).hasSize(3)
         }
 
         @Test
@@ -400,7 +400,7 @@ class UndocumentedPublicPropertySpec {
                     inner class Inner(val b: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -410,7 +410,7 @@ class UndocumentedPublicPropertySpec {
                     class Inner(val a: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -420,7 +420,7 @@ class UndocumentedPublicPropertySpec {
                     class Inner(val b: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -430,7 +430,7 @@ class UndocumentedPublicPropertySpec {
                     inner class Inner(val b: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -447,7 +447,7 @@ class UndocumentedPublicPropertySpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -467,7 +467,7 @@ class UndocumentedPublicPropertySpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -489,7 +489,7 @@ class UndocumentedPublicPropertySpec {
                     Bar,
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyClassBlockSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class EmptyClassBlockSpec {
@@ -12,7 +12,7 @@ class EmptyClassBlockSpec {
     @Test
     fun `reports the empty class body`() {
         val code = "class SomeClass {}"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -22,7 +22,7 @@ class EmptyClassBlockSpec {
                 // Some comment to explain what this class is supposed to do
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -34,7 +34,7 @@ class EmptyClassBlockSpec {
                 */
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -44,13 +44,13 @@ class EmptyClassBlockSpec {
                 class EmptyClass {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `reports the empty object body`() {
         val code = "object SomeObject {}"
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(18 to 20)
     }
@@ -64,6 +64,6 @@ class EmptyClassBlockSpec {
                  object : Open() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyCodeSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
@@ -39,7 +38,7 @@ class EmptyCodeSpec {
                 }
             }
         """.trimIndent()
-        assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EmptyCatchBlock(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -52,7 +51,7 @@ class EmptyCodeSpec {
                 }
             }
         """.trimIndent()
-        assertThat(EmptyCatchBlock(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EmptyCatchBlock(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -65,7 +64,7 @@ class EmptyCodeSpec {
             }
         """.trimIndent()
         val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "foo")
-        assertThat(EmptyCatchBlock(config).compileAndLint(code)).isEmpty()
+        assertThat(EmptyCatchBlock(config).lint(code)).isEmpty()
     }
 
     @Test
@@ -131,14 +130,14 @@ class EmptyCodeSpec {
     @Test
     fun `reports an empty kotlin file`() {
         val rule = EmptyKotlinFile(Config.empty)
-        assertThat(rule.compileAndLint("")).hasSize(1)
+        assertThat(rule.lint("")).hasSize(1)
     }
 
     @Test
     fun doesFailWithInvalidRegex() {
         val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "*foo")
         assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            EmptyCatchBlock(config).compileAndLint(regexTestingCode)
+            EmptyCatchBlock(config).lint(regexTestingCode)
         }
     }
 }
@@ -146,63 +145,62 @@ class EmptyCodeSpec {
 // Each Empty* Rule is tested on the same code to make sure they're all detecting distinct problems.
 @Suppress("LongMethod")
 private fun test(block: () -> Rule) {
-    val rule = block()
-    val findings = rule.lint(
-        """
-            class Empty : Runnable {
-            
-                init {
-            
-                }
-            
-                constructor() {
-            
-                }
-            
-                override fun run() {
-            
-                }
-            
-                fun stuff() {
-                    try {
-            
-                    } catch (e: Exception) {
-            
-                    } catch (e: Exception) {
-                        //no-op
-                    } catch (e: Exception) {
-                        println()
-                    } catch (ignored: Exception) {
-            
-                    } catch (expected: Exception) {
-            
-                    } catch (_: Exception) {
-            
-                    } finally {
-            
-                    }
-                    if (true) {
-            
-                    } else {
-            
-                    }
-                    when (true) {
-            
-                    }
-                    for (i in 1..10) {
-            
-                    }
-                    while (true) {
-            
-                    }
-                    do {
-            
-                    } while (true)
-                }
+    val code = """
+        class Empty : Runnable {
+        
+            init {
+        
             }
-            
-            class EmptyClass() {}
-        """.trimIndent()
-    )
+        
+            constructor() {
+        
+            }
+        
+            override fun run() {
+        
+            }
+        
+            fun stuff() {
+                try {
+        
+                } catch (e: Exception) {
+        
+                } catch (e: Exception) {
+                    //no-op
+                } catch (e: Exception) {
+                    println()
+                } catch (ignored: Exception) {
+        
+                } catch (expected: Exception) {
+        
+                } catch (_: Exception) {
+        
+                } finally {
+        
+                }
+                if (true) {
+        
+                } else {
+        
+                }
+                when (true) {
+        
+                }
+                for (i in 1..10) {
+        
+                }
+                while (true) {
+        
+                }
+                do {
+        
+                } while (true)
+            }
+        }
+        
+        class EmptyClass() {}
+    """.trimIndent()
+    val rule = block()
+    val findings = rule.lint(code, compile = false)
     assertThat(findings).hasSize(1)
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructorSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyDefaultConstructorSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -13,7 +12,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class EmptyConstructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -21,7 +20,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class EmptyPrimaryConstructor constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -29,7 +28,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class EmptyPublicPrimaryConstructor public constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -37,7 +36,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class PrimaryConstructorWithParameter constructor(x: Int)
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -45,7 +44,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class PrimaryConstructorWithAnnotation @SafeVarargs constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -53,7 +52,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             class PrivatePrimaryConstructor private constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -64,7 +63,7 @@ internal class EmptyDefaultConstructorSpec {
                 constructor(i: Int) : this()
             }
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -72,7 +71,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             expect class NeedsConstructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code, compile = false)).isEmpty()
     }
 
     @Test
@@ -80,7 +79,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             actual class NeedsConstructor actual constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code, compile = false)).isEmpty()
     }
 
     @Test
@@ -88,7 +87,7 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             expect annotation class NeedsConstructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code, compile = false)).isEmpty()
     }
 
     @Test
@@ -96,6 +95,6 @@ internal class EmptyDefaultConstructorSpec {
         val code = """
             actual annotation class NeedsConstructor actual constructor()
         """.trimIndent()
-        assertThat(EmptyDefaultConstructor(Config.empty).lint(code)).isEmpty()
+        assertThat(EmptyDefaultConstructor(Config.empty).lint(code, compile = false)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyElseBlockSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class EmptyElseBlockSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -34,7 +34,7 @@ class EmptyElseBlockSpec {
                 } else ;
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -49,7 +49,7 @@ class EmptyElseBlockSpec {
                 i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -64,7 +64,7 @@ class EmptyElseBlockSpec {
                 i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -79,7 +79,7 @@ class EmptyElseBlockSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -92,7 +92,7 @@ class EmptyElseBlockSpec {
                 } else i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -105,6 +105,6 @@ class EmptyElseBlockSpec {
                 } else i++;
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.empty
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class EmptyFunctionBlockSpec {
                 protected fun stuff() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 27)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 27)
     }
 
     @Test
@@ -30,7 +30,7 @@ class EmptyFunctionBlockSpec {
                 open fun stuff() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -40,7 +40,7 @@ class EmptyFunctionBlockSpec {
                 fun stuff() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -50,7 +50,7 @@ class EmptyFunctionBlockSpec {
                 fun b() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 13)
+        assertThat(subject.lint(code)).hasStartSourceLocation(2, 13)
     }
 
     @Nested
@@ -82,13 +82,13 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should flag empty block in overridden function`() {
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
         fun `should not flag overridden functions`() {
             val config = TestConfig(IGNORE_OVERRIDDEN to "true")
-            assertThat(EmptyFunctionBlock(config).compileAndLint(code)).hasStartSourceLocation(1, 13)
+            assertThat(EmptyFunctionBlock(config).lint(code)).hasStartSourceLocation(1, 13)
         }
     }
 
@@ -114,13 +114,13 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions with commented body`() {
-            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(12, 31)
+            assertThat(subject.lint(code)).hasStartSourceLocation(12, 31)
         }
 
         @Test
         fun `should not flag overridden functions with ignoreOverridden`() {
             val config = TestConfig(IGNORE_OVERRIDDEN to "true")
-            assertThat(EmptyFunctionBlock(config).compileAndLint(code)).isEmpty()
+            assertThat(EmptyFunctionBlock(config).lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyIfBlockSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class EmptyIfBlockSpec {
                 i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -31,7 +31,7 @@ class EmptyIfBlockSpec {
                 i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -44,7 +44,7 @@ class EmptyIfBlockSpec {
                 i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -57,7 +57,7 @@ class EmptyIfBlockSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -68,7 +68,7 @@ class EmptyIfBlockSpec {
                 if (i == 0) i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -79,7 +79,7 @@ class EmptyIfBlockSpec {
                 if (i == 0) i++;
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -91,7 +91,7 @@ class EmptyIfBlockSpec {
                 else i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -104,6 +104,6 @@ class EmptyIfBlockSpec {
                 else i++
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyKotlinFileSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.empty
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class EmptyKotlinFileSpec {
@@ -11,7 +11,7 @@ class EmptyKotlinFileSpec {
     @Test
     fun `reports empty if file is blank`() {
         val code = ""
-        assertThat(subject.compileAndLint(code))
+        assertThat(subject.lint(code))
             .singleElement()
             .hasSourceLocation(1, 1)
     }
@@ -21,7 +21,7 @@ class EmptyKotlinFileSpec {
         val codeWithPackageStatement = """
             package my.packagee
         """.trimIndent()
-        assertThat(subject.compileAndLint(codeWithPackageStatement))
+        assertThat(subject.lint(codeWithPackageStatement))
             .singleElement()
             .hasSourceLocation(1, 1)
     }
@@ -33,6 +33,6 @@ class EmptyKotlinFileSpec {
 
             fun myFunction() {}
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsAlwaysReturnsTrueOrFalseSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -58,7 +58,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(6)
+        assertThat(subject.lint(code)).hasSize(6)
     }
 
     @Test
@@ -107,7 +107,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -120,7 +120,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -133,7 +133,7 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 override fun hashCode(): Int = text.hashCode()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -150,6 +150,6 @@ class EqualsAlwaysReturnsTrueOrFalseSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/EqualsWithHashCodeExistSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -29,7 +29,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun equals(other: Any?): Boolean { return super.equals(other) }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -40,7 +40,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -51,7 +51,7 @@ class EqualsWithHashCodeExistSpec {
                     fun hashCode(i: Int): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -66,7 +66,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -81,7 +81,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(i: Int): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -92,7 +92,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -103,7 +103,7 @@ class EqualsWithHashCodeExistSpec {
                     override fun hashCode(): Int { return super.hashCode() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -120,7 +120,7 @@ class EqualsWithHashCodeExistSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -137,7 +137,7 @@ class EqualsWithHashCodeExistSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -153,7 +153,7 @@ class EqualsWithHashCodeExistSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExplicitGarbageCollectionCallSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,6 +17,6 @@ class ExplicitGarbageCollectionCallSpec {
                 System.runFinalization()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/InvalidRangeSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ class InvalidRangeSpec {
                     for (i in (1+1)..3) { }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -38,7 +38,7 @@ class InvalidRangeSpec {
                     for (i in 2 until 1 step 2) { }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(5)
+            assertThat(subject.lint(code)).hasSize(5)
         }
 
         @Test
@@ -50,7 +50,7 @@ class InvalidRangeSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -60,13 +60,13 @@ class InvalidRangeSpec {
         @Test
         fun `reports for '__'`() {
             val code = "val r = 2..1"
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `does not report binary expressions without an invalid range`() {
             val code = "val sum = 1 + 2"
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorHasNextCallsNextMethodSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -63,7 +63,7 @@ class IteratorHasNextCallsNextMethodSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(4)
+        assertThat(subject.lint(code)).hasSize(4)
     }
 
     @Test
@@ -91,6 +91,6 @@ class IteratorHasNextCallsNextMethodSpec {
             
             abstract class AbstractIteratorNotOverridden : Iterator<String>
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IteratorNotThrowingNoSuchElementExceptionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -63,7 +63,7 @@ class IteratorNotThrowingNoSuchElementExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(4)
+        assertThat(subject.lint(code)).hasSize(4)
     }
 
     @Test
@@ -91,6 +91,6 @@ class IteratorNotThrowingNoSuchElementExceptionSpec {
             
             abstract class AbstractIteratorNotOverridden : Iterator<String>
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/LateinitUsageSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Test
@@ -21,28 +21,28 @@ class LateinitUsageSpec {
 
     @Test
     fun `should report lateinit usages`() {
-        val findings = LateinitUsage(Config.empty).compileAndLint(code)
+        val findings = LateinitUsage(Config.empty).lint(code)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     fun `should report lateinit properties when ignoreOnClassesPattern does not match`() {
         val findings =
-            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234")).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test1234")).lint(code)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     fun `should not report lateinit properties when ignoreOnClassesPattern does match`() {
         val findings =
-            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test")).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "[\\w]+Test")).lint(code)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should fail when enabled with faulty regex pattern`() {
         assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "*Test")).compileAndLint(code)
+            LateinitUsage(TestConfig(IGNORE_ON_CLASSES_PATTERN to "*Test")).lint(code)
         }
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingPackageDeclarationSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 internal class MissingPackageDeclarationSpec {
@@ -14,7 +14,7 @@ internal class MissingPackageDeclarationSpec {
             
             class C
         """.trimIndent()
-        val findings = MissingPackageDeclaration(Config.empty).compileAndLint(code)
+        val findings = MissingPackageDeclaration(Config.empty).lint(code)
 
         assertThat(findings).isEmpty()
     }
@@ -23,7 +23,7 @@ internal class MissingPackageDeclarationSpec {
     fun `should report if package declaration is missing`() {
         val code = "class C"
 
-        val findings = MissingPackageDeclaration(Config.empty).compileAndLint(code)
+        val findings = MissingPackageDeclaration(Config.empty).lint(code)
 
         assertThat(findings).hasSize(1)
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnconditionalJumpStatementInLoopSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 for (i in 1..2) return
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -25,7 +25,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 while (true) { return }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -35,7 +35,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 do { return } while(true)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -45,7 +45,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 for (i in 1..2) continue
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -55,7 +55,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 while (true) { continue }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -65,7 +65,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 do { continue } while(true)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -75,7 +75,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 for (i in 1..2) break
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -85,7 +85,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 while (true) { break }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -95,7 +95,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 do { break } while(true)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -109,7 +109,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -123,7 +123,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -137,7 +137,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -152,7 +152,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -167,7 +167,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -182,7 +182,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -195,7 +195,7 @@ class UnconditionalJumpStatementInLoopSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -209,7 +209,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -223,7 +223,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -238,7 +238,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -253,7 +253,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -268,7 +268,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -281,7 +281,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -294,7 +294,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -307,7 +307,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -322,12 +322,12 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `does not report a return after a conditional jump`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 fun f(): Int {
                     for (i in 0 until 10) {
@@ -364,7 +364,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 while (true) this.poll()?.let { action(it) } ?: break
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     // https://github.com/detekt/detekt/issues/6657
@@ -385,7 +385,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -406,7 +406,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -426,7 +426,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -446,7 +446,7 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -466,6 +466,6 @@ class UnconditionalJumpStatementInLoopSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UselessPostfixExpressionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class UselessPostfixExpressionSpec {
                     i = i++ + 1 // invalid
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(3)
+            assertThat(subject.lint(code)).hasSize(3)
         }
 
         @Test
@@ -34,7 +34,7 @@ class UselessPostfixExpressionSpec {
                     j = i++
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -47,7 +47,7 @@ class UselessPostfixExpressionSpec {
                     return i++
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -58,7 +58,7 @@ class UselessPostfixExpressionSpec {
                     return id++.toString()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -87,7 +87,7 @@ class UselessPostfixExpressionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -109,7 +109,7 @@ class UselessPostfixExpressionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
     }
 
@@ -129,7 +129,7 @@ class UselessPostfixExpressionSpec {
                     return str!!.count()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -140,7 +140,7 @@ class UselessPostfixExpressionSpec {
                     str!!
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/WrongEqualsTypeParameterSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class WrongEqualsTypeParameterSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -29,7 +29,7 @@ class WrongEqualsTypeParameterSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -41,7 +41,7 @@ class WrongEqualsTypeParameterSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -60,7 +60,7 @@ class WrongEqualsTypeParameterSpec {
                 override fun equals() = true
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -70,7 +70,7 @@ class WrongEqualsTypeParameterSpec {
                 fun equals(other: String)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -79,6 +79,6 @@ class WrongEqualsTypeParameterSpec {
             fun equals(other: String) {}
             fun equals(other: Any?) {}
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ExceptionRaisedInUnexpectedLocationSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -47,7 +47,7 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(5)
+        assertThat(subject.lint(code)).hasSize(5)
     }
 
     @Test
@@ -86,13 +86,13 @@ class ExceptionRaisedInUnexpectedLocationSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `reports the configured method`() {
         val config = TestConfig("methodNames" to listOf("toDo", "todo2"))
-        val findings = ExceptionRaisedInUnexpectedLocation(config).compileAndLint(
+        val findings = ExceptionRaisedInUnexpectedLocation(config).lint(
             """
                 fun toDo() {
                     throw IllegalStateException()

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/NotImplementedDeclarationSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,7 +16,7 @@ class NotImplementedDeclarationSpec {
                 throw NotImplementedError()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -27,7 +27,7 @@ class NotImplementedDeclarationSpec {
                 TODO()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -37,6 +37,6 @@ class NotImplementedDeclarationSpec {
                 // TODO
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class PrintStackTraceSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -38,7 +38,7 @@ class PrintStackTraceSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -55,7 +55,7 @@ class PrintStackTraceSpec {
                     dumpStack()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/RethrowCaughtExceptionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -35,7 +35,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -49,7 +49,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -65,7 +65,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -78,7 +78,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -93,7 +93,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -109,7 +109,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -128,7 +128,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -143,7 +143,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -159,7 +159,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -171,7 +171,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -186,7 +186,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -202,7 +202,7 @@ class RethrowCaughtExceptionSpec {
                 }
             }
         """.trimIndent()
-        val result = subject.compileAndLint(code)
+        val result = subject.lint(code)
         assertThat(result).hasSize(2)
         // ensure correct violation order
         assertThat(result[0].location.source.line == 4).isTrue

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedExceptionSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -37,7 +37,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -54,7 +54,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -75,7 +75,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -92,7 +92,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -109,7 +109,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -127,7 +127,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -140,7 +140,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Nested
@@ -161,7 +161,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -173,7 +173,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
     }
 
@@ -190,7 +190,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -202,7 +202,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
     }
 
@@ -220,7 +220,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -232,7 +232,7 @@ class SwallowedExceptionSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
     }
 
@@ -248,7 +248,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -263,7 +263,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -280,7 +280,7 @@ class SwallowedExceptionSpec {
                }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @ParameterizedTest(name = "ignores {0} in the catch clause by default")
@@ -297,7 +297,7 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @ParameterizedTest(name = "ignores {0} in the catch body by default")
@@ -320,6 +320,6 @@ class SwallowedExceptionSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionFromFinallySpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class ThrowingExceptionFromFinallySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -33,7 +33,7 @@ class ThrowingExceptionFromFinallySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -46,6 +46,6 @@ class ThrowingExceptionFromFinallySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionInMainSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -13,7 +13,7 @@ class ThrowingExceptionInMainSpec {
         val code = """
             fun main() { throw IllegalArgumentException() }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -21,7 +21,7 @@ class ThrowingExceptionInMainSpec {
         val code = """
             fun main(args: Array<String>) { throw IllegalArgumentException() }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -29,7 +29,7 @@ class ThrowingExceptionInMainSpec {
         val code = """
             fun main(vararg args: String) { throw IllegalArgumentException() }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -54,7 +54,7 @@ class ThrowingExceptionInMainSpec {
                 fun main(args: Array<String>) { throw IllegalArgumentException() }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 
     @Test
@@ -66,7 +66,7 @@ class ThrowingExceptionInMainSpec {
             fun main(args: String) { throw IllegalArgumentException() }
             fun main(args: Array<String>, i: Int) { throw IllegalArgumentException() }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -77,7 +77,7 @@ class ThrowingExceptionInMainSpec {
             fun mai() { }
             fun main(args: String) { }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -86,7 +86,7 @@ class ThrowingExceptionInMainSpec {
             fun main(args: Array<String>) = ""
             fun main() = Unit
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -100,6 +100,6 @@ class ThrowingExceptionInMainSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -24,13 +24,13 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
 
         @Test
         fun `reports calls to the default constructor`() {
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
         fun `does not report calls to the default constructor with empty configuration`() {
             val config = TestConfig("exceptions" to emptyList<String>())
-            val findings = ThrowingExceptionsWithoutMessageOrCause(config).compileAndLint(code)
+            val findings = ThrowingExceptionsWithoutMessageOrCause(config).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -42,7 +42,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                 org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -56,6 +56,6 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                 illegalArgumentException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ThrowingNewInstanceOfSameExceptionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -23,7 +23,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
 
         @Test
         fun `should report`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -41,7 +41,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
 
         @Test
         fun `should not report`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -62,7 +62,7 @@ class ThrowingNewInstanceOfSameExceptionSpec {
 
         @Test
         fun `should not report`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Nested
@@ -36,7 +36,7 @@ class TooGenericExceptionCaughtSpec {
             }
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).hasSameSizeAs(TooGenericExceptionCaught.caughtExceptionDefaults)
+        assertThat(rule.lint(code)).hasSameSizeAs(TooGenericExceptionCaught.caughtExceptionDefaults)
     }
 
     @Nested
@@ -57,7 +57,7 @@ class TooGenericExceptionCaughtSpec {
             val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "myIgnore")
             val rule = TooGenericExceptionCaught(config)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -67,7 +67,7 @@ class TooGenericExceptionCaughtSpec {
             val config = TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]")
             val rule = TooGenericExceptionCaught(config)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -100,7 +100,7 @@ class TooGenericExceptionCaughtSpec {
             val config = TestConfig(ALLOWED_EXCEPTION_NAME_REGEX to "*Foo")
             val rule = TooGenericExceptionCaught(config)
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                rule.compileAndLint(code)
+                rule.lint(code)
             }
         }
     }
@@ -128,7 +128,7 @@ class TooGenericExceptionCaughtSpec {
                 }
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
 
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -35,7 +35,7 @@ class TooGenericExceptionThrownSpec {
             }
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).hasSize(1)
+        assertThat(rule.lint(code)).hasSize(1)
     }
 
     @Test
@@ -61,7 +61,7 @@ class TooGenericExceptionThrownSpec {
             }
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -77,7 +77,7 @@ class TooGenericExceptionThrownSpec {
             }
         """.trimIndent()
 
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -85,7 +85,7 @@ class TooGenericExceptionThrownSpec {
         val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "['Exception']"))
         val code = """fun f() { val ex = Exception() }"""
 
-        assertThat(rule.compileAndLint(code)).isEmpty()
+        assertThat(rule.lint(code)).isEmpty()
     }
 
     @Test
@@ -111,7 +111,7 @@ class TooGenericExceptionThrownSpec {
                 }
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
 
         assertThat(findings).isEmpty()
     }

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClassSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/ForbiddenPublicDataClassSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.libraries
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class ForbiddenPublicDataClassSpec {
             data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -24,7 +24,7 @@ class ForbiddenPublicDataClassSpec {
             private data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -33,7 +33,7 @@ class ForbiddenPublicDataClassSpec {
             internal data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -42,7 +42,7 @@ class ForbiddenPublicDataClassSpec {
             class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -53,7 +53,7 @@ class ForbiddenPublicDataClassSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -64,7 +64,7 @@ class ForbiddenPublicDataClassSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -75,7 +75,7 @@ class ForbiddenPublicDataClassSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -86,7 +86,7 @@ class ForbiddenPublicDataClassSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -97,7 +97,7 @@ class ForbiddenPublicDataClassSpec {
             data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -108,7 +108,7 @@ class ForbiddenPublicDataClassSpec {
             data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -119,7 +119,7 @@ class ForbiddenPublicDataClassSpec {
             data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -130,7 +130,7 @@ class ForbiddenPublicDataClassSpec {
             data class C(val a: String)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -142,6 +142,6 @@ class ForbiddenPublicDataClassSpec {
         """.trimIndent()
 
         val config = TestConfig("ignorePackages" to listOf("*.hello", "com.example"))
-        assertThat(ForbiddenPublicDataClass(config).compileAndLint(code)).isEmpty()
+        assertThat(ForbiddenPublicDataClass(config).lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublicSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryEntitiesShouldNotBePublicSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.libraries
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should report a class`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         class A
                     """.trimIndent()
@@ -26,7 +26,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should report a class with function`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         class A {
                             fun foo(): Int{
@@ -41,7 +41,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should report a typealias`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         typealias A = List<String>
                     """.trimIndent()
@@ -52,7 +52,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should report a typealias and a function`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         typealias A = List<String>
                         fun foo() = Unit
@@ -64,7 +64,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should report a function`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun foo() = Unit
                     """.trimIndent()
@@ -80,7 +80,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should not report a class`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         internal class A {
                             fun foo(): Int{
@@ -95,7 +95,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should not report a class with function`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         internal class A
                     """.trimIndent()
@@ -106,7 +106,7 @@ class LibraryEntitiesShouldNotBePublicSpec {
         @Test
         fun `should not report a typealias`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         internal typealias A = List<String>
                     """.trimIndent()

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ClassNamingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class ClassNamingSpec {
@@ -19,14 +19,14 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
     fun `should use custom name for method and class`() {
         val config = TestConfig(ClassNaming.CLASS_PATTERN to "^aBbD$")
         assertThat(
-            ClassNaming(config).compileAndLint(
+            ClassNaming(config).lint(
                 """
                     class aBbD{}
                 """.trimIndent()
@@ -40,7 +40,7 @@ class ClassNamingSpec {
             class MyClassWithNumbers5
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -50,7 +50,7 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -59,7 +59,7 @@ class ClassNamingSpec {
             class `NamingConventions`
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -68,7 +68,7 @@ class ClassNamingSpec {
             class _NamingConventions
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code))
+        assertThat(ClassNaming(Config.empty).lint(code))
             .hasSize(1)
             .hasTextLocations(6 to 24)
     }
@@ -79,7 +79,7 @@ class ClassNamingSpec {
             class namingConventions {}
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code))
+        assertThat(ClassNaming(Config.empty).lint(code))
             .hasSize(1)
             .hasTextLocations(6 to 23)
     }
@@ -90,7 +90,7 @@ class ClassNamingSpec {
             @Suppress("ClassNaming")
             class namingConventions {}
         """.trimIndent()
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -102,6 +102,6 @@ class ClassNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(ClassNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ClassNaming(Config.empty).lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class ConstructorParameterNamingSpec {
                 constructor(param: String, privateParam: String) {}
             }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ConstructorParameterNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -31,7 +31,7 @@ class ConstructorParameterNamingSpec {
                 constructor(PARAM: String, PRIVATE_PARAM: String) {}
             }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).hasSize(5)
+        assertThat(ConstructorParameterNaming(Config.empty).lint(code)).hasSize(5)
     }
 
     @Test
@@ -39,7 +39,7 @@ class ConstructorParameterNamingSpec {
         val code = """
             class C(val PARAM: String)
         """.trimIndent()
-        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).hasTextLocations(8 to 25)
+        assertThat(ConstructorParameterNaming(Config.empty).lint(code)).hasTextLocations(8 to 25)
     }
 
     @Test
@@ -49,7 +49,7 @@ class ConstructorParameterNamingSpec {
             
             interface I { val PARAM: String }
         """.trimIndent()
-        assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(ConstructorParameterNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Nested
@@ -59,7 +59,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(val `is`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -67,7 +67,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `is`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -75,7 +75,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `PARAM_NAME`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code))
+            assertThat(ConstructorParameterNaming(Config.empty).lint(code))
                 .hasSize(1)
                 .hasStartSourceLocation(1, 11)
         }
@@ -88,7 +88,7 @@ class ConstructorParameterNamingSpec {
                     constructor(`is`: Boolean, `when`: Boolean): this(`is`)
                 }
             """.trimIndent()
-            assertThat(ConstructorParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ConstructorParameterNaming(Config.empty).lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/EnumNamingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class EnumNamingSpec {
@@ -12,7 +12,7 @@ class EnumNamingSpec {
     fun `should use custom name for enum`() {
         val rule = EnumNaming(TestConfig(EnumNaming.ENUM_PATTERN to "^(enum1)|(enum2)$"))
         assertThat(
-            rule.compileAndLint(
+            rule.lint(
                 """
                     enum class aBbD {
                         enum1, enum2
@@ -24,7 +24,7 @@ class EnumNamingSpec {
 
     @Test
     fun `should detect no violation`() {
-        val findings = EnumNaming(Config.empty).compileAndLint(
+        val findings = EnumNaming(Config.empty).lint(
             """
                 enum class WorkFlow {
                     ACTIVE, NOT_ACTIVE, Unknown, Number1
@@ -41,7 +41,7 @@ class EnumNamingSpec {
                 default
             }
         """.trimIndent()
-        assertThat(EnumNaming(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EnumNaming(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -51,7 +51,7 @@ class EnumNamingSpec {
                 _Default
             }
         """.trimIndent()
-        assertThat(EnumNaming(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(EnumNaming(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -61,7 +61,7 @@ class EnumNamingSpec {
                 @Suppress("EnumNaming") _Default
             }
         """.trimIndent()
-        assertThat(EnumNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(EnumNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -71,7 +71,7 @@ class EnumNamingSpec {
                 _Default,
             }
         """.trimIndent()
-        val findings = EnumNaming(Config.empty).compileAndLint(code)
+        val findings = EnumNaming(Config.empty).lint(code)
         assertThat(findings).hasTextLocations(26 to 34)
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ForbiddenClassNameSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class ForbiddenClassNameSpec {
         """.trimIndent()
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("Manager", "Provider")))
-                .compileAndLint(code)
+                .lint(code)
         ).hasSize(2)
     }
 
@@ -27,7 +27,7 @@ class ForbiddenClassNameSpec {
         val code = "class TestProvider {}"
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("test")))
-                .compileAndLint(code)
+                .lint(code)
         ).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class ForbiddenClassNameSpec {
         """.trimIndent()
         assertThat(
             ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("*Manager*", "*Provider*")))
-                .compileAndLint(code)
+                .lint(code)
         ).hasSize(2)
     }
 
@@ -50,7 +50,7 @@ class ForbiddenClassNameSpec {
             class TestManager {}
         """.trimIndent()
         val actual = ForbiddenClassName(TestConfig(FORBIDDEN_NAME to listOf("Test", "Manager", "Provider")))
-            .compileAndLint(code)
+            .lint(code)
         assertThat(actual.first().message)
             .isEqualTo("Class name TestManager is forbidden as it contains: Test, Manager")
     }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionMinNameLengthSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,7 +11,7 @@ class FunctionMinNameLengthSpec {
     @Test
     fun `should report a function name that is too short`() {
         val code = "fun a() = 3"
-        assertThat(FunctionNameMinLength(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(FunctionNameMinLength(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
@@ -19,14 +19,14 @@ class FunctionMinNameLengthSpec {
         val code = "fun four() = 3"
         assertThat(
             FunctionNameMinLength(TestConfig("minimumFunctionNameLength" to 5))
-                .compileAndLint(code)
+                .lint(code)
         ).hasSize(1)
     }
 
     @Test
     fun `should not report a function name that is okay`() {
         val code = "fun three() = 3"
-        assertThat(FunctionNameMinLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNameMinLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -40,7 +40,7 @@ class FunctionMinNameLengthSpec {
         assertThat(
             FunctionNameMinLength(
                 TestConfig("minimumFunctionNameLength" to 50)
-            ).compileAndLint(code)
+            ).lint(code)
         ).isEmpty()
     }
 
@@ -55,7 +55,7 @@ class FunctionMinNameLengthSpec {
         assertThat(
             FunctionNameMinLength(
                 TestConfig("minimumFunctionNameLength" to 5)
-            ).compileAndLint(code)
+            ).lint(code)
         ).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNameMaxLengthSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class FunctionNameMaxLengthSpec {
@@ -12,7 +12,7 @@ class FunctionNameMaxLengthSpec {
     fun `should report a function name that is too long base on config`() {
         val code = "fun thisFunctionLongName() = 3"
         assertThat(
-            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 10)).compileAndLint(code)
+            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 10)).lint(code)
         ).hasSize(1)
     }
 
@@ -25,20 +25,20 @@ class FunctionNameMaxLengthSpec {
             interface I { @Suppress("FunctionNameMaxLength") fun thisFunctionIsWayTooLongButStillShouldNotBeReportedByDefault() }
         """.trimIndent()
         assertThat(
-            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 10)).compileAndLint(code)
+            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 10)).lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `should report a function name that is too long`() {
         val code = "fun thisFunctionIsDefinitelyWayTooLongAndShouldBeMuchShorter() = 3"
-        assertThat(FunctionNameMaxLength(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(FunctionNameMaxLength(Config.empty).lint(code)).hasSize(1)
     }
 
     @Test
     fun `should not report a function name that is okay`() {
         val code = "fun three() = 3"
-        assertThat(FunctionNameMaxLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNameMaxLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class FunctionNameMaxLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 5)).compileAndLint(code)
+            FunctionNameMaxLength(TestConfig("maximumFunctionNameLength" to 5)).lint(code)
         ).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class FunctionNamingSpec {
             @Suppress("FunctionNaming")
             fun MY_FUN() {}
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -28,7 +28,7 @@ class FunctionNamingSpec {
                 return i + i
             }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -39,7 +39,7 @@ class FunctionNamingSpec {
             }
         """.trimIndent()
         val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to ".*Test$")
-        assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(config).lint(code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class FunctionNamingSpec {
             }
             interface I { fun shouldNotBeFlagged() }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).lint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -63,7 +63,7 @@ class FunctionNamingSpec {
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_NOT_BE_FLAGGED() }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -74,7 +74,7 @@ class FunctionNamingSpec {
             
             fun Foo(): Foo = FooImpl()
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -83,7 +83,7 @@ class FunctionNamingSpec {
             interface Foo<T>
             fun <T> Foo(): Foo<T> = object : Foo<T> {}
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -96,7 +96,7 @@ class FunctionNamingSpec {
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).lint(code)).hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -104,7 +104,7 @@ class FunctionNamingSpec {
         val code = """
             fun `7his is a function name _`() = Unit
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).hasStartSourceLocations(SourceLocation(1, 5))
+        assertThat(FunctionNaming(Config.empty).lint(code)).hasStartSourceLocations(SourceLocation(1, 5))
     }
 
     @Test
@@ -116,7 +116,7 @@ class FunctionNamingSpec {
             }
         """.trimIndent()
         val config = TestConfig(FunctionNaming.FUNCTION_PATTERN to "^`.+`$")
-        assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(config).lint(code)).isEmpty()
     }
 
     @Test
@@ -131,14 +131,14 @@ class FunctionNamingSpec {
             }
         """.trimIndent()
         val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar")
-        assertThat(FunctionNaming(config).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(config).lint(code)).isEmpty()
     }
 
     @Test
     fun `should report a function name that begins with a backtick, capitals, and spaces`() {
         val subject = FunctionNaming(Config.empty)
         val code = "fun `Hi bye`() = 3"
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -158,7 +158,7 @@ class FunctionNamingSpec {
         fun shouldFailWithInvalidRegexFunctionNaming() {
             val config = TestConfig(FunctionNaming.EXCLUDE_CLASS_PATTERN to "*Foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                FunctionNaming(config).compileAndLint(excludeClassPatternFunctionRegexCode)
+                FunctionNaming(config).lint(excludeClassPatternFunctionRegexCode)
             }
         }
     }
@@ -171,6 +171,6 @@ class FunctionNamingSpec {
                 val (_, HOLY_GRAIL) = D(5, 4)
             }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(FunctionNaming(Config.empty).lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionParameterNamingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class FunctionParameterNamingSpec {
                     fun someStuff(param: String) {}
                 }
             """.trimIndent()
-            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -32,7 +32,7 @@ class FunctionParameterNamingSpec {
                 }
                 interface I { fun someStuff(@Suppress("FunctionParameterNaming") `object`: String) }
             """.trimIndent()
-            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -42,7 +42,7 @@ class FunctionParameterNamingSpec {
                     fun someStuff(PARAM: String) {}
                 }
             """.trimIndent()
-            assertThat(FunctionParameterNaming(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(FunctionParameterNaming(Config.empty).lint(code)).hasSize(1)
         }
     }
 
@@ -58,13 +58,13 @@ class FunctionParameterNamingSpec {
                     fun f(PARAM: Int) {}
                 }
             """.trimIndent()
-            assertThat(FunctionParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(config).lint(code)).isEmpty()
         }
 
         @Test
         fun `should not detect constructor parameter`() {
             val code = "class Excluded(val PARAM: Int) {}"
-            assertThat(FunctionParameterNaming(config).compileAndLint(code)).isEmpty()
+            assertThat(FunctionParameterNaming(config).lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/LambdaParameterNamingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class LambdaParameterNamingSpec {
@@ -12,7 +12,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { HELLO_THERE -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
     }
@@ -22,7 +22,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String, Int) -> Unit = { HI, HELLO_THERE -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
     }
@@ -32,7 +32,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { helloThere -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -41,7 +41,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a = { helloThere: String -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -50,7 +50,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { _ -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -59,7 +59,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: (String) -> Unit = { Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -68,7 +68,7 @@ class LambdaParameterNamingSpec {
         val code = """
             val a: () -> Unit = { Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -78,7 +78,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String)
             val a: (Bar) -> Unit = { (HELLO_THERE) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .hasSize(1)
             .hasTextLocations("HELLO_THERE")
     }
@@ -89,7 +89,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (HI, HELLO_THERE) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .hasSize(2)
             .hasTextLocations("HI", "HELLO_THERE")
     }
@@ -100,7 +100,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -110,7 +110,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (a: String, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -120,7 +120,7 @@ class LambdaParameterNamingSpec {
             data class Bar(val a: String, val b: String)
             val a: (Bar) -> Unit = { (_, b) -> Unit }
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -129,7 +129,7 @@ class LambdaParameterNamingSpec {
         val code = """
             data class C(val _invalid: String)
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 
@@ -138,7 +138,7 @@ class LambdaParameterNamingSpec {
         val code = """
             fun f(_invalid: String) = Unit
         """.trimIndent()
-        assertThat(LambdaParameterNaming(Config.empty).compileAndLint(code))
+        assertThat(LambdaParameterNaming(Config.empty).lint(code))
             .isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -25,7 +25,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicConst.negative}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -35,7 +35,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicConst.positive}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -45,7 +45,7 @@ class ObjectPropertyNamingSpec {
                     ${PrivateConst.negative}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -55,7 +55,7 @@ class ObjectPropertyNamingSpec {
                     ${PrivateConst.positive}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -65,7 +65,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicConst.positive}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(2, 15)
+            assertThat(subject.lint(code)).hasStartSourceLocation(2, 15)
         }
     }
 
@@ -83,7 +83,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -95,7 +95,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -107,7 +107,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -119,7 +119,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -131,7 +131,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasStartSourceLocation(3, 19)
+            assertThat(subject.lint(code)).hasStartSourceLocation(3, 19)
         }
     }
 
@@ -147,7 +147,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicVal.negative}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -157,7 +157,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicVal.positive}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -167,7 +167,7 @@ class ObjectPropertyNamingSpec {
                     ${PrivateVal.negative}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -177,7 +177,7 @@ class ObjectPropertyNamingSpec {
                     private val __NAME = "Artur"
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -198,7 +198,7 @@ class ObjectPropertyNamingSpec {
                     const val _name = "Artur"
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -209,7 +209,7 @@ class ObjectPropertyNamingSpec {
                     private val _1234 = "Artur"
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -228,7 +228,7 @@ class ObjectPropertyNamingSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -242,7 +242,7 @@ class ObjectPropertyNamingSpec {
                 val _invalidNaming = 1
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -254,7 +254,7 @@ class ObjectPropertyNamingSpec {
                 val _invalidNaming = 1
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -267,7 +267,7 @@ class ObjectPropertyNamingSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/PackageNamingSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,26 +11,26 @@ class PackageNamingSpec {
     @Test
     fun `should use custom name for package`() {
         val rule = PackageNaming(TestConfig(PackageNaming.PACKAGE_PATTERN to "^(package_1)$"))
-        assertThat(rule.compileAndLint("package package_1")).isEmpty()
+        assertThat(rule.lint("package package_1")).isEmpty()
     }
 
     @Test
     fun `should find a uppercase package name`() {
-        assertThat(PackageNaming(Config.empty).compileAndLint("package FOO.BAR")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).lint("package FOO.BAR")).hasSize(1)
     }
 
     @Test
     fun `should find a upper camel case package name`() {
-        assertThat(PackageNaming(Config.empty).compileAndLint("package Foo.Bar")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).lint("package Foo.Bar")).hasSize(1)
     }
 
     @Test
     fun `should find a camel case package name`() {
-        assertThat(PackageNaming(Config.empty).compileAndLint("package fOO.bAR")).hasSize(1)
+        assertThat(PackageNaming(Config.empty).lint("package fOO.bAR")).hasSize(1)
     }
 
     @Test
     fun `should check an valid package name`() {
-        assertThat(PackageNaming(Config.empty).compileAndLint("package foo.bar")).isEmpty()
+        assertThat(PackageNaming(Config.empty).lint("package foo.bar")).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +17,7 @@ class TopLevelPropertyNamingSpec {
             const val lowerCaseConst = ""
         """.trimIndent()
         val subject = TopLevelPropertyNaming(TestConfig(TopLevelPropertyNaming.CONSTANT_PATTERN to "^lowerCaseConst$"))
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Nested
@@ -30,7 +29,7 @@ class TopLevelPropertyNamingSpec {
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code, compile = false)).isEmpty()
         }
 
         @Test
@@ -42,7 +41,7 @@ class TopLevelPropertyNamingSpec {
                 private const val _nAme = "Artur"
                 const val serialVersionUID = 42L
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(5)
+            assertThat(subject.lint(code, compile = false)).hasSize(5)
         }
     }
 
@@ -52,7 +51,7 @@ class TopLevelPropertyNamingSpec {
             val String._foo = "foo"
         """.trimIndent()
 
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Nested
@@ -72,7 +71,7 @@ class TopLevelPropertyNamingSpec {
                 val s_d_d_1 = listOf("")
                 private val INTERNAL_VERSION = "1.0.0"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -80,7 +79,7 @@ class TopLevelPropertyNamingSpec {
             val code = """
                 val _nAme = "Artur"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -88,7 +87,7 @@ class TopLevelPropertyNamingSpec {
             val code = """
                 private val __NAME = "Artur"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -104,6 +103,6 @@ class TopLevelPropertyNamingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMaxLengthSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class VariableMaxLengthSpec {
@@ -16,13 +16,13 @@ class VariableMaxLengthSpec {
                 val (_, status) = getResult()
             }
         """.trimIndent()
-        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableMaxLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
     fun `should not report a variable with 64 letters`() {
         val code = "private val varThatIsExactly64LettersLongWhichYouMightNotWantToBelieveInLolz = 3"
-        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableMaxLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -39,13 +39,13 @@ class VariableMaxLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            VariableMaxLength(TestConfig("maximumVariableNameLength" to 10)).compileAndLint(code)
+            VariableMaxLength(TestConfig("maximumVariableNameLength" to 10)).lint(code)
         ).isEmpty()
     }
 
     @Test
     fun `should report a variable name that is too long`() {
         val code = "private val thisVariableIsDefinitelyWayTooLongLongerThanEverythingAndShouldBeMuchShorter = 3"
-        assertThat(VariableMaxLength(Config.empty).compileAndLint(code)).hasSize(1)
+        assertThat(VariableMaxLength(Config.empty).lint(code)).hasSize(1)
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class VariableMinLengthSpec {
         @Test
         fun `reports a very short variable name`() {
             val code = "private val a = 3"
-            assertThat(variableMinLength.compileAndLint(code)).hasSize(1)
+            assertThat(variableMinLength.lint(code)).hasSize(1)
         }
 
         @Test
@@ -28,20 +28,20 @@ class VariableMinLengthSpec {
                     val prop: (Int) -> Unit = { _ -> Unit }
                 }
             """.trimIndent()
-            assertThat(variableMinLength.compileAndLint(code)).isEmpty()
+            assertThat(variableMinLength.lint(code)).isEmpty()
         }
     }
 
     @Test
     fun `should not report a variable name that is okay`() {
         val code = "private val thisOneIsCool = 3"
-        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
     fun `should not report a variable with single letter name`() {
         val code = "private val a = 3"
-        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class VariableMinLengthSpec {
                 val (_, status) = getResult()
             }
         """.trimIndent()
-        assertThat(VariableMinLength(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableMinLength(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -69,7 +69,7 @@ class VariableMinLengthSpec {
             }
         """.trimIndent()
         assertThat(
-            VariableMinLength(TestConfig("minimumVariableNameLength" to 15)).compileAndLint(code)
+            VariableMinLength(TestConfig("minimumVariableNameLength" to 15)).lint(code)
         ).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/VariableNamingSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class VariableNamingSpec {
         fun shouldFailWithInvalidRegexVariableNaming() {
             val config = TestConfig(VariableNaming.EXCLUDE_CLASS_PATTERN to "*Foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java).isThrownBy {
-                VariableNaming(config).compileAndLint(excludeClassPatternVariableRegexCode)
+                VariableNaming(config).lint(excludeClassPatternVariableRegexCode)
             }
         }
     }
@@ -46,7 +46,7 @@ class VariableNamingSpec {
             }
         """.trimIndent()
         val config = TestConfig(VariableNaming.EXCLUDE_CLASS_PATTERN to "Foo|Bar")
-        assertThat(VariableNaming(config).compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(config).lint(code)).isEmpty()
     }
 
     @Test
@@ -58,7 +58,7 @@ class VariableNamingSpec {
                 val camel_Case_Property = 5
             }
         """.trimIndent()
-        assertThat(VariableNaming(Config.empty).compileAndLint(code))
+        assertThat(VariableNaming(Config.empty).lint(code))
             .hasStartSourceLocations(
                 SourceLocation(2, 17),
                 SourceLocation(3, 9),
@@ -75,7 +75,7 @@ class VariableNamingSpec {
                 val camelCaseProperty = 5
             }
         """.trimIndent()
-        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -91,7 +91,7 @@ class VariableNamingSpec {
                 @Suppress("VariableNaming") val SHOULD_NOT_BE_FLAGGED: String
             }
         """.trimIndent()
-        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -104,7 +104,7 @@ class VariableNamingSpec {
                 listOf<Pair<Int, Int>>().flatMap { (right, _) -> listOf(right) }
             }
         """.trimIndent()
-        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -115,6 +115,6 @@ class VariableNamingSpec {
                 val (_, HOLY_GRAIL) = D(5, 4)
             }
         """.trimIndent()
-        assertThat(VariableNaming(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(VariableNaming(Config.empty).lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -65,7 +65,7 @@ class ForEachOnRangeSpec {
 
         @Test
         fun `should report the forEach usage`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(15)
         }
 
@@ -84,7 +84,7 @@ class ForEachOnRangeSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(3)
         }
     }
@@ -99,7 +99,7 @@ class ForEachOnRangeSpec {
 
         @Test
         fun `should not report any issues`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -119,7 +119,7 @@ class ForEachOnRangeSpec {
 
         @Test
         fun `should not report any issues`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryPartOfBinaryExpressionSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class UnnecessaryPartOfBinaryExpressionSpec {
@@ -19,7 +19,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -38,7 +38,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -57,7 +57,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -73,7 +73,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -89,7 +89,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -105,7 +105,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1).hasTextLocations("baz && baz")
     }
 
@@ -120,7 +120,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -137,7 +137,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -154,7 +154,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -169,7 +169,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -184,7 +184,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -202,7 +202,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -217,7 +217,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -233,7 +233,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -247,7 +247,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -263,7 +263,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -280,7 +280,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -292,7 +292,7 @@ class UnnecessaryPartOfBinaryExpressionSpec {
             }
         """.trimIndent()
 
-        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).compileAndLint(code)
+        val findings = UnnecessaryPartOfBinaryExpression(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTemporaryInstantiationSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,12 +11,12 @@ class UnnecessaryTemporaryInstantiationSpec {
     @Test
     fun `temporary instantiation for conversion`() {
         val code = "val i = Integer(1).toString()"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `right conversion without instantiation`() {
         val code = "val i = Integer.toString(1)"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
+++ b/detekt-rules-ruleauthors/src/test/kotlin/io/gitlab/arturbosch/detekt/authors/UseEntityAtNameSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.authors
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 internal class UseEntityAtNameSpec {
@@ -21,7 +21,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -37,7 +37,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.atName(element), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -53,7 +53,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.nameIdentifier!!), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
         assertThat(findings).hasTextLocations("from")
     }
@@ -70,7 +70,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.nameIdentifier!!!!), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
         assertThat(findings).hasTextLocations("from")
     }
@@ -87,7 +87,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.nameIdentifier ?: element), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
         assertThat(findings).hasTextLocations("from")
     }
@@ -107,7 +107,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.getStrictParentOfType<KtClass>()?.nameIdentifier ?: element), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element.getStrictParentOfType<KtClass>()) instead.")
         assertThat(findings).hasTextLocations("from")
@@ -126,7 +126,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.nameIdentifier ?: element2), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement().hasMessage("Recommended to use Entity.atName(element) instead.")
         assertThat(findings).hasTextLocations("from")
     }
@@ -144,7 +144,7 @@ internal class UseEntityAtNameSpec {
                 report(CodeSmell(Entity.from(element.nameIdentifier ?: element2, 0), "message"))
             }
         """.trimIndent()
-        val findings = rule.compileAndLint(code)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApplySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class AlsoCouldBeApplySpec {
@@ -18,7 +18,7 @@ class AlsoCouldBeApplySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -30,7 +30,7 @@ class AlsoCouldBeApplySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -43,7 +43,7 @@ class AlsoCouldBeApplySpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(2, 7)
@@ -59,7 +59,7 @@ class AlsoCouldBeApplySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -71,7 +71,7 @@ class AlsoCouldBeApplySpec {
                 })
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -83,7 +83,7 @@ class AlsoCouldBeApplySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -96,7 +96,7 @@ class AlsoCouldBeApplySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -106,7 +106,7 @@ class AlsoCouldBeApplySpec {
                 a.also { it.plus(5); it.minus(10) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -116,7 +116,7 @@ class AlsoCouldBeApplySpec {
                 a.also { x -> x.also { it.plus(10) } }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -135,7 +135,7 @@ class AlsoCouldBeApplySpec {
                 fun baz() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -148,6 +148,6 @@ class AlsoCouldBeApplySpec {
             
             class Foo
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.rules.style.BracesOnIfStatementsSpec.Companio
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnIfStatementsSpec.Companion.test
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -2194,7 +2193,7 @@ class BracesOnIfStatementsSpec {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
             val compileTest = dynamicTest("Compiles: $code") {
-                BracesOnIfStatements(Config.empty).compileAndLint(code)
+                BracesOnIfStatements(Config.empty).lint(code)
             }
             val validationTests = createBraceTests(singleLine, multiLine) { rule ->
                 rule.test(code, *codeLocation)
@@ -2210,7 +2209,7 @@ class BracesOnIfStatementsSpec {
         private fun BracesOnIfStatements.test(code: String, vararg locations: Pair<Int, Int>) {
             // This creates a 10 character prefix (signature/9, space/1) for every code example.
             // Note: not compileAndLint for performance reasons, compilation is in a separate test.
-            val findings = lint("fun f() { $code }")
+            val findings = lint("fun f() { $code }", compile = false)
             // Offset text locations by the above prefix, it results in 0-indexed locations.
             val offset = 10
             assertThat(findings)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.rules.style.BracesOnWhenStatementsSpec.Compan
 import io.gitlab.arturbosch.detekt.rules.style.BracesOnWhenStatementsSpec.Companion.test
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatCode
@@ -1216,7 +1215,7 @@ class BracesOnWhenStatementsSpec {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
             val compileTest = dynamicTest("Compiles: $code") {
-                BracesOnWhenStatements(Config.empty).compileAndLint(code)
+                BracesOnWhenStatements(Config.empty).lint(code)
             }
             val validationTests = createBraceTests(singleLine, multiLine) { rule ->
                 rule.test(code, *codeLocation)
@@ -1232,7 +1231,7 @@ class BracesOnWhenStatementsSpec {
         private fun BracesOnWhenStatements.test(code: String, vararg locations: Pair<Int, Int>) {
             // This creates a 10 character prefix (signature/9, space/1) for every code example.
             // Note: not compileAndLint for performance reasons, compilation is in a separate test.
-            val findings = lint("fun f() { $code }")
+            val findings = lint("fun f() { $code }", compile = false)
             // Offset text locations by the above prefix, it results in 0-indexed locations.
             val offset = 10
             assertThat(findings)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CascadingCallWrappingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class CascadingCallWrappingSpec {
                 .plus(0).plus(0).plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code))
+        assertThat(subject.lint(code))
             .hasSize(1)
             .hasTextLocations(23 to 30)
             .first()
@@ -30,7 +30,7 @@ class CascadingCallWrappingSpec {
             val a = 0.plus(0).plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -41,7 +41,7 @@ class CascadingCallWrappingSpec {
                 .plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class CascadingCallWrappingSpec {
                 .plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -62,7 +62,7 @@ class CascadingCallWrappingSpec {
                 ?.plus(0)?.plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -72,7 +72,7 @@ class CascadingCallWrappingSpec {
                 .plus(0)!!.plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -85,7 +85,7 @@ class CascadingCallWrappingSpec {
                 .length.plus(0)
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Nested
@@ -102,7 +102,7 @@ class CascadingCallWrappingSpec {
                     }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -119,7 +119,7 @@ class CascadingCallWrappingSpec {
                     )
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code))
+            assertThat(subject.lint(code))
                 .hasTextLocations(64 to 85)
                 .hasSize(1)
         }
@@ -134,7 +134,7 @@ class CascadingCallWrappingSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -145,7 +145,7 @@ class CascadingCallWrappingSpec {
                 )
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -162,8 +162,8 @@ class CascadingCallWrappingSpec {
                     ?: 0
             """.trimIndent()
 
-            assertThat(subjectIncludingElvis.compileAndLint(code)).isEmpty()
-            assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
+            assertThat(subjectIncludingElvis.lint(code)).isEmpty()
+            assertThat(subjectExcludingElvis.lint(code)).isEmpty()
         }
 
         @Test
@@ -173,10 +173,10 @@ class CascadingCallWrappingSpec {
                     .plus(0) ?: 42
             """.trimIndent()
 
-            assertThat(subjectIncludingElvis.compileAndLint(code))
+            assertThat(subjectIncludingElvis.lint(code))
                 .hasTextLocations(23 to 28)
                 .hasSize(1)
-            assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
+            assertThat(subjectExcludingElvis.lint(code)).isEmpty()
         }
 
         @Test
@@ -188,10 +188,10 @@ class CascadingCallWrappingSpec {
                 }
             """.trimIndent()
 
-            assertThat(subjectIncludingElvis.compileAndLint(code))
+            assertThat(subjectIncludingElvis.lint(code))
                 .hasTextLocations(23 to 38)
                 .hasSize(1)
-            assertThat(subjectExcludingElvis.compileAndLint(code)).isEmpty()
+            assertThat(subjectExcludingElvis.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ClassOrderingSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -28,7 +28,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -51,7 +51,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -62,7 +62,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -71,7 +71,7 @@ class ClassOrderingSpec {
             class InOrder
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -84,7 +84,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -107,7 +107,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo(
             "initializer blocks should be declared before secondary constructors."
@@ -134,7 +134,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo(
             "secondary constructor should be declared after property declarations and initializer blocks."
@@ -161,7 +161,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message)
             .isEqualTo("method `returnX()` should be declared after secondary constructors.")
@@ -187,7 +187,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("method `returnX()` should be declared before companion object.")
     }
@@ -212,7 +212,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -235,7 +235,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -260,7 +260,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(3)
         assertThat(findings[0].message)
             .isEqualTo("method `returnX()` should be declared before companion object.")
@@ -286,7 +286,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(3)
         assertThat(findings[0].message)
             .isEqualTo("method `returnX()` should be declared before companion object.")
@@ -317,7 +317,7 @@ class ClassOrderingSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message)
             .isEqualTo("companion object should be declared after method declarations.")
@@ -347,7 +347,7 @@ class ClassOrderingSpec {
 
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message)
             .isEqualTo("method `bar()` should be declared after property declarations and initializer blocks.")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CollapsibleIfStatementsSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -33,7 +33,7 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -46,7 +46,7 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -58,7 +58,7 @@ class CollapsibleIfStatementsSpec {
                 } else {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -71,7 +71,7 @@ class CollapsibleIfStatementsSpec {
                 else {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -84,7 +84,7 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -97,7 +97,7 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -110,6 +110,6 @@ class CollapsibleIfStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassContainsFunctionsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -27,14 +27,14 @@ class DataClassContainsFunctionsSpec {
 
         @Test
         fun `reports valid data class with conversion function`() {
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `reports valid data class without conversion function`() {
             val config = TestConfig(CONVERSION_FUNCTION_PREFIX to emptyList<String>())
             val rule = DataClassContainsFunctions(config)
-            assertThat(rule.compileAndLint(code)).hasSize(2)
+            assertThat(rule.lint(code)).hasSize(2)
         }
     }
 
@@ -49,28 +49,28 @@ class DataClassContainsFunctionsSpec {
         @Test
         fun `reports operators if not allowed by default`() {
             val rule = DataClassContainsFunctions(Config.empty)
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
         fun `reports operators if not allowed`() {
             val config = TestConfig(ALLOW_OPERATORS to false)
             val rule = DataClassContainsFunctions(config)
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
         fun `does not report operators if allowed`() {
             val config = TestConfig(ALLOW_OPERATORS to true)
             val rule = DataClassContainsFunctions(config)
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
     }
 
     @Test
     fun `does not report a data class without a function`() {
         val code = "data class C(val i: Int)"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -80,7 +80,7 @@ class DataClassContainsFunctionsSpec {
                 fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -101,6 +101,6 @@ class DataClassContainsFunctionsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DataClassShouldBeImmutableSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -11,7 +11,7 @@ class DataClassShouldBeImmutableSpec {
     @Test
     fun `reports mutable variable in primary constructor`() {
         val code = "data class C(var i: Int)"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -21,7 +21,7 @@ class DataClassShouldBeImmutableSpec {
                 var s: String? = null
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -32,7 +32,7 @@ class DataClassShouldBeImmutableSpec {
                     private set
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -42,13 +42,13 @@ class DataClassShouldBeImmutableSpec {
                 lateinit var s: String
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `does not report readonly variable in primary constructor`() {
         val code = "data class C(val i: Int)"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -58,7 +58,7 @@ class DataClassShouldBeImmutableSpec {
                 val s: String? = null
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -68,7 +68,7 @@ class DataClassShouldBeImmutableSpec {
                 val s: String by lazy { "" }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -78,6 +78,6 @@ class DataClassShouldBeImmutableSpec {
                 val s: String by lazy { "" }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     println(c)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -45,7 +45,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     println(d)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -60,7 +60,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -78,7 +78,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -99,7 +99,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     println(y)
                 }
             """.trimIndent()
-            assertThat(configuredRule.compileAndLint(code)).isEmpty()
+            assertThat(configuredRule.lint(code)).isEmpty()
         }
 
         @Test
@@ -112,7 +112,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
                     println(c)
                 }
             """.trimIndent()
-            assertThat(configuredRule.compileAndLint(code)).hasSize(1)
+            assertThat(configuredRule.lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.toConfig
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { !it.isEven() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -31,7 +31,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it > 0 && !it.isEven() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -42,7 +42,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { !(it == 0 || it.isEven()) }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -53,7 +53,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isEven().takeIf { i -> !i } ?: false }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -64,7 +64,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isEven().takeUnless { i -> !i } ?: false }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
         assertThat(findings[0]).hasSourceLocation(3, 62) // second takeUnless
         assertThat(findings[1]).hasSourceLocation(3, 37) // first takeUnless
@@ -78,7 +78,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isNotZero() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -89,7 +89,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isNonNegative() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -100,7 +100,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isNotGreaterThan(0) }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -110,7 +110,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it != 0 }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -120,7 +120,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it !== 0 }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -130,7 +130,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it !in 1..3 }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -139,7 +139,7 @@ class DoubleNegativeLambdaSpec {
             val list = listOf(3, "a", true)
             val maybeBoolean = list.firstOrNull().takeUnless { it !is Boolean }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -149,7 +149,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { (it > 0).not() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -159,7 +159,7 @@ class DoubleNegativeLambdaSpec {
             val nonAnnotated = "".takeUnless { it.hasAnnotations() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -168,7 +168,7 @@ class DoubleNegativeLambdaSpec {
             val x = "".takeUnless { it!!.isEmpty() }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -177,7 +177,7 @@ class DoubleNegativeLambdaSpec {
             val isAllEven = listOf(1, 2, 3).none { it % 2 != 0 }
         """.trimIndent()
 
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -193,7 +193,7 @@ class DoubleNegativeLambdaSpec {
             val isValid = listOf(1, 2, 3).filterNot { !it.isEven() }
         """.trimIndent()
 
-        assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(1)
+        assertThat(DoubleNegativeLambda(config).lint(code)).hasSize(1)
     }
 
     @Test
@@ -205,7 +205,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it.isntOdd() }
         """.trimIndent()
 
-        assertThat(DoubleNegativeLambda(config).compileAndLint(code)).hasSize(1)
+        assertThat(DoubleNegativeLambda(config).lint(code)).hasSize(1)
     }
 
     @Test
@@ -216,7 +216,7 @@ class DoubleNegativeLambdaSpec {
             val rand = Random.Default.nextInt().takeUnless { it !in list && it != 0 }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage(
             "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Use `takeIf` instead."
         )
@@ -238,7 +238,7 @@ class DoubleNegativeLambdaSpec {
             val result = list.never { it != 0 }
         """.trimIndent()
 
-        val findings = DoubleNegativeLambda(config).compileAndLint(code)
+        val findings = DoubleNegativeLambda(config).lint(code)
         assertThat(findings).singleElement().hasMessage(
             "Double negative through using `!=` inside a `never` lambda. Rewrite in the positive."
         )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsNullCallSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,7 +15,7 @@ class EqualsNullCallSpec {
                 a.equals(null)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -25,7 +25,7 @@ class EqualsNullCallSpec {
                 a.equals(b.equals(null))
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -35,6 +35,6 @@ class EqualsNullCallSpec {
                 a.equals(b)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/EqualsOnSignatureLineSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -13,7 +13,7 @@ class EqualsOnSignatureLineSpec {
     inner class `with expression syntax and without a return type` {
         @Test
         fun `reports when the equals is on a new line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun foo()
                         = 1
@@ -24,7 +24,7 @@ class EqualsOnSignatureLineSpec {
 
         @Test
         fun `does not report when the equals is on the same line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun foo() = 1
                     
@@ -40,7 +40,7 @@ class EqualsOnSignatureLineSpec {
     inner class `with expression syntax and with a return type` {
         @Test
         fun `reports when the equals is on a new line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun one(): Int
                         = 1
@@ -61,7 +61,7 @@ class EqualsOnSignatureLineSpec {
 
         @Test
         fun `does not report when the equals is on the same line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun one(): Int =
                         1
@@ -101,7 +101,7 @@ class EqualsOnSignatureLineSpec {
     inner class `with expression syntax and with a where clause` {
         @Test
         fun `reports when the equals is on a new line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun <V> one(): Int where V : Number
                         = 1
@@ -123,7 +123,7 @@ class EqualsOnSignatureLineSpec {
 
         @Test
         fun `does not report when the equals is on the same line`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     fun <V> one(): Int where V : Number =
                         1
@@ -139,7 +139,7 @@ class EqualsOnSignatureLineSpec {
 
     @Test
     fun `does not report non-expression functions`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 fun foo() {
                 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaMultipleParametersSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaMultipleParametersSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -14,7 +14,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `reports when parameter types are not declared`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it -> it + index }
@@ -27,7 +27,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `reports when parameter types are declared explicitly`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val lambda = { it: Int, that: String -> it.toString() + that }
@@ -40,7 +40,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `does not report when parameter type with is declared explicitly for multi params un-inferrable lambda`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f(): (Int, Int) -> Int {
                         return { value: Int, a: Int -> (value + a).inc() }::invoke
@@ -53,7 +53,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `reports when parameter type with name it when declared explicitly for multi params un-inferrable lambda`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f(): (Int, Int) -> Int {
                         return { it: Int, a: Int -> (it + a).inc() }::invoke
@@ -70,7 +70,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `does not report implicit 'it' parameter usage`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val lambda = { i: Int -> i.toString() }
@@ -88,7 +88,7 @@ class ExplicitItLambdaMultipleParametersSpec {
         @Test
         fun `does not report explicit 'it' parameter usage in one parameter`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val digits = 1234.let { it -> listOf(it) }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitItLambdaParameterSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -14,7 +14,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `reports when parameter type is not declared`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val digits = 1234.let { it -> listOf(it) }
@@ -30,7 +30,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `reports when parameter type is declared explicitly`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val lambda = { it: Int -> it.toString() }
@@ -43,7 +43,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `does not report when parameter type is declared explicitly when variable name is not it`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val lambda = { value: Int -> value.toString() }
@@ -56,7 +56,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `does not report when parameter type is declared explicitly for un-inferrable lambda`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f1(): (Int) -> Int {
                         return { value: Int -> value.inc() }::invoke
@@ -77,7 +77,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `does not report when parameter type is declared explicitly for un-inferrable lambda wrapped in paren`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f(): (Int) -> Int {
                         return ({ value: Int -> value.inc() })::invoke
@@ -93,7 +93,7 @@ class ExplicitItLambdaParameterSpec {
         @Test
         fun `does not report implicit 'it' parameter usage`() {
             val findings =
-                subject.compileAndLint(
+                subject.lint(
                     """
                     fun f() {
                         val lambda = { i: Int -> i.toString() }
@@ -110,14 +110,13 @@ class ExplicitItLambdaParameterSpec {
     inner class `multiple parameters one of which with name 'it' declared explicitly` {
         @Test
         fun `does not report explicit 'it' parameter usage in multiple parameters`() {
-            val findings =
-                subject.compileAndLint(
-                    """
-                    fun f() {
-                        val lambda = { it: Int, that: String -> it.toString() + that }
-                    }
-                    """.trimIndent(),
-                )
+            val findings = subject.lint(
+                """
+                fun f() {
+                    val lambda = { it: Int, that: String -> it.toString() + that }
+                }
+                """.trimIndent(),
+            )
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class ExpressionBodySyntaxSpec {
         @Test
         fun `reports constant return`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun stuff(): Int {
                             return 5
@@ -41,7 +41,7 @@ class ExpressionBodySyntaxSpec {
                         }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -54,13 +54,13 @@ class ExpressionBodySyntaxSpec {
                     var b2: Boolean = false
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports return statement with method chain`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun stuff(): String {
                             return StringBuilder().append(0).toString()
@@ -73,7 +73,7 @@ class ExpressionBodySyntaxSpec {
         @Test
         fun `reports return statements with conditionals`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun stuff(): Int {
                             return if (true) return 5 else return 3
@@ -89,7 +89,7 @@ class ExpressionBodySyntaxSpec {
         @Test
         fun `does not report multiple if statements`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun stuff(): Boolean {
                             if (true) return true
@@ -103,7 +103,7 @@ class ExpressionBodySyntaxSpec {
         @Test
         fun `does not report when using shortcut return`() {
             assertThat(
-                subject.compileAndLint(
+                subject.lint(
                     """
                         fun caller(): String {
                             return callee("" as String? ?: return "")
@@ -129,13 +129,13 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `does not report with the default configuration`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
             val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
-            assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
+            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }
 
@@ -153,13 +153,13 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `does not report with the default configuration`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
             val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
-            assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
+            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }
 
@@ -179,13 +179,13 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `does not report with the default configuration`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `does not report with includeLineWrapping = true configuration`() {
             val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
-            assertThat(ExpressionBodySyntax(config).compileAndLint(code)).isEmpty()
+            assertThat(ExpressionBodySyntax(config).lint(code)).isEmpty()
         }
     }
 
@@ -201,13 +201,13 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `does not report with the default configuration`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
             val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
-            assertThat(ExpressionBodySyntax(config).compileAndLint(code)).hasSize(1)
+            assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenCommentSpec.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.ValueWithReason
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.toConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
@@ -29,7 +29,7 @@ class ForbiddenCommentSpec {
         @DisplayName("should report TODO: usages")
         fun reportTodoColon() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// TODO: I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// TODO: I need to fix this.")
             assertThat(findings).singleElement()
                 .hasMessage("Forbidden TODO todo marker in comment, please do the changes.")
         }
@@ -37,7 +37,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should not report TODO usages`() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// TODO I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// TODO I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
@@ -45,14 +45,14 @@ class ForbiddenCommentSpec {
         @DisplayName("should report FIXME: usages")
         fun reportFixMe() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// FIXME: I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// FIXME: I need to fix this.")
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not report FIXME usages`() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// FIXME I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// FIXME I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
@@ -60,7 +60,7 @@ class ForbiddenCommentSpec {
         @DisplayName("should report STOPSHIP: usages")
         fun reportStopShipColon() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// STOPSHIP: I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// STOPSHIP: I need to fix this.")
             assertThat(findings).singleElement().hasMessage(
                 "Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code."
             )
@@ -69,7 +69,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should not report STOPSHIP usages`() {
             val findings =
-                ForbiddenComment(Config.empty).compileAndLint("// STOPSHIP I need to fix this.")
+                ForbiddenComment(Config.empty).lint("// STOPSHIP I need to fix this.")
             assertThat(findings).isEmpty()
         }
 
@@ -80,7 +80,7 @@ class ForbiddenCommentSpec {
                  TODO: I need to fix this.
                  */
             """.trimIndent()
-            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -89,7 +89,7 @@ class ForbiddenCommentSpec {
             val code = """
                 /*TODO: I need to fix this.*/
             """.trimIndent()
-            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -105,7 +105,7 @@ class ForbiddenCommentSpec {
                      */
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).lint(code)
             assertThat(findings).hasSize(2)
         }
 
@@ -117,7 +117,7 @@ class ForbiddenCommentSpec {
                  */
                 class A
             """.trimIndent()
-            val findings = ForbiddenComment(Config.empty).compileAndLint(code)
+            val findings = ForbiddenComment(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -134,7 +134,7 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report TODO: usages")
             fun todoColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// TODO: I need to fix this.")
+                    ForbiddenComment(config).lint("// TODO: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
@@ -142,7 +142,7 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report FIXME: usages")
             fun fixmeColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// FIXME: I need to fix this.")
+                    ForbiddenComment(config).lint("// FIXME: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
@@ -150,13 +150,13 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report STOPME: usages")
             fun stopShipColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// STOPSHIP: I need to fix this.")
+                    ForbiddenComment(config).lint("// STOPSHIP: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
             @Test
             fun `should report Banana usages`() {
-                val findings = ForbiddenComment(config).compileAndLint(banana)
+                val findings = ForbiddenComment(config).lint(banana)
                 assertThat(findings).hasSize(1)
             }
 
@@ -164,7 +164,7 @@ class ForbiddenCommentSpec {
             fun `should report Banana usages regardless of case sensitive`() {
                 val forbiddenComment =
                     ForbiddenComment(TestConfig(COMMENTS to listOf("(?i)bAnAnA")))
-                val findings = forbiddenComment.compileAndLint(banana)
+                val findings = forbiddenComment.lint(banana)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -178,7 +178,7 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report TODO: usages")
             fun todoColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// TODO: I need to fix this.")
+                    ForbiddenComment(config).lint("// TODO: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
@@ -186,7 +186,7 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report FIXME: usages")
             fun fixmeColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// FIXME: I need to fix this.")
+                    ForbiddenComment(config).lint("// FIXME: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
@@ -194,13 +194,13 @@ class ForbiddenCommentSpec {
             @DisplayName("should not report STOPME: usages")
             fun stopShipColon() {
                 val findings =
-                    ForbiddenComment(config).compileAndLint("// STOPSHIP: I need to fix this.")
+                    ForbiddenComment(config).lint("// STOPSHIP: I need to fix this.")
                 assertThat(findings).isEmpty()
             }
 
             @Test
             fun `should report Banana usages`() {
-                val findings = ForbiddenComment(config).compileAndLint(banana)
+                val findings = ForbiddenComment(config).lint(banana)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -216,14 +216,14 @@ class ForbiddenCommentSpec {
         @Test
         fun `should not report Comment usages when any one pattern is present`() {
             val comment = "// Comment Ticket:234."
-            val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(patternsConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not report Comment usages when all patterns are present`() {
             val comment = "// Comment Ticket:123 Task:456 comment."
-            val findings = ForbiddenComment(patternsConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(patternsConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
     }
@@ -237,7 +237,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a Finding with message 'Custom Message'`() {
             val comment = "// Comment"
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message)
                 .isEqualTo("This comment contains 'Comment' that has been defined as forbidden.")
@@ -253,7 +253,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a Finding with reason`() {
             val comment = "// Comment"
-            val findings = ForbiddenComment(messageWithReasonConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageWithReasonConfig).lint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings.first().message).isEqualTo("Comment is disallowed")
         }
@@ -269,14 +269,14 @@ class ForbiddenCommentSpec {
         @Test
         fun `should not report a finding when review doesn't match the pattern`() {
             val comment = "// to express in the preview that it's not a normal TextView."
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should report a finding when STOPSHIP is present`() {
             val comment = "// STOPSHIP to express in the preview that it's not a normal TextView."
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings).singleElement()
                 .hasMessage(
@@ -291,7 +291,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a finding when review pattern is matched with comment with leading space`() {
             val comment = "// REVIEW foo -> flag"
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings).singleElement()
                 .hasMessage(
@@ -306,7 +306,7 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a finding when review pattern is matched with comment with out leading space`() {
             val comment = "//REVIEW foo -> flag"
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
             assertThat(findings).singleElement()
                 .hasMessage(
@@ -321,14 +321,14 @@ class ForbiddenCommentSpec {
         @Test
         fun `should report a finding matching two patterns`() {
             val comment = "// REVIEW foo -> flag STOPSHIP"
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(2)
         }
 
         @Test
         fun `should report a finding matching a pattern contained in the comment`() {
             val comment = "// foo STOPSHIP bar"
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -339,7 +339,7 @@ class ForbiddenCommentSpec {
                 // foo STOPSHIP bar
                 // foo STOPSHIP bar
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(3)
         }
     }
@@ -359,7 +359,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -371,7 +371,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -386,7 +386,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -400,7 +400,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -414,7 +414,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -428,7 +428,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment(messageConfig).compileAndLint(comment)
+            val findings = ForbiddenComment(messageConfig).lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -442,7 +442,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^    comment").compileAndLint(comment)
+            val findings = ForbiddenComment("^    comment").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -456,7 +456,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^comment").compileAndLint(comment)
+            val findings = ForbiddenComment("^comment").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -470,7 +470,7 @@ class ForbiddenCommentSpec {
                     }
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^ foo").compileAndLint(comment)
+            val findings = ForbiddenComment("^ foo").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -484,7 +484,7 @@ class ForbiddenCommentSpec {
                     }
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^ foo").compileAndLint(comment)
+            val findings = ForbiddenComment("^ foo").lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -496,7 +496,7 @@ class ForbiddenCommentSpec {
                     val a = 0
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("stopship").compileAndLint(comment)
+            val findings = ForbiddenComment("stopship").lint(comment)
             assertThat(findings).hasSize(1)
         }
     }
@@ -509,7 +509,7 @@ class ForbiddenCommentSpec {
             val comment = """
                 fun f() {} // TODO implement
             """.trimIndent()
-            val findings = ForbiddenComment("TODO").compileAndLint(comment)
+            val findings = ForbiddenComment("TODO").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -520,7 +520,7 @@ class ForbiddenCommentSpec {
                     /*public*/ fun f() {}
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("public").compileAndLint(comment)
+            val findings = ForbiddenComment("public").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -531,7 +531,7 @@ class ForbiddenCommentSpec {
                     fun f() /*: String*/ {}
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^: .+$").compileAndLint(comment)
+            val findings = ForbiddenComment("^: .+$").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -543,7 +543,7 @@ class ForbiddenCommentSpec {
                         TODO()
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^error").compileAndLint(comment)
+            val findings = ForbiddenComment("^error").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -554,7 +554,7 @@ class ForbiddenCommentSpec {
                     /**public*/ fun f() {}
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("public").compileAndLint(comment)
+            val findings = ForbiddenComment("public").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -565,7 +565,7 @@ class ForbiddenCommentSpec {
                     fun f() /**: String*/ {}
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^: .+$").compileAndLint(comment)
+            val findings = ForbiddenComment("^: .+$").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -577,7 +577,7 @@ class ForbiddenCommentSpec {
                         TODO()
                 }
             """.trimIndent()
-            val findings = ForbiddenComment("^error").compileAndLint(comment)
+            val findings = ForbiddenComment("^error").lint(comment)
             assertThat(findings).hasSize(1)
         }
     }
@@ -593,7 +593,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("^baz").compileAndLint(comment)
+            val findings = ForbiddenComment("^baz").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -605,7 +605,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("(?-m)^baz").compileAndLint(comment)
+            val findings = ForbiddenComment("(?-m)^baz").lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -617,7 +617,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("bar$").compileAndLint(comment)
+            val findings = ForbiddenComment("bar$").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -629,7 +629,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("(?-m)bar$").compileAndLint(comment)
+            val findings = ForbiddenComment("(?-m)bar$").lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -641,9 +641,9 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings1 = ForbiddenComment("^foo").compileAndLint(comment)
+            val findings1 = ForbiddenComment("^foo").lint(comment)
             assertThat(findings1).hasSize(1)
-            val findings2 = ForbiddenComment("\\Afoo").compileAndLint(comment)
+            val findings2 = ForbiddenComment("\\Afoo").lint(comment)
             assertThat(findings2).hasSize(1)
         }
 
@@ -655,9 +655,9 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings1 = ForbiddenComment("qux$").compileAndLint(comment)
+            val findings1 = ForbiddenComment("qux$").lint(comment)
             assertThat(findings1).hasSize(1)
-            val findings2 = ForbiddenComment("qux\\Z").compileAndLint(comment)
+            val findings2 = ForbiddenComment("qux\\Z").lint(comment)
             assertThat(findings2).hasSize(1)
         }
 
@@ -669,7 +669,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("^foo.*qux$").compileAndLint(comment)
+            val findings = ForbiddenComment("^foo.*qux$").lint(comment)
             assertThat(findings).hasSize(1)
         }
 
@@ -681,7 +681,7 @@ class ForbiddenCommentSpec {
                  * baz qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("(?-s)^foo.*qux$").compileAndLint(comment)
+            val findings = ForbiddenComment("(?-s)^foo.*qux$").lint(comment)
             assertThat(findings).isEmpty()
         }
 
@@ -693,7 +693,7 @@ class ForbiddenCommentSpec {
                  * bar qux
                  */
             """.trimIndent()
-            val findings = ForbiddenComment("^foo", "^bar").compileAndLint(comment)
+            val findings = ForbiddenComment("^foo", "^bar").lint(comment)
             assertThat(findings).hasSize(2)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenImportSpec.kt
@@ -26,26 +26,26 @@ class ForbiddenImportSpec {
 
     @Test
     fun `should report nothing by default`() {
-        val findings = ForbiddenImport(Config.empty).lint(code)
+        val findings = ForbiddenImport(Config.empty).lint(code, compile = false)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report nothing when imports are blank`() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("  "))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("  "))).lint(code, compile = false)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report nothing when imports do not match`() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("org.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("org.*"))).lint(code, compile = false)
         assertThat(findings).isEmpty()
     }
 
     @Test
     @DisplayName("should report kotlin.* when imports are kotlin.*")
     fun reportKotlinWildcardImports() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.*"))).lint(code, compile = false)
         assertThat(findings)
             .extracting("message")
             .containsExactlyInAnyOrder(
@@ -58,7 +58,7 @@ class ForbiddenImportSpec {
     @DisplayName("should report kotlin.* when imports are kotlin.* with reasons")
     fun reportKotlinWildcardImports2() {
         val config = TestConfig(IMPORTS to listOf(ValueWithReason("kotlin.*", "I'm just joking!").toConfig()))
-        val findings = ForbiddenImport(config).lint(code)
+        val findings = ForbiddenImport(config).lint(code, compile = false)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
             .isEqualTo("The import `kotlin.jvm.JvmField` has been forbidden: I'm just joking!")
@@ -69,7 +69,7 @@ class ForbiddenImportSpec {
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via fully qualified name")
     fun reportKotlinSinceKotlinWhenFqdnSpecified() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin"))).lint(code, compile = false)
         assertThat(findings)
             .hasSize(1)
     }
@@ -77,8 +77,8 @@ class ForbiddenImportSpec {
     @Test
     @DisplayName("should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names")
     fun reportMultipleConfiguredImportsCommaSeparated() {
-        val findings =
-            ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))
+            .lint(code, compile = false)
         assertThat(findings).hasSize(2)
     }
 
@@ -87,23 +87,23 @@ class ForbiddenImportSpec {
         "should report kotlin.SinceKotlin and kotlin.jvm.JvmField when specified via fully qualified names list"
     )
     fun reportMultipleConfiguredImportsInList() {
-        val findings = ForbiddenImport(
-            TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField"))
-        ).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.SinceKotlin", "kotlin.jvm.JvmField")))
+            .lint(code, compile = false)
         assertThat(findings).hasSize(2)
     }
 
     @Test
     @DisplayName("should report kotlin.SinceKotlin when specified via kotlin.Since*")
     fun reportsKotlinSinceKotlinWhenSpecifiedWithWildcard() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.Since*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("kotlin.Since*")))
+            .lint(code, compile = false)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     @DisplayName("should report all of com.example.R.string, net.example.R.dimen, and net.example.R.dimension")
     fun preAndPostWildcard() {
-        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("*.R.*"))).lint(code)
+        val findings = ForbiddenImport(TestConfig(IMPORTS to listOf("*.R.*"))).lint(code, compile = false)
         assertThat(findings).hasSize(3)
     }
 
@@ -111,21 +111,21 @@ class ForbiddenImportSpec {
     @DisplayName("should report net.example.R.dimen but not net.example.R.dimension")
     fun doNotReportSubstringOfFqdn() {
         val findings =
-            ForbiddenImport(TestConfig(IMPORTS to listOf("net.example.R.dimen"))).lint(code)
+            ForbiddenImport(TestConfig(IMPORTS to listOf("net.example.R.dimen"))).lint(code, compile = false)
         assertThat(findings).hasSize(1)
     }
 
     @Test
     fun `should not report import when it does not match any pattern`() {
         val findings =
-            ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "nets.*R")).lint(code)
+            ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "nets.*R")).lint(code, compile = false)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should report import when it matches the forbidden pattern`() {
-        val findings =
-            ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental")).lint(code)
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_PATTERNS to "net.*R|com.*expiremental"))
+            .lint(code, compile = false)
         assertThat(findings).hasSize(2)
         assertThat(findings[0].message)
             .isEqualTo("The import `net.example.R.dimen` has been forbidden in the detekt config.")

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -22,7 +22,7 @@ internal class ForbiddenSuppressSpec {
                 @SuppressWarnings("ARule")
                 class Foo
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
@@ -36,7 +36,7 @@ internal class ForbiddenSuppressSpec {
                 @file:Suppress("ARule")
                 package config
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
@@ -52,7 +52,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("ARule")
                 fun foo() { }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
@@ -70,7 +70,7 @@ internal class ForbiddenSuppressSpec {
                     println("bar")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 5)
             assertThat(findings.first()).hasMessage(
@@ -86,7 +86,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("UNCHECKED_CAST")
                 fun foo() { }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -98,7 +98,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("UNCHECKED_CAST", "ARule")
                 fun foo() { }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
@@ -114,7 +114,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress
                 fun foo() { }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -131,7 +131,7 @@ internal class ForbiddenSuppressSpec {
                 @file:Suppress("ARule", "BRule")
                 package config
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
@@ -148,7 +148,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("BRule")
                 fun foo() { }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
@@ -171,7 +171,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("ForbiddenSuppress")
                 class Foo
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -183,7 +183,7 @@ internal class ForbiddenSuppressSpec {
                 @Suppress("ForbiddenSuppress", "ARule")
                 class Foo
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -198,7 +198,7 @@ internal class ForbiddenSuppressSpec {
                 @file:Suppress("ARule")
                 package config
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -57,26 +56,26 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports functions which return constants`() {
-            assertThat(subject.compileAndLint(code)).hasSize(6)
+            assertThat(subject.lint(code)).hasSize(6)
         }
 
         @Test
         fun `reports overridden functions which return constants`() {
             val config = TestConfig(IGNORE_OVERRIDABLE_FUNCTION to "false")
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.compileAndLint(code)).hasSize(9)
+            assertThat(rule.lint(code)).hasSize(9)
         }
 
         @Test
         fun `does not report actual functions which return constants`() {
-            assertThat(subject.lint(actualFunctionCode)).isEmpty()
+            assertThat(subject.lint(actualFunctionCode, compile = false)).isEmpty()
         }
 
         @Test
         fun `reports actual functions which return constants`() {
             val config = TestConfig(IGNORE_ACTUAL_FUNCTION to "false")
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.lint(actualFunctionCode)).hasSize(1)
+            assertThat(rule.lint(actualFunctionCode, compile = false)).hasSize(1)
         }
 
         @Test
@@ -84,7 +83,7 @@ class FunctionOnlyReturningConstantSpec {
             val code = "fun f() = 1"
             val config = TestConfig(EXCLUDED_FUNCTIONS to listOf("f"))
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -92,7 +91,7 @@ class FunctionOnlyReturningConstantSpec {
             val code = "fun function() = 1"
             val config = TestConfig(EXCLUDED_FUNCTIONS to listOf("f*ion"))
             val rule = FunctionOnlyReturningConstant(config)
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
     }
 
@@ -110,7 +109,7 @@ class FunctionOnlyReturningConstantSpec {
                 
                 fun functionNotReturningConstantString1(str: String) = "str: ${'$'}str"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 private const val MAX_JUMP_COUNT = "maxJumpCount"
@@ -23,7 +23,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 23)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).lint(code)).hasTextLocations(20 to 23)
     }
 
     @Test
@@ -35,7 +35,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 25)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).lint(code)).hasTextLocations(20 to 25)
     }
 
     @Test
@@ -47,7 +47,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 } while (i < 1)
             }
         """.trimIndent()
-        assertThat(LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)).hasTextLocations(20 to 22)
+        assertThat(LoopWithTooManyJumpStatements(Config.empty).lint(code)).hasTextLocations(20 to 22)
     }
 
     @Test
@@ -63,7 +63,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -76,7 +76,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -89,7 +89,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 } while (i < 1)
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -102,7 +102,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -119,7 +119,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(Config.empty).compileAndLint(code)
+        val findings = LoopWithTooManyJumpStatements(Config.empty).lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.junit.jupiter.api.DisplayName
@@ -33,13 +32,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -50,13 +49,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -67,13 +66,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -84,13 +83,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -101,13 +100,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 14)
         }
     }
@@ -118,13 +117,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -135,26 +134,26 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
 
         @Test
         fun `should be ignored when ignoredNumbers contains it verbatim`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2L"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2L"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be ignored when ignoredNumbers contains it as floating point`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2f"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("-2f"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be ignored when ignoredNumbers contains 2 but not -2`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0")))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).hasStartSourceLocation(1, 15)
         }
     }
@@ -165,13 +164,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -182,13 +181,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
     }
@@ -199,13 +198,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -216,13 +215,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
     }
@@ -233,13 +232,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -250,13 +249,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported when ignoredNumbers contains 300`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains a floating point 300`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300.0"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("300.0"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -267,13 +266,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains a binary literal 0b01001`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("0b01001"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("0b01001"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -284,25 +283,25 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 13)
         }
 
         @Test
         fun `should not be reported when ignored verbatim`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100_000"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100_000"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored with different underscores`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("10_00_00"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("10_00_00"))).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignored without underscores`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100000"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("100000"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -313,7 +312,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(1, 17),
@@ -338,7 +337,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber(Config.empty).lint(code)
+            val findings = MagicNumber(Config.empty).lint(code, compile = false)
             assertThat(findings).hasStartSourceLocations(
                 SourceLocation(3, 9),
                 SourceLocation(3, 21),
@@ -360,7 +359,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -375,7 +374,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -386,7 +385,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -398,13 +397,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasStartSourceLocation(1, 12)
         }
 
         @Test
         fun `should not be reported when ignoredNumbers contains it`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf(".5"))).compileAndLint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf(".5"))).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -415,7 +414,7 @@ class MagicNumberSpec {
         @Test
         fun `should report`() {
             val code = "val file = Array<String?>(42) { null }"
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -426,7 +425,7 @@ class MagicNumberSpec {
         @Test
         fun `throws a NumberFormatException`() {
             assertThatExceptionOfType(NumberFormatException::class.java).isThrownBy {
-                MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("banana"))).compileAndLint("val i = 0")
+                MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("banana"))).lint("val i = 0")
             }
         }
     }
@@ -476,7 +475,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).lint(code, compile = false)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(1, 17),
@@ -501,7 +500,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
             )
 
-            val findings = MagicNumber(config).lint(code)
+            val findings = MagicNumber(config).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -520,7 +519,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not report any issues by default`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -532,7 +531,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -544,7 +543,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -556,7 +555,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -568,7 +567,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -580,7 +579,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings).hasStartSourceLocation(4, 35)
         }
 
@@ -592,7 +591,7 @@ class MagicNumberSpec {
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
             )
 
-            val findings = MagicNumber(config).compileAndLint(code)
+            val findings = MagicNumber(config).lint(code)
             assertThat(findings)
                 .hasStartSourceLocations(
                     SourceLocation(4, 35),
@@ -607,7 +606,7 @@ class MagicNumberSpec {
 
         @Test
         fun `should not lead to a crash #276`() {
-            val findings = MagicNumber(Config.empty).compileAndLint(code)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -628,35 +627,35 @@ class MagicNumberSpec {
             @Test
             fun `should not ignore int`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.compileAndLint(code("53"))).hasSize(1)
+                assertThat(rule.lint(code("53"))).hasSize(1)
             }
 
             @Test
             fun `should not ignore float`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.lint(code("53f"))).hasSize(1)
+                assertThat(rule.lint(code("53f"), compile = false)).hasSize(1)
             }
 
             @Test
             fun `should not ignore binary`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.compileAndLint(code("0b01001"))).hasSize(1)
+                assertThat(rule.lint(code("0b01001"))).hasSize(1)
             }
 
             @Test
             fun `should ignore integer with underscores`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.compileAndLint(code("101_000"))).hasSize(1)
+                assertThat(rule.lint(code("101_000"))).hasSize(1)
             }
 
             @Test
             fun `should ignore numbers by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code("53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code("53"))).isEmpty()
             }
 
             @Test
             fun `should ignore negative numbers by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code("-53"))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code("-53"))).isEmpty()
             }
 
             @Test
@@ -666,14 +665,14 @@ class MagicNumberSpec {
                     
                     object B : A(n = 5)
                 """.trimIndent()
-                assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
             }
 
             @Test
             fun `should ignore named arguments in parameter annotations - #1115`() {
                 val code =
                     "@JvmStatic fun setCustomDimension(@IntRange(from = 0, to = 19) index: Int, value: String?) {}"
-                assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code, compile = false)).isEmpty()
             }
         }
 
@@ -691,7 +690,7 @@ class MagicNumberSpec {
 
             @Test
             fun `should detect the argument by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code("53"))).hasSize(1)
+                assertThat(MagicNumber(Config.empty).lint(code("53"))).hasSize(1)
             }
         }
 
@@ -705,22 +704,22 @@ class MagicNumberSpec {
 
             @Test
             fun `should ignore int by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code(53))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(53))).isEmpty()
             }
 
             @Test
             fun `should ignore float by default`() {
-                assertThat(MagicNumber(Config.empty).lint(code(53f))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(53f), compile = false)).isEmpty()
             }
 
             @Test
             fun `should ignore binary by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code(0b01001))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(0b01001))).isEmpty()
             }
 
             @Test
             fun `should ignore integer with underscores`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code(101_000))).isEmpty()
+                assertThat(MagicNumber(Config.empty).lint(code(101_000))).isEmpty()
             }
         }
 
@@ -735,13 +734,13 @@ class MagicNumberSpec {
 
             @Test
             fun `should be reported by default`() {
-                assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(1)
+                assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
             }
 
             @Test
             fun `numbers when 'ignoreEnums' is set to true`() {
                 val rule = MagicNumber(TestConfig(IGNORE_ENUMS to "true"))
-                assertThat(rule.compileAndLint(code)).isEmpty()
+                assertThat(rule.lint(code)).isEmpty()
             }
         }
 
@@ -757,7 +756,7 @@ class MagicNumberSpec {
             @Test
             fun `should be reported`() {
                 val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
-                assertThat(rule.compileAndLint(code)).hasSize(1)
+                assertThat(rule.lint(code)).hasSize(1)
             }
 
             @Test
@@ -768,7 +767,7 @@ class MagicNumberSpec {
                         IGNORE_ENUMS to "true",
                     )
                 )
-                assertThat(rule.compileAndLint(code)).isEmpty()
+                assertThat(rule.lint(code)).isEmpty()
             }
         }
 
@@ -782,7 +781,7 @@ class MagicNumberSpec {
                 )
             """.trimIndent()
 
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
     }
 
@@ -795,7 +794,7 @@ class MagicNumberSpec {
                 fun x() = 9
                 fun y(): Int { return 9 }
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -804,7 +803,7 @@ class MagicNumberSpec {
                 fun x() = 9 + 1
                 fun y(): Int { return 9 + 1 }
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(2)
+            assertThat(MagicNumber(Config.empty).lint(code)).hasSize(2)
         }
     }
 
@@ -814,13 +813,13 @@ class MagicNumberSpec {
         @Test
         fun `reports no finding`() {
             val code = "class SomeClassWithDefault(val defaultValue: Int = 10)"
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for an explicit declaration`() {
             val code = "class SomeClassWithDefault constructor(val defaultValue: Int = 10)"
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -830,7 +829,7 @@ class MagicNumberSpec {
 
                 class SomeClassWithDefault constructor(val defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS))
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code, compile = false)).isEmpty()
         }
     }
 
@@ -844,7 +843,7 @@ class MagicNumberSpec {
                     constructor(defaultValue: Int = 10) { }
                 }
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
@@ -854,7 +853,7 @@ class MagicNumberSpec {
                     constructor(defaultValue: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) { }
                 }
             """.trimIndent()
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code, compile = false)).isEmpty()
         }
     }
 
@@ -864,13 +863,13 @@ class MagicNumberSpec {
         @Test
         fun `reports no finding`() {
             val code = "fun f(p: Int = 100) {}"
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
         }
 
         @Test
         fun `reports no finding for a function expression`() {
             val code = "fun f(p: Duration = 10.toDuration(DurationUnit.MILLISECONDS)) {}"
-            assertThat(MagicNumber(Config.empty).lint(code)).isEmpty()
+            assertThat(MagicNumber(Config.empty).lint(code, compile = false)).isEmpty()
         }
     }
 
@@ -891,33 +890,33 @@ class MagicNumberSpec {
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell by default`(code: String) {
-            assertThat(MagicNumber(Config.empty).compileAndLint(code)).hasSize(1)
+            assertThat(MagicNumber(Config.empty).lint(code)).hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a code smell if ranges are not ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).compileAndLint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).lint(code))
                 .hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports no finding if ranges are ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code))
                 .isEmpty()
         }
 
         @Test
         fun `reports a finding for a parenthesized number if ranges are ignored`() {
             val code = "val foo : Int = (127)"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
         }
 
         @Test
         fun `reports a finding for an addition if ranges are ignored`() {
             val code = "val foo : Int = 1 + 27"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).compileAndLint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
         }
     }
 
@@ -929,13 +928,13 @@ class MagicNumberSpec {
         @Test
         fun `reports 3 due to the assignment to a local variable`() {
             val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "false"))
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
         fun `should not report 3 due to the ignored local variable config`() {
             val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "true"))
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
     }
 
@@ -951,17 +950,17 @@ class MagicNumberSpec {
 
         @Test
         fun `should report 3`() {
-            assertThat(rule.compileAndLint("""fun bar() { foo(3) }; fun foo(n: Int) {}""")).hasSize(1)
+            assertThat(rule.lint("""fun bar() { foo(3) }; fun foo(n: Int) {}""")).hasSize(1)
         }
 
         @Test
         fun `should not report named 3`() {
-            assertThat(rule.compileAndLint("""fun bar() { foo(param=3) }; fun foo(param: Int) {}""")).isEmpty()
+            assertThat(rule.lint("""fun bar() { foo(param=3) }; fun foo(param: Int) {}""")).isEmpty()
         }
 
         @Test
         fun `should not report 3 due to scoped describing variable`() {
-            assertThat(rule.compileAndLint("""fun bar() { val a = 3; foo(a) }; fun foo(n: Int) {}""")).isEmpty()
+            assertThat(rule.lint("""fun bar() { val a = 3; foo(a) }; fun foo(n: Int) {}""")).isEmpty()
         }
     }
 
@@ -980,7 +979,7 @@ class MagicNumberSpec {
                 val a = 500.dp()
             """.trimIndent()
 
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -992,7 +991,7 @@ class MagicNumberSpec {
                 val a = 500.dp
             """.trimIndent()
 
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -1003,7 +1002,7 @@ class MagicNumberSpec {
                 val a = 500.dp(400)
             """.trimIndent()
 
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.assertj.core.api.Assertions.assertThat as doAssert
@@ -81,7 +81,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -89,7 +89,7 @@ class MaxLineLengthSpec {
         fun `should report all errors with default maxLineLength`() {
             val rule = MaxLineLength(Config.empty)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(3)
         }
 
@@ -101,7 +101,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(7)
         }
 
@@ -109,7 +109,7 @@ class MaxLineLengthSpec {
         fun `should report meaningful signature for all violations`() {
             val rule = MaxLineLength(Config.empty)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             val locations = findings.map { it.entity.signature.substringAfterLast('$') }
             doAssert(locations).allSatisfy { doAssert(it).isNotBlank() }
         }
@@ -143,7 +143,7 @@ class MaxLineLengthSpec {
                         .trimIndent()
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
     }
 
@@ -222,7 +222,7 @@ class MaxLineLengthSpec {
         fun `should not report as lines are suppressed`() {
             val rule = MaxLineLength(Config.empty)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -243,7 +243,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -257,7 +257,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(2)
         }
 
@@ -271,7 +271,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -317,7 +317,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(8)
         }
 
@@ -332,7 +332,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(8)
         }
 
@@ -345,7 +345,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(5)
         }
     }
@@ -370,7 +370,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -384,7 +384,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(3)
         }
 
@@ -398,7 +398,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(6, 1))
@@ -415,7 +415,7 @@ class MaxLineLengthSpec {
             )
         )
 
-        val findings = rule.compileAndLint(
+        val findings = rule.lint(
             """
                 // some other content
                 val x = Regex($TQ
@@ -438,7 +438,7 @@ class MaxLineLengthSpec {
             )
         )
 
-        val findings = rule.compileAndLint(
+        val findings = rule.lint(
             """
                 // some other content
                 val x = "Foo".matches($TQ...too long\(parens\) and some more$TQ.toRegex())
@@ -457,7 +457,7 @@ class MaxLineLengthSpec {
             )
         )
 
-        val findings = rule.compileAndLint(
+        val findings = rule.lint(
             """
                 interface TaskContainer {
                     fun register(name: String, block: Number.() -> Unit = {})
@@ -503,7 +503,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -520,7 +520,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            assertThat(rule.compileAndLint(code)).isEmpty()
+            assertThat(rule.lint(code)).isEmpty()
         }
 
         @Test
@@ -539,7 +539,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            assertThat(rule.compileAndLint(code)).hasSize(3)
+            assertThat(rule.lint(code)).hasSize(3)
         }
     }
 
@@ -565,7 +565,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            assertThat(rule.compileAndLint(code)).hasSize(1)
+            assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
@@ -587,7 +587,7 @@ class MaxLineLengthSpec {
                 )
             )
 
-            assertThat(rule.compileAndLint(code)).hasSize(3)
+            assertThat(rule.lint(code)).hasSize(3)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MayBeConstantSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +20,7 @@ class MayBeConstantSpec {
                     const val X = 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -32,7 +31,7 @@ class MayBeConstantSpec {
                     const val TEST = "Test"
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -45,7 +44,7 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -62,7 +61,7 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -75,7 +74,7 @@ class MayBeConstantSpec {
                 val p = Pair(Something.a, Something.a + Something.a)
                 val p2 = emptyList<Int>().plus(Something.a)
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -87,7 +86,7 @@ class MayBeConstantSpec {
             val code = """
                 val x = 1
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 5)
             )
@@ -98,7 +97,7 @@ class MayBeConstantSpec {
             val code = """
                 @JvmField val x = 1
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(1, 15)
             )
@@ -111,7 +110,7 @@ class MayBeConstantSpec {
                     @JvmField val test = "Test"
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(2, 19)
             )
@@ -126,7 +125,7 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 13)
             )
@@ -143,7 +142,7 @@ class MayBeConstantSpec {
                     val two = one * 2
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
@@ -159,7 +158,7 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(4, 13)
             )
@@ -173,7 +172,7 @@ class MayBeConstantSpec {
                     val two = one * 2 + 1
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
@@ -187,7 +186,7 @@ class MayBeConstantSpec {
                     val two = one * (2 + 1)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 9)
             )
@@ -203,7 +202,7 @@ class MayBeConstantSpec {
                     val b = a + 1
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(5, 9)
             )
@@ -217,7 +216,7 @@ class MayBeConstantSpec {
                     private val B = A + "b"
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 17)
             )
@@ -229,28 +228,28 @@ class MayBeConstantSpec {
         @Test
         fun `does not report arrays`() {
             val code = "val arr = arrayOf(\"a\", \"b\")"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `is a var`() {
             val code = "var test = 1"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `has a getter`() {
             val code = "val withGetter get() = 42"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `is initialized to null`() {
             val code = "val test = null"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -261,7 +260,7 @@ class MayBeConstantSpec {
                     @JvmField val a = 3
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -272,7 +271,7 @@ class MayBeConstantSpec {
                 
                 @A val a = 55
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -287,14 +286,14 @@ class MayBeConstantSpec {
                     override val property = 1
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not detect just a dollar as interpolation`() {
             val code = """ val hasDollar = "$" """
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -316,7 +315,7 @@ class MayBeConstantSpec {
                 var test_var = "test"
                 var code = $innerCode
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -329,14 +328,14 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not report actual vals`() {
             // Until the [KotlinScriptEngine] can compile KMP, we will only lint.
-            val findings = subject.lint("""actual val abc123 = "abc123" """)
+            val findings = subject.lint("""actual val abc123 = "abc123" """, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -361,7 +360,7 @@ class MayBeConstantSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(3).hasStartSourceLocations(
                 SourceLocation(4, 13),
                 SourceLocation(7, 17),

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ModifierOrderSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,23 +17,23 @@ class ModifierOrderSpec {
 
         @Test
         fun `should report incorrectly ordered modifiers`() {
-            subject.compileAndLint(bad1).let {
+            subject.lint(bad1).let {
                 assertThat(it).singleElement().hasMessage("Modifier order should be: internal data")
             }
-            subject.lint(bad2).let {
+            subject.lint(bad2, compile = false).let {
                 assertThat(it).singleElement().hasMessage("Modifier order should be: private actual")
             }
-            subject.lint(bad3).let {
+            subject.lint(bad3, compile = false).let {
                 assertThat(it).singleElement().hasMessage("Modifier order should be: expect annotation")
             }
         }
 
         @Test
         fun `does not report correctly ordered modifiers`() {
-            assertThat(subject.compileAndLint("internal data class Test(val test: String)")).isEmpty()
-            assertThat(subject.lint("private actual class Test(val test: String)")).isEmpty()
-            assertThat(subject.lint("expect annotation class Test")).isEmpty()
-            assertThat(subject.compileAndLint("private /* comment */ data class Test(val test: String)")).isEmpty()
+            assertThat(subject.lint("internal data class Test(val test: String)")).isEmpty()
+            assertThat(subject.lint("private actual class Test(val test: String)", compile = false)).isEmpty()
+            assertThat(subject.lint("expect annotation class Test", compile = false)).isEmpty()
+            assertThat(subject.lint("private /* comment */ data class Test(val test: String)")).isEmpty()
         }
     }
 
@@ -44,13 +43,13 @@ class ModifierOrderSpec {
         @Test
         fun `should report wrongly ordered modifiers`() {
             val code = "lateinit internal var test: String"
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `should not report correctly ordered modifiers`() {
             val code = "internal lateinit var test: String"
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -67,7 +66,7 @@ class ModifierOrderSpec {
                     override open fun test() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -80,7 +79,7 @@ class ModifierOrderSpec {
                     override fun test() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -94,7 +93,7 @@ class ModifierOrderSpec {
                     tailrec private fun foo(x: Double = 1.0): Double = 1.0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -104,7 +103,7 @@ class ModifierOrderSpec {
                     private tailrec fun foo(x: Double = 1.0): Double = 1.0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -114,13 +113,13 @@ class ModifierOrderSpec {
         @Test
         fun `should report incorrectly ordered modifiers`() {
             val code = "class Foo(vararg private val strings: String) {}"
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
         fun `should not report correctly ordered modifiers`() {
             val code = "class Foo(private vararg val strings: String) {}"
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -134,7 +133,7 @@ class ModifierOrderSpec {
                     fun loadMore(): Boolean
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -147,7 +146,7 @@ class ModifierOrderSpec {
                 @JvmInline
                 private value class Foo(val bar: Int)
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class MultilineRawStringIndentationSpec {
                 Hello world!
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(2, 1)
@@ -35,7 +35,7 @@ class MultilineRawStringIndentationSpec {
                 How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(2)
                 .hasTextLocations("Hello world!", "How are you?")
@@ -49,7 +49,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(2, 2)
@@ -65,7 +65,7 @@ class MultilineRawStringIndentationSpec {
                      How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(2, 5)
@@ -81,7 +81,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -95,7 +95,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -109,7 +109,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -122,7 +122,7 @@ class MultilineRawStringIndentationSpec {
                   
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(3, 1)
@@ -137,7 +137,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(4, 1)
@@ -155,7 +155,7 @@ class MultilineRawStringIndentationSpec {
                     Hello world!
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(3, 5)
@@ -171,7 +171,7 @@ class MultilineRawStringIndentationSpec {
                     How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(2)
         }
@@ -185,7 +185,7 @@ class MultilineRawStringIndentationSpec {
                         How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(3, 6)
@@ -201,7 +201,7 @@ class MultilineRawStringIndentationSpec {
                          How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(3, 9)
@@ -218,7 +218,7 @@ class MultilineRawStringIndentationSpec {
                         How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -232,7 +232,7 @@ class MultilineRawStringIndentationSpec {
                         How are you?
                     $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -246,7 +246,7 @@ class MultilineRawStringIndentationSpec {
                         How are you?
                         $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(5, 5)
@@ -262,7 +262,7 @@ class MultilineRawStringIndentationSpec {
                         How are you?
                   $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(5, 3)
@@ -279,7 +279,7 @@ class MultilineRawStringIndentationSpec {
                 Hello world!
                 $TQ
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -288,7 +288,7 @@ class MultilineRawStringIndentationSpec {
             val code = """
                 val a = ${TQ}Hello world!$TQ
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -297,7 +297,7 @@ class MultilineRawStringIndentationSpec {
             val code = """
                 val a = "Hello world!"
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -307,7 +307,7 @@ class MultilineRawStringIndentationSpec {
                 val a = $TQ
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -317,7 +317,7 @@ class MultilineRawStringIndentationSpec {
             val code = """
                 val a = ${TQ}Hello world!$TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }
@@ -341,7 +341,7 @@ class MultilineRawStringIndentationSpec {
                 }
             """.trimIndent()
             val subject = MultilineRawStringIndentation(TestConfig("indentSize" to 1))
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -356,7 +356,7 @@ class MultilineRawStringIndentationSpec {
                     Hola mundo!
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
         }
@@ -368,7 +368,7 @@ class MultilineRawStringIndentationSpec {
                     Hello world!
                     Hola mundo!$TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
         }
@@ -379,7 +379,7 @@ class MultilineRawStringIndentationSpec {
                 val a = ${TQ}Hello world!
                     Hola mundo!$TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .hasSize(1)
         }
@@ -392,7 +392,7 @@ class MultilineRawStringIndentationSpec {
                     Hola mundo!
                 $TQ.trimIndent()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings)
                 .isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NestedClassesVisibilitySpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class NestedClassesVisibilitySpec {
                 public class C
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(3)
+        assertThat(subject.lint(code)).hasSize(3)
     }
 
     @Test
@@ -28,7 +28,7 @@ class NestedClassesVisibilitySpec {
                 public class C
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -41,7 +41,7 @@ class NestedClassesVisibilitySpec {
                  internal interface I
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -51,7 +51,7 @@ class NestedClassesVisibilitySpec {
                 private class A
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -61,7 +61,7 @@ class NestedClassesVisibilitySpec {
                 public enum class E { E1; }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -71,7 +71,7 @@ class NestedClassesVisibilitySpec {
                 public companion object C
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -81,7 +81,7 @@ class NestedClassesVisibilitySpec {
                 companion object C
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -91,7 +91,7 @@ class NestedClassesVisibilitySpec {
                  class A
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -101,7 +101,7 @@ class NestedClassesVisibilitySpec {
                  class A
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -113,6 +113,6 @@ class NestedClassesVisibilitySpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NewLineAtEndOfFileSpec {
@@ -12,19 +12,19 @@ class NewLineAtEndOfFileSpec {
     @Test
     fun `should not flag a kt file containing new line at the end`() {
         val code = "class Test\n"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `should flag a kt file not containing new line at the end`() {
         val code = "class Test"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
             .hasStartSourceLocation(1, 11)
     }
 
     @Test
     fun `should not flag an empty kt file`() {
         val code = ""
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NoTabsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class NoTabsSpec {
@@ -21,7 +21,7 @@ class NoTabsSpec {
               val multiStr = $TQ${'$'}{${TAB}methodOk()}$TQ // reports 1
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(5)
     }
 
@@ -38,7 +38,7 @@ class NoTabsSpec {
                 val multiStr = ""${'"'}A \t tab	""${'"'}
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/OptionalAbstractKeywordSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class OptionalAbstractKeywordSpec {
@@ -11,19 +11,19 @@ class OptionalAbstractKeywordSpec {
     @Test
     fun `does not report abstract keywords on an interface`() {
         val code = "interface A {}"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `reports abstract interface with abstract property`() {
         val code = "abstract interface A { abstract var x: Int }"
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
     fun `reports abstract interface with abstract function`() {
         val code = "abstract interface A { abstract fun x() }"
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
 
         assertThat(findings).hasSize(2)
         assertThat(findings).hasTextLocations(0 to 8, 23 to 31)
@@ -38,13 +38,13 @@ class OptionalAbstractKeywordSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
     fun `does not report an abstract class`() {
         val code = "abstract class A { abstract fun x() }"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -56,6 +56,6 @@ class OptionalAbstractKeywordSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected var i1 = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 5)
         }
@@ -35,7 +35,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 5)
         }
@@ -47,7 +47,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected fun function() {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 5)
         }
@@ -61,7 +61,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 9)
         }
@@ -75,7 +75,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasStartSourceLocations(
                 SourceLocation(2, 5),
@@ -94,7 +94,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(3)
             assertThat(findings).hasStartSourceLocations(
                 SourceLocation(2, 5),
@@ -114,7 +114,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(4, 13)
         }
@@ -128,7 +128,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(3, 9)
         }
@@ -138,7 +138,7 @@ class ProtectedMemberInFinalClassSpec {
             val code = """
                 class FinalClassWithProtectedConstructor protected constructor()
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 42)
         }
@@ -152,7 +152,7 @@ class ProtectedMemberInFinalClassSpec {
                      }               
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 6)
         }
@@ -164,7 +164,7 @@ class ProtectedMemberInFinalClassSpec {
                      protected val finalize get() = "hello world"         
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(2, 6)
         }
@@ -181,7 +181,7 @@ class ProtectedMemberInFinalClassSpec {
                     private val i = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -195,7 +195,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected override val abstractProp = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -210,7 +210,7 @@ class ProtectedMemberInFinalClassSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -223,7 +223,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected object InnerObject
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -233,7 +233,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected fun a() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -244,7 +244,7 @@ class ProtectedMemberInFinalClassSpec {
                     protected fun foo() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -256,7 +256,7 @@ class ProtectedMemberInFinalClassSpec {
                      }               
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RangeUntilInsteadOfRangeToSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10 - 1) {}
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage("`..` call can be replaced with `..<`")
     }
 
@@ -28,7 +28,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 ..< 10 - 1) {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10) {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -49,26 +49,26 @@ class RangeUntilInsteadOfRangeToSpec {
                 for (i in 0 .. 10 - 2) {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     @DisplayName("reports for '..'")
     fun reportsForDoubleDots() {
         val code = "val r = 0 .. 10 - 1"
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
     fun `does not report binary expressions without a range operator`() {
         val code = "val sum = 1 + 2"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `reports for 'rangeTo'`() {
         val code = "val r = 0.rangeTo(10 - 1)"
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage("`rangeTo` call can be replaced with `..<`")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeywordSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantConstructorKeywordSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -13,7 +13,7 @@ class RedundantConstructorKeywordSpec {
             data class Foo constructor(val foo: Int)
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(
             "The `constructor` keyword on Foo is redundant and should be removed."
@@ -25,7 +25,7 @@ class RedundantConstructorKeywordSpec {
             abstract class Foo constructor(val foo: Int)
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(
             "The `constructor` keyword on Foo is redundant and should be removed."
@@ -41,7 +41,7 @@ class RedundantConstructorKeywordSpec {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(
             "The `constructor` keyword on AnnotatedParam is redundant and should be removed."
@@ -53,7 +53,7 @@ class RedundantConstructorKeywordSpec {
             annotation class Foo constructor(val foo: Int)
         """.trimIndent()
 
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(
             "The `constructor` keyword on Foo is redundant and should be removed."
@@ -64,7 +64,7 @@ class RedundantConstructorKeywordSpec {
         val code = """
             data class Foo(val foo: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test fun `does not report on constructor with comments`() {
@@ -73,14 +73,14 @@ class RedundantConstructorKeywordSpec {
             // my comment
             constructor(val foo: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test fun `does not report on private constructor`() {
         val code = """
             class Foo private constructor(val foo: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test fun `does not report if annotated constructor`() {
@@ -89,6 +89,6 @@ class RedundantConstructorKeywordSpec {
 
             class Foo @Ann constructor(val foo: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantVisibilityModifierSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.FakeCompilerResources
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.jetbrains.kotlin.config.ExplicitApiMode
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class RedundantVisibilityModifierSpec {
                 override public fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -36,7 +36,7 @@ class RedundantVisibilityModifierSpec {
                 override fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -50,7 +50,7 @@ class RedundantVisibilityModifierSpec {
                 override public fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -60,7 +60,7 @@ class RedundantVisibilityModifierSpec {
                 public fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -70,7 +70,7 @@ class RedundantVisibilityModifierSpec {
                 fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -80,7 +80,7 @@ class RedundantVisibilityModifierSpec {
                 fun f() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -90,7 +90,7 @@ class RedundantVisibilityModifierSpec {
                 public fun f()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(2)
+        assertThat(subject.lint(code)).hasSize(2)
     }
 
     @Test
@@ -100,7 +100,7 @@ class RedundantVisibilityModifierSpec {
                 public val str : String = "test"
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -110,7 +110,7 @@ class RedundantVisibilityModifierSpec {
                 val str : String = "test"
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -124,7 +124,7 @@ class RedundantVisibilityModifierSpec {
                 override val test: String = "valid"
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -138,7 +138,7 @@ class RedundantVisibilityModifierSpec {
                 override public val test: String = "valid"
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -148,7 +148,7 @@ class RedundantVisibilityModifierSpec {
                 internal class InternalClass
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -158,7 +158,7 @@ class RedundantVisibilityModifierSpec {
                 internal fun internalFunction() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Nested
@@ -171,19 +171,19 @@ class RedundantVisibilityModifierSpec {
 
         @Test
         fun `does not report public function in class if explicit API mode is set to strict`() {
-            val findings = subject.compileAndLint(code, FakeCompilerResources(ExplicitApiMode.STRICT))
+            val findings = subject.lint(code, FakeCompilerResources(ExplicitApiMode.STRICT))
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not report public function in class if explicit API mode is set to warning`() {
-            val findings = subject.compileAndLint(code, FakeCompilerResources(ExplicitApiMode.WARNING))
+            val findings = subject.lint(code, FakeCompilerResources(ExplicitApiMode.WARNING))
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `reports public function in class if explicit API mode is disabled`() {
-            val findings = subject.compileAndLint(code, FakeCompilerResources(ExplicitApiMode.DISABLED))
+            val findings = subject.lint(code, FakeCompilerResources(ExplicitApiMode.DISABLED))
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ReturnCountSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -24,7 +23,7 @@ class ReturnCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ReturnCount(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ReturnCount(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -36,7 +35,7 @@ class ReturnCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ReturnCount(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ReturnCount(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -56,7 +55,7 @@ class ReturnCountSpec {
         @Test
         fun `should not get flagged for if condition guard clauses`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -80,14 +79,14 @@ class ReturnCountSpec {
         @Test
         fun `should not get flagged for if condition guard clauses`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged without guard clauses`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "false"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -115,7 +114,7 @@ class ReturnCountSpec {
         @Test
         fun `should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -136,7 +135,7 @@ class ReturnCountSpec {
         @Test
         fun `should not get flagged for ELVIS operator guard clauses`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -157,7 +156,7 @@ class ReturnCountSpec {
         @Test
         fun `should get flagged for an if condition guard clause which is not the first statement`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -178,7 +177,7 @@ class ReturnCountSpec {
         @Test
         fun `should get flagged for an ELVIS guard clause which is not the first statement`() {
             val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
-                .compileAndLint(code)
+                .lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -207,7 +206,7 @@ class ReturnCountSpec {
                 TestConfig(
                     EXCLUDE_GUARD_CLAUSES to "true"
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -217,7 +216,7 @@ class ReturnCountSpec {
                 TestConfig(
                     EXCLUDE_GUARD_CLAUSES to "false"
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -248,7 +247,7 @@ class ReturnCountSpec {
                         EXCLUDE_GUARD_CLAUSES to "true",
                         MAX to 0,
                     )
-                ).compileAndLint(code)
+                ).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -276,7 +275,7 @@ class ReturnCountSpec {
                         EXCLUDE_GUARD_CLAUSES to "true",
                         MAX to 0,
                     )
-                ).compileAndLint(code)
+                ).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -305,7 +304,7 @@ class ReturnCountSpec {
                         EXCLUDE_GUARD_CLAUSES to "true",
                         MAX to 0,
                     )
-                ).compileAndLint(code)
+                ).lint(code)
                 assertThat(findings).isEmpty()
             }
 
@@ -334,7 +333,7 @@ class ReturnCountSpec {
                         EXCLUDE_GUARD_CLAUSES to "false",
                         MAX to 3,
                     )
-                ).compileAndLint(code)
+                ).lint(code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -355,19 +354,19 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged by default`() {
-            val findings = ReturnCount(Config.empty).compileAndLint(code)
+            val findings = ReturnCount(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not get flagged when max value is 3`() {
-            val findings = ReturnCount(TestConfig(MAX to "3")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "3")).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(MAX to "1")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "1")).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -386,19 +385,19 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged by default`() {
-            val findings = ReturnCount(Config.empty).compileAndLint(code)
+            val findings = ReturnCount(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not get flagged when max value is 2`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(MAX to "1")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "1")).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -423,7 +422,7 @@ class ReturnCountSpec {
                     MAX to "2",
                     EXCLUDED_FUNCTIONS to listOf("test"),
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -466,7 +465,7 @@ class ReturnCountSpec {
                     MAX to "2",
                     EXCLUDED_FUNCTIONS to listOf("factorial", "fac"),
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -477,7 +476,7 @@ class ReturnCountSpec {
                     MAX to "2",
                     EXCLUDED_FUNCTIONS to listOf("fa*ctorial"),
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -505,7 +504,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -542,7 +541,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -581,7 +580,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -600,26 +599,21 @@ class ReturnCountSpec {
 
         @Test
         fun `should not count labeled returns from lambda by default`() {
-            val findings = ReturnCount(Config.empty).lint(code)
+            val findings = ReturnCount(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should count labeled returns from lambda when activated`() {
-            val findings = ReturnCount(
-                TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")
-            ).lint(code)
+            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+                .lint(code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should be empty when labeled returns are de-activated`() {
-            val findings = ReturnCount(
-                TestConfig(
-                    EXCLUDE_LABELED to "true",
-                    EXCLUDE_RETURN_FROM_LAMBDA to "false",
-                )
-            ).lint(code)
+            val findings = ReturnCount(TestConfig(EXCLUDE_LABELED to "true", EXCLUDE_RETURN_FROM_LAMBDA to "false",))
+                .lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -638,13 +632,13 @@ class ReturnCountSpec {
 
         @Test
         fun `should count labeled return of lambda with explicit label`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")).compileAndLint(code)
+            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")).lint(code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not count labeled return of lambda with explicit label when deactivated by default`() {
-            val findings = ReturnCount(Config.empty).compileAndLint(code)
+            val findings = ReturnCount(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -655,7 +649,7 @@ class ReturnCountSpec {
                     EXCLUDE_RETURN_FROM_LAMBDA to "true",
                     EXCLUDE_LABELED to "false",
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -686,7 +680,7 @@ class ReturnCountSpec {
                     EXCLUDE_GUARD_CLAUSES to "true",
                     MAX to 1,
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -726,7 +720,7 @@ class ReturnCountSpec {
                     EXCLUDE_GUARD_CLAUSES to "true",
                     MAX to 1,
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -754,7 +748,7 @@ class ReturnCountSpec {
                     EXCLUDE_GUARD_CLAUSES to "true",
                     MAX to 1,
                 )
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SafeCastSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 
 class SafeCastSpec {
@@ -19,7 +19,7 @@ class SafeCastSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -33,7 +33,7 @@ class SafeCastSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -43,7 +43,7 @@ class SafeCastSpec {
                 val cast = if (element !is Number) null else element
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -53,7 +53,7 @@ class SafeCastSpec {
                 val cast = if (element is Number) element else null
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -68,7 +68,7 @@ class SafeCastSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -82,6 +82,6 @@ class SafeCastSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -17,7 +17,7 @@ class SerialVersionUIDInSerializableClassSpec {
             
             class C : Serializable
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement()
             .hasMessage(
                 "The class C implements the `Serializable` interface and should thus define " +
@@ -39,7 +39,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
             .hasStartSourceLocation(5, 27)
@@ -57,7 +57,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
             .hasStartSourceLocation(5, 27)
@@ -75,7 +75,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
         assertThat(findings)
             .hasStartSourceLocation(5, 19)
@@ -97,7 +97,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings)
             .hasSize(2)
             .hasStartSourceLocations(SourceLocation(3, 7), SourceLocation(8, 12))
@@ -123,7 +123,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 private val serialVersionUID = 1L
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings)
             .hasSize(2)
             .hasStartSourceLocations(SourceLocation(5, 21), SourceLocation(8, 17))
@@ -151,7 +151,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings)
             .hasSize(2)
             .hasStartSourceLocations(SourceLocation(6, 25), SourceLocation(11, 21))
@@ -171,7 +171,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 class B : Serializable
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings)
             .hasSize(2)
             .hasStartSourceLocations(SourceLocation(3, 7), SourceLocation(4, 11))
@@ -185,7 +185,7 @@ class SerialVersionUIDInSerializableClassSpec {
     @Test
     fun `does not report a unserializable class`() {
         val code = "class NoSerializableClass"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -195,7 +195,7 @@ class SerialVersionUIDInSerializableClassSpec {
             
             interface I : Serializable
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -209,7 +209,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -223,7 +223,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -237,7 +237,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -251,7 +251,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -14,42 +13,42 @@ class SpacingAfterPackageDeclarationSpec {
     @Test
     fun `has no blank lines violation`() {
         val code = "package test\n\nimport a.b\n\nclass A {}"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Test
     fun `has a package and import declaration`() {
         val code = "package test\n\nimport a.b"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Test
     fun `has no import declaration`() {
         val code = "package test\n\nclass A {}"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `has no package declaration`() {
         val code = "import a.b\n\nclass A {}"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Test
     fun `has no package and import declaration`() {
         val code = "class A {}"
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
     fun `has a comment declaration`() {
         val code = "import a.b\n\n// a comment"
-        assertThat(subject.lint(code)).isEmpty()
+        assertThat(subject.lint(code, compile = false)).isEmpty()
     }
 
     @Test
     fun `is an empty kt file`() {
-        assertThat(subject.compileAndLint("")).isEmpty()
+        assertThat(subject.lint("")).isEmpty()
     }
 
     @Nested
@@ -80,25 +79,25 @@ class SpacingAfterPackageDeclarationSpec {
     @Test
     fun `has code on new line`() {
         val code = "package test\nimport a.b\nclass A {}"
-        assertThat(subject.lint(code)).hasSize(2)
+        assertThat(subject.lint(code, compile = false)).hasSize(2)
     }
 
     @Test
     fun `has code with spaces`() {
         val code = "package test; import a.b; class A {}"
-        assertThat(subject.lint(code)).hasSize(2)
+        assertThat(subject.lint(code, compile = false)).hasSize(2)
     }
 
     @Test
     fun `has too many blank lines`() {
         val code = "package test\n\n\nimport a.b\n\n\nclass A {}"
-        assertThat(subject.lint(code)).hasSize(2)
+        assertThat(subject.lint(code, compile = false)).hasSize(2)
     }
 
     @Test
     fun `has package declarations in same line`() {
         val code = "package test;import a.b;class A {}"
-        assertThat(subject.lint(code)).hasSize(2)
+        assertThat(subject.lint(code, compile = false)).hasSize(2)
     }
 
     @Test
@@ -111,7 +110,7 @@ class SpacingAfterPackageDeclarationSpec {
             
             class A { }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -122,6 +121,6 @@ class SpacingAfterPackageDeclarationSpec {
             import kotlin.collections.List
             import kotlin.collections.Set
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/StringShouldBeRawStringSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -21,7 +21,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject =
             StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -37,7 +37,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject =
             StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -56,7 +56,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject =
             StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -75,7 +75,7 @@ class StringShouldBeRawStringSpec {
         """.trimIndent()
         val subject =
             StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to maxEscapedCharacterCount - 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -100,7 +100,7 @@ class StringShouldBeRawStringSpec {
                 IGNORED_CHARACTERS to allowedCharacters,
             )
         )
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -114,7 +114,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -126,7 +126,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -139,7 +139,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -150,7 +150,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = !"\n\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -161,7 +161,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = "\n\n".not()
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -172,7 +172,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -183,7 +183,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + "\n\n\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -194,7 +194,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + "\n" + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -205,7 +205,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = ((!"\n\n").toString() + "\n") + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -216,7 +216,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + ("\n" + "\n")
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -227,7 +227,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -238,7 +238,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!"\n\n").toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -249,7 +249,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = (!("\n\n" + "\n")).toString() + ("\n" + "\n") + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -260,7 +260,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = ((!"\n\n").toString()) + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -271,7 +271,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = "\n\n"[0] + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -282,7 +282,7 @@ class StringShouldBeRawStringSpec {
             val totalSize = ("\n\n"[0]) + "\n"
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -295,7 +295,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -308,7 +308,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 1))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(2)
     }
 
@@ -321,7 +321,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -336,7 +336,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 2))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -349,7 +349,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -362,7 +362,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -376,7 +376,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -393,7 +393,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).singleElement().hasSourceLocation(5, 13)
     }
 
@@ -411,7 +411,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -425,7 +425,7 @@ class StringShouldBeRawStringSpec {
             }
         """.trimIndent()
         val subject = StringShouldBeRawString(TestConfig(MAX_ESCAPED_CHARACTER_COUNT to 0))
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ThrowsCountSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -21,7 +20,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ThrowsCount(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ThrowsCount(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -33,7 +32,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation by default`() {
-            assertThat(ThrowsCount(Config.empty).compileAndLint(code)).isEmpty()
+            assertThat(ThrowsCount(Config.empty).lint(code)).isEmpty()
         }
     }
 
@@ -53,7 +52,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report violation`() {
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -74,7 +73,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `reports violation by default`() {
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -95,7 +94,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `reports violation by default`() {
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code, compile = false)).hasSize(1)
         }
     }
 
@@ -119,7 +118,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `reports violation by default`() {
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.location.source.line).isEqualTo(4)
         }
@@ -141,14 +140,14 @@ class ThrowsCountSpec {
         fun `does not report when max parameter is 3`() {
             val config = TestConfig(MAX to "3")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports violation when max parameter is 2`() {
             val config = TestConfig(MAX to "2")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -169,14 +168,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithGuardClause)).isEmpty()
+            assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithGuardClause)).hasSize(1)
+            assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
     }
 
@@ -197,14 +196,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithGuardClause)).isEmpty()
+            assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithGuardClause)).hasSize(1)
+            assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
     }
 
@@ -232,7 +231,7 @@ class ThrowsCountSpec {
         fun `should report violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -253,7 +252,7 @@ class ThrowsCountSpec {
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -274,7 +273,7 @@ class ThrowsCountSpec {
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithIfCondition)).hasSize(1)
+            assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
     }
 
@@ -298,14 +297,14 @@ class ThrowsCountSpec {
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithMultipleGuardClauses)).isEmpty()
+            assertThat(subject.lint(codeWithMultipleGuardClauses)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
             val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
             val subject = ThrowsCount(config)
-            assertThat(subject.compileAndLint(codeWithMultipleGuardClauses)).hasSize(1)
+            assertThat(subject.lint(codeWithMultipleGuardClauses)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrailingWhitespaceSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -15,28 +15,28 @@ class TrailingWhitespaceSpec {
         @Test
         fun `reports a line just with a whitespace`() {
             val code = " "
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasTextLocations(0 to 1)
         }
 
         @Test
         fun `reports a commented line with a whitespace at the end`() {
             val code = "// A comment "
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasTextLocations(12 to 13)
         }
 
         @Test
         fun `reports a class declaration with a whitespace at the end`() {
             val code = "  class TrailingWhitespacePositive { \n  }"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasTextLocations(36 to 37)
         }
 
         @Test
         fun `reports a print statement with a tab at the end`() {
             val code = "\t\tprintln(\"A message\")\t"
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).hasTextLocations(22 to 23)
         }
     }
@@ -55,7 +55,7 @@ class TrailingWhitespaceSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -68,7 +68,7 @@ class TrailingWhitespaceSpec {
                     Should ignore indent on the previous line
                 ""${'"'}
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/TrimMultilineRawStringSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -16,7 +16,7 @@ class TrimMultilineRawStringSpec {
             Hello world!
             $TQ
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -28,7 +28,7 @@ class TrimMultilineRawStringSpec {
             Hello world!
             $TQ.trimIndent()
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -41,7 +41,7 @@ class TrimMultilineRawStringSpec {
             $TQ.customTrim()
         """.trimIndent()
         val findings = TrimMultilineRawString(TestConfig("trimmingMethods" to listOf("customTrim")))
-            .compileAndLint(code)
+            .lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -52,7 +52,7 @@ class TrimMultilineRawStringSpec {
             Hello world!
             $TQ.length
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -63,7 +63,7 @@ class TrimMultilineRawStringSpec {
             Hello world!
             $TQ.trimIndent()
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -74,7 +74,7 @@ class TrimMultilineRawStringSpec {
             |Hello world!
             $TQ.trimMargin()
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -85,7 +85,7 @@ class TrimMultilineRawStringSpec {
             >Hello world!
             $TQ.trimMargin(">")
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -94,7 +94,7 @@ class TrimMultilineRawStringSpec {
         val code = """
             val a = ${TQ}Hello world!$TQ
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -103,7 +103,7 @@ class TrimMultilineRawStringSpec {
         val code = """
             val a = "Hello world!"
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -114,7 +114,7 @@ class TrimMultilineRawStringSpec {
                 "cruel"
             } world!"
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -130,7 +130,7 @@ class TrimMultilineRawStringSpec {
                     $TQ
             }
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -147,7 +147,7 @@ class TrimMultilineRawStringSpec {
             )
             class Foo
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -163,7 +163,7 @@ class TrimMultilineRawStringSpec {
                     $TQ
             )
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -180,7 +180,7 @@ class TrimMultilineRawStringSpec {
             )
             class Foo
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -196,7 +196,7 @@ class TrimMultilineRawStringSpec {
                     $TQ
             )
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -20,7 +19,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -28,7 +27,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "3")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -39,7 +38,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -50,7 +49,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -58,7 +57,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "7")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -69,7 +68,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -77,7 +76,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "3")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -88,7 +87,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -96,7 +95,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "3")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -107,7 +106,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -118,7 +117,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -126,7 +125,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should not be reported if ignored acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "7")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -138,7 +137,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -149,7 +148,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -157,7 +156,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "3")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -168,7 +167,8 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
+            val findings =
+                UnderscoresInNumericLiterals(Config.empty).lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
     }
@@ -179,7 +179,8 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
+            val findings =
+                UnderscoresInNumericLiterals(Config.empty).lint(code, compile = false)
             assertThat(findings).isNotEmpty
         }
     }
@@ -190,7 +191,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -198,7 +199,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should still be reported even if acceptableLength is 99`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "99")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -206,7 +207,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should not be reported if allowNonStandardGrouping is true`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ALLOW_NON_STANDARD_GROUPING to true)
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -217,7 +218,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -228,7 +229,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -239,7 +240,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -256,7 +257,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -271,7 +272,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -286,7 +287,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -305,7 +306,7 @@ class UnderscoresInNumericLiteralsSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -320,7 +321,7 @@ class UnderscoresInNumericLiteralsSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -337,7 +338,7 @@ class UnderscoresInNumericLiteralsSpec {
                     private val serialVersionUID = -43857148126114372L
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -350,7 +351,7 @@ class UnderscoresInNumericLiteralsSpec {
                     private val serialVersionUID = 43857148126114372L
                 }
             """.trimIndent()
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -361,7 +362,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -369,7 +370,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should not be reported if acceptableLength is 5`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "5")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -381,7 +382,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -393,7 +394,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -407,7 +408,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "3")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isNotEmpty
         }
     }
@@ -419,7 +420,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isNotEmpty
         }
 
@@ -427,7 +428,7 @@ class UnderscoresInNumericLiteralsSpec {
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
                 TestConfig(ACCEPTABLE_LENGTH to "7")
-            ).compileAndLint(code)
+            ).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -439,7 +440,7 @@ class UnderscoresInNumericLiteralsSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = UnderscoresInNumericLiterals(Config.empty).compileAndLint(code)
+            val findings = UnderscoresInNumericLiterals(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTargetSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -16,7 +16,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("param:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).hasTextLocations("param:")
     }
 
     @Test
@@ -27,7 +27,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("param:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).hasTextLocations("param:")
     }
 
     @Test
@@ -38,7 +38,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -49,7 +49,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).isEmpty()
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).isEmpty()
     }
 
     @Test
@@ -62,7 +62,7 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("property:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).hasTextLocations("property:")
     }
 
     @Test
@@ -73,6 +73,6 @@ class UnnecessaryAnnotationUseSiteTargetSpec {
             
             annotation class Asdf
         """.trimIndent()
-        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).compileAndLint(code)).hasTextLocations("property:")
+        assertThat(UnnecessaryAnnotationUseSiteTarget(Config.empty).lint(code)).hasTextLocations("property:")
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryBackticksSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class UnnecessaryBackticksSpec {
                     val y = ::`Foo`
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(4)
+            assertThat(subject.lint(code)).hasSize(4)
         }
 
         @Test
@@ -29,7 +29,7 @@ class UnnecessaryBackticksSpec {
                 val x = `foo`()
                 val y = ::`foo`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(3)
+            assertThat(subject.lint(code)).hasSize(3)
         }
 
         @Test
@@ -40,7 +40,7 @@ class UnnecessaryBackticksSpec {
                 val y = ::`foo`
                 val z = `foo`.length
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(4)
+            assertThat(subject.lint(code)).hasSize(4)
         }
 
         @Test
@@ -48,7 +48,7 @@ class UnnecessaryBackticksSpec {
             val code = """
                 import kotlin.`let`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -59,7 +59,7 @@ class UnnecessaryBackticksSpec {
                 val y = "${'$'}`foo` bar"
                 val z = "${'$'}{`foo`}bar"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(3)
+            assertThat(subject.lint(code)).hasSize(3)
         }
     }
 
@@ -72,7 +72,7 @@ class UnnecessaryBackticksSpec {
                 val x: `Foo Bar` = `Foo Bar`()
                 val y = ::`Foo Bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -82,7 +82,7 @@ class UnnecessaryBackticksSpec {
                 val x = `foo bar`()
                 val y = ::`foo bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -93,7 +93,7 @@ class UnnecessaryBackticksSpec {
                 val y = ::`foo bar`
                 val z = `foo bar`.length
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -102,7 +102,7 @@ class UnnecessaryBackticksSpec {
                 val `is` = 1
                 val `fun` = 2
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -111,7 +111,7 @@ class UnnecessaryBackticksSpec {
                 val `_` = 1
                 val `__` = 2
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -121,7 +121,7 @@ class UnnecessaryBackticksSpec {
                 import test.`Foo Bar`
                 class `Foo Bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -132,7 +132,7 @@ class UnnecessaryBackticksSpec {
                 val `bar baz` = ""
                 val y = "${'$'}`bar baz`"
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInheritanceSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -11,7 +10,7 @@ class UnnecessaryInheritanceSpec {
 
     @Test
     fun `has unnecessary super type declarations`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 class A : Any()
                 class B : Object()
@@ -22,7 +21,7 @@ class UnnecessaryInheritanceSpec {
 
     @Test
     fun `has no unnecessary super type declarations`() {
-        val findings = subject.lint("class C : An()")
+        val findings = subject.lint("class C : An()", compile = false)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Named
@@ -16,7 +15,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on val assignment`(testCase: RuleTestCase) {
         val code = "val local = (5)"
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -24,7 +23,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on val assignment operation`(testCase: RuleTestCase) {
         val code = "val local = (5 + 3)"
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -32,7 +31,7 @@ class UnnecessaryParenthesesSpec {
     fun `with unnecessary parentheses on function call`(testCase: RuleTestCase) {
         val code = "val local = 3.plus((5))"
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -46,7 +45,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -62,7 +61,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -78,7 +77,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -90,7 +89,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code, compile = false)).isEmpty()
     }
 
     @ParameterizedTest
@@ -104,7 +103,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -119,7 +118,7 @@ class UnnecessaryParenthesesSpec {
             })
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code, compile = false)).isEmpty()
     }
 
     @ParameterizedTest
@@ -134,7 +133,7 @@ class UnnecessaryParenthesesSpec {
             })
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code, compile = false)).isEmpty()
     }
 
     @ParameterizedTest
@@ -148,7 +147,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code, compile = false)).isEmpty()
     }
 
     @ParameterizedTest
@@ -169,7 +168,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -188,7 +187,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -209,7 +208,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code, compile = false)).isEmpty()
     }
 
     @ParameterizedTest
@@ -219,7 +218,7 @@ class UnnecessaryParenthesesSpec {
             class Clazz: Comparable<String> by ("hello".filter { it != 'l' })
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -237,7 +236,7 @@ class UnnecessaryParenthesesSpec {
             val c = (4 + 5) * 3 // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
     }
 
     @ParameterizedTest
@@ -251,7 +250,7 @@ class UnnecessaryParenthesesSpec {
             val b2 = (1 * 2) * 3
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(5)
+        assertThat(testCase.rule.lint(code)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -264,7 +263,7 @@ class UnnecessaryParenthesesSpec {
             val c = (true || false) && false // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
 
     @ParameterizedTest
@@ -278,7 +277,7 @@ class UnnecessaryParenthesesSpec {
             val b2 = (true || false) || false
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(5)
+        assertThat(testCase.rule.lint(code)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -289,7 +288,7 @@ class UnnecessaryParenthesesSpec {
             val e = false or (true and false) // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -318,7 +317,7 @@ class UnnecessaryParenthesesSpec {
 
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
+        assertThat(testCase.rule.lint(code, compile = false)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 6)
     }
 
     @ParameterizedTest
@@ -333,7 +332,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -350,7 +349,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 2)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 2)
     }
 
     @ParameterizedTest
@@ -363,7 +362,7 @@ class UnnecessaryParenthesesSpec {
             val d = (1 to 2)..(3 to 4) // parens required
         """.trimIndent()
 
-        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+        assertThat(testCase.rule.lint(code, compile = false)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
 
     @ParameterizedTest
@@ -373,7 +372,7 @@ class UnnecessaryParenthesesSpec {
             val a = (1)..(2)
             val b = (1)..<(2)
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+        assertThat(testCase.rule.lint(code)).hasSize(4)
     }
 
     @ParameterizedTest
@@ -398,7 +397,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -421,7 +420,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 4)
     }
 
     @ParameterizedTest
@@ -441,7 +440,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -460,7 +459,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -482,7 +481,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @Test
@@ -504,9 +503,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.compileAndLint(code)).hasSize(
-            3
-        )
+        assertThat(RuleTestCase(allowForUnclearPrecedence = true).rule.lint(code, compile = true)).hasSize(3)
     }
 
     @Test
@@ -527,9 +524,7 @@ class UnnecessaryParenthesesSpec {
                 val violation3 = ++((a.value))
             }
         """.trimIndent()
-        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.compileAndLint(code)).hasSize(
-            5
-        )
+        assertThat(RuleTestCase(allowForUnclearPrecedence = false).rule.lint(code, compile = true)).hasSize(5)
     }
 
     @ParameterizedTest
@@ -552,7 +547,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).isEmpty()
+        assertThat(testCase.rule.lint(code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -576,7 +571,7 @@ class UnnecessaryParenthesesSpec {
             }
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 3)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 3)
     }
 
     @ParameterizedTest
@@ -586,7 +581,7 @@ class UnnecessaryParenthesesSpec {
             val a = ((false || (((true && false)))))
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 4 else 5)
     }
 
     @ParameterizedTest
@@ -597,7 +592,7 @@ class UnnecessaryParenthesesSpec {
         val code = """
             val a = .1F..(.2F)
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -606,7 +601,7 @@ class UnnecessaryParenthesesSpec {
         val code = """
             val a = (.1F)..0.2F
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(1)
+        assertThat(testCase.rule.lint(code)).hasSize(1)
     }
 
     @ParameterizedTest
@@ -618,7 +613,7 @@ class UnnecessaryParenthesesSpec {
             val c = (.1F)..<.2F
             val d = (.1F)..<.2F
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+        assertThat(testCase.rule.lint(code)).hasSize(4)
     }
 
     @ParameterizedTest
@@ -628,7 +623,7 @@ class UnnecessaryParenthesesSpec {
             val a = .1..(.2)
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
+        assertThat(testCase.rule.lint(code)).hasSize(if (testCase.allowForUnclearPrecedence) 0 else 1)
     }
 
     @ParameterizedTest
@@ -641,7 +636,7 @@ class UnnecessaryParenthesesSpec {
             val d = (0.1)..<0.2
         """.trimIndent()
 
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(4)
+        assertThat(testCase.rule.lint(code)).hasSize(4)
     }
 
     @ParameterizedTest
@@ -652,7 +647,7 @@ class UnnecessaryParenthesesSpec {
             val b = 0.3
             val range = (a)..(b)
         """.trimIndent()
-        assertThat(testCase.rule.compileAndLint(code)).hasSize(2)
+        assertThat(testCase.rule.lint(code)).hasSize(2)
     }
 
     companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -21,7 +20,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -32,7 +31,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -43,7 +42,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -54,7 +53,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -65,7 +64,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -80,7 +79,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -100,7 +99,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(2)
+            assertThat(subject.lint(code)).hasSize(2)
         }
 
         @Test
@@ -115,7 +114,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -130,7 +129,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -145,7 +144,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
 
         @Test
@@ -160,7 +159,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).hasSize(1)
+            assertThat(subject.lint(code)).hasSize(1)
         }
     }
 
@@ -172,7 +171,7 @@ class UnusedParameterSpec {
                 fun foo(@Suppress("UnusedParameter") unused: String){}
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -181,7 +180,7 @@ class UnusedParameterSpec {
                 fun foo(@Suppress("UnusedParameter") unused: String, unusedWithoutAnnotation: String){}
             """.trimIndent()
 
-            val lint = subject.compileAndLint(code)
+            val lint = subject.lint(code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].message).isEqualTo("Function parameter `unusedWithoutAnnotation` is unused.")
@@ -194,7 +193,7 @@ class UnusedParameterSpec {
                 fun foo(unused: String, otherUnused: String){}
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -207,7 +206,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -219,7 +218,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -235,7 +234,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -247,7 +246,7 @@ class UnusedParameterSpec {
                 fun foo(unused: Int){}
             """.trimIndent()
 
-            val lint = subject.compileAndLint(code)
+            val lint = subject.lint(code)
 
             assertThat(lint.first().message).startsWith("Function parameter")
         }
@@ -267,7 +266,7 @@ class UnusedParameterSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -277,7 +276,7 @@ class UnusedParameterSpec {
                     println("b")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -288,7 +287,7 @@ class UnusedParameterSpec {
             val code = """
                 fun test(`foo bar`: Int) = `foo bar`
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -307,7 +306,7 @@ class UnusedParameterSpec {
                     ) = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1).hasStartSourceLocation(6, 9)
+            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(6, 9)
         }
     }
 
@@ -324,7 +323,7 @@ class UnusedParameterSpec {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).hasSize(1).hasStartSourceLocation(1, 9)
+            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(1, 9)
         }
 
         @Test
@@ -338,7 +337,7 @@ class UnusedParameterSpec {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
     }
 
@@ -353,7 +352,7 @@ class UnusedParameterSpec {
                     actual fun baz(i: Int, s: String) {}
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code, compile = false)).isEmpty()
         }
 
         @Test
@@ -361,7 +360,7 @@ class UnusedParameterSpec {
             val code = """
                 actual class Foo actual constructor(bar: String) {}
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +20,7 @@ class UnusedPrivateClassSpec {
                 class Bar
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 1)
@@ -36,7 +36,7 @@ class UnusedPrivateClassSpec {
                     class Bar
                 """.trimIndent()
 
-                val findings = subject.compileAndLint(code)
+                val findings = subject.lint(code)
 
                 assertThat(findings).hasSize(1)
                 assertThat(findings).hasStartSourceLocation(1, 1)
@@ -49,7 +49,7 @@ class UnusedPrivateClassSpec {
                     private class Bar : Foo()
                 """.trimIndent()
 
-                val findings = subject.compileAndLint(code)
+                val findings = subject.lint(code)
 
                 assertThat(findings).hasSize(1)
                 assertThat(findings).hasStartSourceLocation(2, 1)
@@ -68,7 +68,7 @@ class UnusedPrivateClassSpec {
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLint(code)
+                val findings = subject.lint(code)
 
                 assertThat(findings).isEmpty()
             }
@@ -83,7 +83,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -97,7 +97,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -109,7 +109,7 @@ class UnusedPrivateClassSpec {
                 private val a: Foo? = null
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -121,7 +121,7 @@ class UnusedPrivateClassSpec {
                 private lateinit var a: Foo
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -133,7 +133,7 @@ class UnusedPrivateClassSpec {
                 private lateinit var foos: List<Foo>
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -145,7 +145,7 @@ class UnusedPrivateClassSpec {
                 private class Item
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -157,7 +157,7 @@ class UnusedPrivateClassSpec {
                 private abstract class Something<E>: Collection<E>
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -173,7 +173,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -185,7 +185,7 @@ class UnusedPrivateClassSpec {
                 private lateinit var foos: List<List<Foo>>
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -197,7 +197,7 @@ class UnusedPrivateClassSpec {
                 private lateinit var foos: Foo<String>
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -209,7 +209,7 @@ class UnusedPrivateClassSpec {
                 private var foos: Foo<String>? = Foo()
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -221,7 +221,7 @@ class UnusedPrivateClassSpec {
                 private val a = Foo()
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -233,7 +233,7 @@ class UnusedPrivateClassSpec {
                 private val a = Foo("test")
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -247,7 +247,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -259,7 +259,7 @@ class UnusedPrivateClassSpec {
                 private val lambda: ((Foo) -> Unit)? = null
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -271,7 +271,7 @@ class UnusedPrivateClassSpec {
                 private val lambda: (() -> Foo)? = null
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -283,7 +283,7 @@ class UnusedPrivateClassSpec {
                 private val lambda: (() -> List<Foo>)? = null
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -302,7 +302,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -313,7 +313,7 @@ class UnusedPrivateClassSpec {
                 private class Foo(val bar: String)
                 private fun f(a: Any) = a as Foo
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -323,7 +323,7 @@ class UnusedPrivateClassSpec {
                 private class Foo(val bar: String)
                 private fun f(a: Any) = a is Foo
             """.trimIndent()
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -340,7 +340,7 @@ class UnusedPrivateClassSpec {
                 fun bar(clazz: KClass<*>) = Unit
             """.trimIndent()
 
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
 
             assertThat(findings).hasSize(1)
         }
@@ -360,7 +360,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -385,7 +385,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -404,7 +404,7 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
 
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
 
             assertThat(findings).isEmpty()
         }
@@ -428,7 +428,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -453,7 +453,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(10, 5)
         }
@@ -465,7 +465,7 @@ class UnusedPrivateClassSpec {
 
                 private val listOfConstructors = listOf(::A)
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -478,7 +478,7 @@ class UnusedPrivateClassSpec {
                     private val list = listOf(Parent::Foo)
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -492,7 +492,7 @@ class UnusedPrivateClassSpec {
                     }
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -505,7 +505,7 @@ class UnusedPrivateClassSpec {
                     private val list = listOf(::Foo)
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -520,7 +520,7 @@ class UnusedPrivateClassSpec {
                     private val list = listOf(1).map(::Foo)
                 }
             """.trimIndent()
-            val findings = UnusedPrivateClass(Config.empty).compileAndLint(code)
+            val findings = UnusedPrivateClass(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseArrayLiteralsInAnnotationsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -12,7 +12,7 @@ class UseArrayLiteralsInAnnotationsSpec {
 
     @Test
     fun `finds an arrayOf usage`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 annotation class Test(val values: Array<String>)
                 @Test(arrayOf("value"))
@@ -31,7 +31,7 @@ class UseArrayLiteralsInAnnotationsSpec {
             @Test(intArrayOf(1, 2))
             fun test() {}
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -43,7 +43,7 @@ class UseArrayLiteralsInAnnotationsSpec {
             @Test(longArrayOf(1, 2))
             fun test() {}
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings).hasSize(1)
     }
 
@@ -52,7 +52,7 @@ class UseArrayLiteralsInAnnotationsSpec {
         val code = """
             annotation class Test(val s: Array<String> = arrayOf("a", "b"))
         """.trimIndent()
-        val findings = subject.compileAndLint(code)
+        val findings = subject.lint(code)
         assertThat(findings)
             .hasSize(1)
             .hasTextLocations(45 to 62)
@@ -61,7 +61,7 @@ class UseArrayLiteralsInAnnotationsSpec {
     @Test
     @DisplayName("expects [] syntax")
     fun expectsBracketSyntax() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 annotation class Test(val values: Array<String>)
                 @Test(["value"])

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfInsteadOfWhenSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class UseIfInsteadOfWhenSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     @Test
@@ -34,7 +34,7 @@ class UseIfInsteadOfWhenSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -49,7 +49,7 @@ class UseIfInsteadOfWhenSpec {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test
@@ -64,7 +64,7 @@ class UseIfInsteadOfWhenSpec {
                 return false
             }
         """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     // TC inspired from https://github.com/JetBrains/kotlin/pull/2921/files
@@ -84,7 +84,7 @@ class UseIfInsteadOfWhenSpec {
             }
         """.trimIndent()
         val subject = UseIfInsteadOfWhen(TestConfig(IGNORE_WHEN_CONTAINING_VARIABLE_DECLARATION to true))
-        assertThat(subject.compileAndLint(code)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     // TC inspired from https://github.com/JetBrains/kotlin/pull/2921/files
@@ -104,7 +104,7 @@ class UseIfInsteadOfWhenSpec {
             }
         """.trimIndent()
         val subject = UseIfInsteadOfWhen(TestConfig(IGNORE_WHEN_CONTAINING_VARIABLE_DECLARATION to false))
-        assertThat(subject.compileAndLint(code)).hasSize(1)
+        assertThat(subject.lint(code)).hasSize(1)
     }
 
     companion object {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseLetSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
@@ -37,7 +37,7 @@ class UseLetSpec {
                     DynamicTest.dynamicTest("($condition) $left else $right") {
                         val expr = "fun test() = if ($condition) $left else $right"
                         val shouldFail = (isNonNullCheck && rightIsNull) || (isNullCheck && leftIsNull)
-                        val findings = subject.compileAndLint(expr)
+                        val findings = subject.lint(expr)
                         if (shouldFail) {
                             assertThat(findings).singleElement().hasMessage(subject.description)
                         } else {
@@ -51,7 +51,7 @@ class UseLetSpec {
 
     @Test
     fun `do not capture blocks that have multiple expressions`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 fun testCallToCreateTempFile(s: String?) {
                     val x = if (s == null) {
@@ -69,7 +69,7 @@ class UseLetSpec {
 
     @Test
     fun `it allows the following expressions (currently)`() {
-        val findings = subject.compileAndLint(
+        val findings = subject.lint(
             """
                 fun testCallToCreateTempFile() {
                     val x: String? = "abc"

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UtilityClassWithPublicConstructorSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -20,7 +19,7 @@ class UtilityClassWithPublicConstructorSpec {
 
         @BeforeEach
         fun beforeEachTest() {
-            findings = subject.compileAndLint(
+            findings = subject.lint(
                 """
                     class UtilityClassWithDefaultConstructor { // violation
                         companion object {
@@ -98,7 +97,7 @@ class UtilityClassWithPublicConstructorSpec {
         @Suppress("LongMethod") // TODO split this up into multiple test case functions.
         @Test
         fun `does not report given classes`() {
-            val findings = subject.compileAndLint(
+            val findings = subject.lint(
                 """
                     class UtilityClassWithPrimaryPrivateConstructorOk private constructor() {
                         companion object {
@@ -227,7 +226,7 @@ class UtilityClassWithPublicConstructorSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lint(code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -4,6 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/WildcardImportSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -25,7 +25,7 @@ class WildcardImportSpec {
         fun `should report all wildcard imports`() {
             val rule = WildcardImport(Config.empty)
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(2)
         }
 
@@ -33,7 +33,7 @@ class WildcardImportSpec {
         fun `should not report excluded wildcard imports`() {
             val rule = WildcardImport(TestConfig(EXCLUDED_IMPORTS to listOf("org.assertj.core.api.Assertions.*")))
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -48,7 +48,7 @@ class WildcardImportSpec {
                 )
             )
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -56,7 +56,7 @@ class WildcardImportSpec {
         fun `ignores excludes that are not matching`() {
             val rule = WildcardImport(TestConfig(EXCLUDED_IMPORTS to listOf("other.test.*")))
 
-            val findings = rule.compileAndLint(code)
+            val findings = rule.lint(code)
             assertThat(findings).hasSize(2)
         }
 
@@ -66,7 +66,7 @@ class WildcardImportSpec {
                 import java.util.*
             """.trimIndent()
 
-            val findings = WildcardImport(Config.empty).compileAndLint(code2)
+            val findings = WildcardImport(Config.empty).lint(code2)
             assertThat(findings).isEmpty()
         }
     }
@@ -84,7 +84,7 @@ class WildcardImportSpec {
 
         @Test
         fun `should not report any issues`() {
-            val findings = WildcardImport(Config.empty).compileAndLint(code)
+            val findings = WildcardImport(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/MandatoryBracesLoopsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.test.compileAndLint
+import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -24,7 +24,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -35,7 +35,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -46,7 +46,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -58,7 +58,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.ktElement.text).isEqualTo("println(i)")
@@ -74,7 +74,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -89,7 +89,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -100,7 +100,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -114,7 +114,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].location.source).isEqualTo(SourceLocation(line = 3, column = 9))
@@ -131,7 +131,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
         }
@@ -146,7 +146,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(2)
 
@@ -167,7 +167,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].location.source).isEqualTo(SourceLocation(line = 4, column = 9))
@@ -188,7 +188,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].location.source).isEqualTo(SourceLocation(line = 6, column = 13))
@@ -208,7 +208,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -219,7 +219,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -231,7 +231,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.ktElement.text).isEqualTo("println()")
@@ -247,7 +247,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -261,7 +261,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
         }
@@ -280,7 +280,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -291,7 +291,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -304,7 +304,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].entity.ktElement.text).isEqualTo("println()")
@@ -321,7 +321,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -336,7 +336,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -348,7 +348,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLint(code)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -363,7 +363,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].location.source).isEqualTo(SourceLocation(line = 3, column = 9))
@@ -381,7 +381,7 @@ class MandatoryBracesLoopsSpec {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLint(code)
+            val findings = subject.lint(code)
 
             assertThat(findings).hasSize(1)
         }

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -41,13 +41,11 @@ public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
-	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
-	public static synthetic fun compileAndLint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
-	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
+	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
-	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -41,8 +41,8 @@ public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
-	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
-	public static synthetic fun compileAndLint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun compileAndLint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
+	public static synthetic fun compileAndLint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -18,33 +18,23 @@ import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
 private val shouldCompileTestSnippets: Boolean =
     System.getProperty("compile-test-snippets", "false")!!.toBoolean()
 
-fun Rule.compileAndLint(
+fun Rule.lint(
     @Language("kotlin") content: String,
     compilerResources: CompilerResources = FakeCompilerResources(),
     compile: Boolean = true,
 ): List<Finding> {
     require(this !is RequiresFullAnalysis) {
-        "${this.ruleName} requires full analysis so you should use compileAndLintWithContext instead of compileAndLint"
+        if (compile) {
+            "${this.ruleName} requires full analysis so you should use compileAndLintWithContext instead of lint"
+        } else {
+            "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
+        }
     }
     if (compile && shouldCompileTestSnippets) {
         KotlinScriptEngine.compile(content)
     }
     val ktFile = compileContentForTest(content)
     return visitFile(ktFile, compilerResources = compilerResources).filterSuppressed(this)
-}
-
-@Deprecated(
-    "Use compileAndLint with compile = false",
-    ReplaceWith("compileAndLint(content, compilerResources, false)"),
-)
-fun Rule.lint(
-    @Language("kotlin") content: String,
-    compilerResources: CompilerResources = FakeCompilerResources(),
-): List<Finding> {
-    require(this !is RequiresFullAnalysis) {
-        "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
-    }
-    return compileAndLint(content, compilerResources, false)
 }
 
 fun Rule.lintWithContext(
@@ -57,7 +47,7 @@ fun Rule.lintWithContext(
     ),
 ): List<Finding> {
     require(this is RequiresFullAnalysis) {
-        "${this.ruleName} doesn't require full analysis so you should use lint instead of lintWithContext"
+        "${this.ruleName} doesn't require full analysis so you should use lint instead of lint"
     }
     val ktFile = compileContentForTest(content)
     val additionalKtFiles = additionalContents.mapIndexed { index, additionalContent ->
@@ -77,7 +67,7 @@ fun Rule.compileAndLintWithContext(
     ),
 ): List<Finding> {
     require(this is RequiresFullAnalysis) {
-        "${this.ruleName} doesn't require full analysis so you should use compileAndLintWithContext instead of " +
+        "${this.ruleName} doesn't require full analysis so you should use lint with compile = true instead of " +
             "compileAndLint"
     }
     if (shouldCompileTestSnippets) {


### PR DESCRIPTION
The idea behind this change is that we don't want usages of the old `lint` because it doesn't checks that the code is "real" kotlin. This is bad because we assume that the code is correct to do our analysis so the test could be wrong. But we also know that there are cases where it's easier to just use `lint` with code that doesn't compile for multiple reasons.

This PR what it does is to rename `compileAndLint` to `lint` so the funcion is always the same AND if you in one case doesn't want to compile the snippet of code you can set `.lint(code, compile = false)` to specify that you don't want to verify the snippet. I think that this API is better for this things:

- Less functions, it's better.
- Reviewing the code is easier to spot a `.lint(code, compile = false)` between a lot of `.lint(code)` thatn a `.lint(code)` between a lot of `.compileandLint(code)`. The `compile = false` is easy to spot.
- New users will use the correct function by default.

If this PR is approved I will do the same for `lintWithContext` and `compileAndLintWithContext` but I didn't want to do that refactor too if you don't like this one.