### PR TITLE
Ensure that the correct lint function is called for the passed rule

### DIFF
--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -248,20 +247,6 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-    }
-
-    @Test
-    fun `should not report a null-check when there is no binding context`() {
-        val code = """
-            class A(private var a: Int?) {
-                fun foo() {
-                    if (a != null) {
-                        println(2 + a!!)
-                    }
-                }
-            }
-        """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -343,7 +342,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             val config = TestConfig(ALLOWED_PATTERN to "^(is|has|are|need)")
-            assertThat(BooleanPropertyNaming(config).compileAndLint(code))
+            assertThat(BooleanPropertyNaming(config).compileAndLintWithContext(env, code))
                 .isEmpty()
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -14,19 +13,6 @@ import org.junit.jupiter.api.Test
 @KotlinCoreEnvironmentTest
 class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
     val subject = CanBeNonNullable(Config.empty)
-
-    @Test
-    fun `does not report when there is no context`() {
-        val code = """
-            class A {
-                private var a: Int? = 5
-                fun foo() {
-                    a = 6
-                }
-            }
-        """.trimIndent()
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
 
     @Nested
     inner class `evaluating private properties` {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
@@ -2,7 +2,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -18,22 +17,6 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
      * The recommended replacement string for `?: [fallback]`.
      */
     private fun replacementForElvis(fallback: Boolean): String = if (fallback) "!= false" else "== true"
-
-    @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `does not report when there is no context`(bool: Boolean) {
-        val code = """
-            import kotlin.random.Random
-            
-            fun nullableBoolean(): Boolean? = true.takeIf { Random.nextBoolean() }
-            
-            fun foo(): Boolean {
-                return nullableBoolean() ?: $bool
-            }
-        """.trimIndent()
-
-        assertThat(subject.compileAndLint(code)).isEmpty()
-    }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -146,20 +145,6 @@ class ObjectLiteralToLambdaSpec {
 
         @Nested
         inner class `is not correct implement` {
-            @Test
-            fun `without type resolution`() {
-                val code = """
-                    fun interface Sam {
-                        fun foo()
-                    }
-                    val a = object : Sam {
-                        override fun foo() {
-                        }
-                    }
-                """.trimIndent()
-                assertThat(subject.compileAndLint(code)).isEmpty()
-            }
-
             @Test
             fun `is empty interface`() {
                 val code = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLint
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
@@ -508,22 +507,6 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     } else null
                 """.trimIndent()
                 assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
-            }
-
-            @Test
-            fun `does not report when an object initializes a variable directly - without type solving`() {
-                val code = """
-                    interface I {
-                        var optionEnabled: Boolean
-                    }
-                    fun test(): I {
-                        val o = object: I {
-                            override var optionEnabled: Boolean = false
-                        }
-                        return o
-                    }
-                """.trimIndent()
-                assertThat(subject.compileAndLint(code)).isEmpty()
             }
         }
     }

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(projects.detektApi)
     api(projects.detektTestUtils)
     implementation(projects.detektUtils)
+    implementation(libs.kotlin.reflect)
     compileOnly(libs.assertj.core)
     implementation(projects.detektCore)
 }


### PR DESCRIPTION
Related with #7873 but they do different things.

This PR ensures that if the rule requires FullAnalysis we call `lintWithContext` and if we don't need it we call `lint`.

If this PR and #7873 are accepted we could even merge `lint` and `lintWithContext`. We could add a parameter to `lint` like this: `environment: KotlinCoreEnvironment = null` and ensure that if the rule requires full analysis it is not null.

This change should make it easier for rule authors to spot that they are not using the correct function. You can even see that we had some tests with this error.