### PR TITLE
Compile detekt with Java 17

### DIFF
--- a/build-logic/src/main/kotlin/Versions.kt
+++ b/build-logic/src/main/kotlin/Versions.kt
@@ -1,10 +1,7 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 object Versions {
 
     const val DETEKT: String = "1.23.7"
     const val SNAPSHOT_NAME: String = "main"
-    val JVM_TARGET: JvmTarget = JvmTarget.JVM_1_8
 
     fun currentOrSnapshot(): String {
         if (System.getProperty("snapshot")?.toBoolean() == true) {

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 
 plugins {
@@ -50,9 +51,11 @@ tasks.withType<Test>().configureEach {
     }
 }
 
+val jvmTargetVersion = versionCatalog.findVersion("jvm-target").get().requiredVersion
+
 kotlin {
     compilerOptions {
-        jvmTarget = Versions.JVM_TARGET
+        jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
         progressiveMode = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
@@ -77,8 +80,8 @@ testing {
 java {
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
+    targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     consistentResolution {
         useCompileClasspathVersions()
     }

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -55,9 +55,14 @@ val jvmTargetVersion = versionCatalog.findVersion("jvm-target").get().requiredVe
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
         progressiveMode = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
     }
 }
 

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -61,12 +61,12 @@ kotlin {
     }
 }
 
-val java8Launcher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(8)
+val javaLauncher = javaToolchains.launcherFor {
+    languageVersion = JavaLanguageVersion.of(versionCatalog.findVersion("java-compile-toolchain").get().requiredVersion)
 }
 
 project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
-    kotlinJavaToolchain.toolchain.use(java8Launcher)
+    kotlinJavaToolchain.toolchain.use(javaLauncher)
 }
 
 testing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ ktlint = "1.3.1"
 slf4j = "2.0.16"
 
 jvm-target = "1.8"
+java-compile-toolchain = "8"
 
 [libraries]
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ kotlin = "2.1.10"
 ktlint = "1.3.1"
 slf4j = "2.0.16"
 
+jvm-target = "1.8"
+
 [libraries]
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ ktlint = "1.3.1"
 slf4j = "2.0.16"
 
 jvm-target = "1.8"
-java-compile-toolchain = "8"
+java-compile-toolchain = "17"
 
 [libraries]
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's


### PR DESCRIPTION
Two changes:
1. Shift config so the JVM target and compilation toolchain JVM version are set in the version catalog. This seems like the right place for those settings, and also avoids having to recompile the precompiled scripts when the values are updated (though I acknowledge this is rare).
2. Compiles with the much more modern Java 17 instead of Java 8. Java 17 is selected over 21 because Java 21 introduced some new collection utility functions that conflict with Kotlin's, and compiling with 21 without other changes would mean breaking compatibility with Java 20 and below. The proper way to fix this is by setting `-Xjdk-release=1.8` for compilation but we have a unique problem due to a `sun.*` import in detekt-parser. Setting JDK release to 1.8 to restrict API usage to what was available in Java 1.8 uses a file called `ct.sym` which is included in most JDK distributions. `sun.*` was internal API in Java 1.8 so isn't included in the 1.8 public API definition included in `ct.sym`. It's only included in API definition for Java 9+. Until that usage is removed, or we drop Java 1.8 compatibility (which I don't think we should yet) we're left in this awkward position. The only way around it is to include Java 1.8's `rt.jar` on the boot classpath, but that requires additional config that we'd want to avoid in our build.

More info on point 2:
* [JEP 247: Compile for Older Platform Versions](https://openjdk.org/jeps/247)
* [Comment on JEP 247](https://bugs.openjdk.org/browse/JDK-8058150?focusedId=13847552&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13847552)
* [JEP 260: Encapsulate Most Internal APIs](https://openjdk.org/jeps/260)