### PR TITLE
Use standard binary Gradle wrapper distribution

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,10 +13,6 @@ tasks.withType<DokkaMultiModuleTask>().configureEach {
     outputDirectory = layout.projectDirectory.dir("website/static/kdoc")
 }
 
-tasks.wrapper {
-    distributionType = Wrapper.DistributionType.ALL
-}
-
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output = layout.buildDirectory.file("reports/detekt/merge.sarif.json")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
There is no reason to use the full distribution as the wrapper. IDEs will download sources as required. The full distribution is larger so it takes more time to download and extract locally and on CI, and takes up more space.