### PR TITLE
Faster MaxLineLength

### DIFF
--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -55,7 +55,7 @@ class MaxLineLength(config: Config) : Rule(
 
         val sourceFileLinesMapping = KtPsiSourceFileLinesMapping(file)
 
-        file.text.lines().withIndex()
+        file.text.lineSequence().withIndex()
             .filterNot { (index, line) -> isValidLine(file, sourceFileLinesMapping.getLineStartOffset(index), line) }
             .forEach { (index, line) ->
                 val offset = sourceFileLinesMapping.getLineStartOffset(index)
@@ -72,13 +72,12 @@ class MaxLineLength(config: Config) : Rule(
             }
     }
 
-    private fun isValidLine(file: KtFile, offset: Int, line: String): Boolean {
-        val isUrl = line.lastArgumentMatchesUrl()
-        val isMarkdownOrRefUrl =
+    private fun isValidLine(file: KtFile, offset: Int, line: String) =
+        line.length <= maxLineLength ||
+            isIgnoredStatement(file, offset, line) ||
+            line.lastArgumentMatchesUrl() ||
             line.lastArgumentMatchesMarkdownUrlSyntax() ||
-                line.lastArgumentMatchesKotlinReferenceUrlSyntax()
-        return line.length <= maxLineLength || isIgnoredStatement(file, offset, line) || isUrl || isMarkdownOrRefUrl
-    }
+            line.lastArgumentMatchesKotlinReferenceUrlSyntax()
 
     private fun isIgnoredStatement(file: KtFile, offset: Int, line: String): Boolean =
         containsIgnoredPackageStatement(line) ||

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLength.kt
@@ -62,13 +62,12 @@ class MaxLineLength(config: Config) : Rule(
                 val ktElement = findFirstMeaningfulKtElementInParents(file, offset, line) ?: file
                 val textRange = TextRange(offset, offset + line.length)
                 val lineAndColumnRange = getLineAndColumnRangeInPsiFile(file, textRange)
-                val location =
-                    Location(
-                        source = SourceLocation(lineAndColumnRange.start.line, lineAndColumnRange.start.column),
-                        endSource = SourceLocation(lineAndColumnRange.end.line, lineAndColumnRange.end.column),
-                        text = TextLocation(offset, offset + line.length),
-                        path = file.absolutePath(),
-                    )
+                val location = Location(
+                    source = SourceLocation(lineAndColumnRange.start.line, lineAndColumnRange.start.column),
+                    endSource = SourceLocation(lineAndColumnRange.end.line, lineAndColumnRange.end.column),
+                    text = TextLocation(offset, offset + line.length),
+                    path = file.absolutePath(),
+                )
                 report(CodeSmell(Entity.from(ktElement, location), description))
             }
     }


### PR DESCRIPTION
Based on this data: https://github.com/detekt/detekt/issues/6962#issuecomment-2582455298 I checked why `MaxLineLength` was SO slow. And I found out. We were doing the slow checks before the fast ones. If we know that the line is smaller than the threshold we don't need to check anything else, the line is fine. If it's not then we need to do the other checks.

This makes the rule around 6 times faster. I don't have really good measures here, but my "poor" mesurements indicate that it's CLEARLY faster now.