### PR TITLE
Add a note to use compileOnly to depend on detekt-api

### DIFF
--- a/website/docs/introduction/extensions.md
+++ b/website/docs/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.0/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.0/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.1/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.1/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.3/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.3/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.4/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.4/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.5/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.5/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.6/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.6/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.

--- a/website/versioned_docs/version-1.23.7/introduction/extensions.md
+++ b/website/versioned_docs/version-1.23.7/introduction/extensions.md
@@ -23,6 +23,13 @@ has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitla
 You can use our [GitHub template](https://github.com/detekt/detekt-custom-rule-template) to have a basic scaffolding to
 develop your own custom rules. Another option is to clone the provided [detekt/detekt-sample-extensions](https://github.com/detekt/detekt/tree/main/detekt-sample-extensions) project.
 
+:::note
+
+It's important that the dependency of `io.gitlab.arturbosch.detekt:detekt-api` is configured as `compileOnly` (as in the examples).
+You can read more information about this [here](https://github.com/detekt/detekt/issues/7883).
+
+:::
+
 Own rules have to extend the abstract _Rule_ class and override the `visitXXX()`-functions from the AST.  
 A `RuleSetProvider` must be implemented, which declares a `RuleSet` in the `instance()`-function.
 To leverage the configuration mechanism of detekt you must pass the Config object from your rule set provider to your rule.


### PR DESCRIPTION
This an improvement in the documentation to avoid errors like #7883