### PR TITLE
Compile Gradle plugin with latest 2.0.x release

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -37,7 +37,7 @@ detekt {
 
 kotlin {
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
-    compilerVersion = "2.0.10"
+    compilerVersion = "2.0.21"
 }
 
 testing {


### PR DESCRIPTION
We should be able to safely compile DGP with Kotlin 2.0.21