### PR TITLE
Enable TrailingCommaOnDeclarationSite for detekt project

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -98,7 +98,7 @@ formatting:
   TrailingCommaOnCallSite:
     active: false
   TrailingCommaOnDeclarationSite:
-    active: false
+    active: true
   ValueArgumentComment:
     active: false
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ActiveByDefault.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ActiveByDefault.kt
@@ -10,5 +10,5 @@ annotation class ActiveByDefault(
     /**
      *  The version the rule was activated by default.
      */
-    val since: String
+    val since: String,
 )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Alias.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Alias.kt
@@ -10,5 +10,5 @@ package io.gitlab.arturbosch.detekt.api
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)
 annotation class Alias(
-    vararg val values: String
+    vararg val values: String,
 )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/CompilerResources.kt
@@ -8,5 +8,5 @@ import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactory
  */
 class CompilerResources(
     val languageVersionSettings: LanguageVersionSettings,
-    val dataFlowValueFactory: DataFlowValueFactory
+    val dataFlowValueFactory: DataFlowValueFactory,
 )

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ConfigProperty.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KProperty0
  * the config. Although [T] is defined as [Any], only [String], [Int], [Boolean] and [List<String>] are supported.
  */
 fun <T : Any> config(
-    defaultValue: T
+    defaultValue: T,
 ): ReadOnlyProperty<Rule, T> = config(defaultValue) { it }
 
 /**
@@ -26,7 +26,7 @@ fun <T : Any> config(
  */
 fun <T : Any, U : Any> config(
     defaultValue: T,
-    transformer: (T) -> U
+    transformer: (T) -> U,
 ): ReadOnlyProperty<Rule, U> = TransformedConfigProperty(defaultValue, transformer)
 
 /**
@@ -45,7 +45,7 @@ fun <T : Any, U : Any> config(
  */
 fun <T : Any> configWithFallback(
     fallbackProperty: KProperty0<T>,
-    defaultValue: T
+    defaultValue: T,
 ): ReadOnlyProperty<Rule, T> = configWithFallback(fallbackProperty, defaultValue) { it }
 
 /**
@@ -67,7 +67,7 @@ fun <T : Any> configWithFallback(
 fun <T : Any, U : Any> configWithFallback(
     fallbackProperty: KProperty0<U>,
     defaultValue: T,
-    transformer: (T) -> U
+    transformer: (T) -> U,
 ): ReadOnlyProperty<Rule, U> =
     FallbackConfigProperty(fallbackProperty, defaultValue, transformer)
 
@@ -101,7 +101,7 @@ fun <T : Any> configWithAndroidVariants(
 fun <T : Any, U : Any> configWithAndroidVariants(
     defaultValue: T,
     defaultAndroidValue: T,
-    transformer: (T) -> U
+    transformer: (T) -> U,
 ): ReadOnlyProperty<Rule, U> =
     TransformedConfigPropertyWithAndroidVariants(defaultValue, defaultAndroidValue, transformer)
 
@@ -112,7 +112,8 @@ private fun <T : Any> getValueOrDefault(config: Config, propertyName: String, de
         is List<*> -> config.getListOrDefault(propertyName, defaultValue) as T
         is String,
         is Boolean,
-        is Int -> config.valueOrDefault(propertyName, defaultValue)
+        is Int,
+        -> config.valueOrDefault(propertyName, defaultValue)
 
         else -> error(
             "${defaultValue.javaClass} is not supported for delegated config property '$propertyName'. " +
@@ -132,7 +133,7 @@ private fun Config.getListOrDefault(propertyName: String, defaultValue: List<*>)
 
 private fun Config.getValuesWithReasonOrDefault(
     propertyName: String,
-    defaultValue: ValuesWithReason
+    defaultValue: ValuesWithReason,
 ): ValuesWithReason {
     val valuesAsList: List<*> = valueOrNull(propertyName) ?: return defaultValue
     if (valuesAsList.all { it is String }) {
@@ -171,7 +172,7 @@ private abstract class MemoizedConfigProperty<U : Any> : ReadOnlyProperty<Rule, 
 private class TransformedConfigPropertyWithAndroidVariants<T : Any, U : Any>(
     private val defaultValue: T,
     private val defaultAndroidValue: T,
-    private val transform: (T) -> U
+    private val transform: (T) -> U,
 ) : MemoizedConfigProperty<U>() {
     override fun doGetValue(thisRef: Rule, property: KProperty<*>): U {
         val rulesetConfig = requireNotNull(thisRef.config.parent) {
@@ -185,7 +186,7 @@ private class TransformedConfigPropertyWithAndroidVariants<T : Any, U : Any>(
 
 private class TransformedConfigProperty<T : Any, U : Any>(
     private val defaultValue: T,
-    private val transform: (T) -> U
+    private val transform: (T) -> U,
 ) : MemoizedConfigProperty<U>() {
     override fun doGetValue(thisRef: Rule, property: KProperty<*>): U =
         transform(getValueOrDefault(thisRef.config, property.name, defaultValue))
@@ -194,7 +195,7 @@ private class TransformedConfigProperty<T : Any, U : Any>(
 private class FallbackConfigProperty<T : Any, U : Any>(
     private val fallbackProperty: KProperty0<U>,
     private val defaultValue: T,
-    private val transform: (T) -> U
+    private val transform: (T) -> U,
 ) : MemoizedConfigProperty<U>() {
     override fun doGetValue(thisRef: Rule, property: KProperty<*>): U {
         if (thisRef.config.isConfigured(property.name)) {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Entity.kt
@@ -13,7 +13,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 class Entity(
     val signature: String,
     val location: Location,
-    val ktElement: KtElement
+    val ktElement: KtElement,
 ) {
     override fun toString(): String =
         "Entity(signature=$signature, location=$location, ktElement=$ktElement)"
@@ -51,7 +51,7 @@ class Entity(
         private fun from(
             elementToReport: PsiElement,
             elementForSignature: PsiElement,
-            location: Location
+            location: Location,
         ): Entity {
             val signature = elementForSignature.buildFullSignature()
             val ktElement = elementToReport.getNonStrictParentOfType<KtElement>() ?: error("KtElement expected")

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Notification.kt
@@ -17,6 +17,6 @@ interface Notification {
     enum class Level {
         Info,
         Warning,
-        Error
+        Error,
     }
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectMetric.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ProjectMetric.kt
@@ -8,7 +8,7 @@ open class ProjectMetric(
     val value: Int,
     val priority: Int = -1,
     val isDouble: Boolean = false,
-    val conversionFactor: Int = DEFAULT_FLOAT_CONVERSION_FACTOR
+    val conversionFactor: Int = DEFAULT_FLOAT_CONVERSION_FACTOR,
 ) {
 
     override fun toString(): String {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -46,7 +46,7 @@ open class Rule(
     fun visitFile(
         root: KtFile,
         bindingContext: BindingContext = BindingContext.EMPTY,
-        compilerResources: CompilerResources
+        compilerResources: CompilerResources,
     ): List<Finding> {
         findings.clear()
         this.bindingContext = bindingContext

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/internal/AutoCorrectable.kt
@@ -11,5 +11,5 @@ annotation class AutoCorrectable(
      *  The detekt version since the rule is auto-correctable in the following format: <major>.<minor>.<patch>,
      *  where major, minor and patch are non-negative integer numbers.
      */
-    val since: String
+    val since: String,
 )

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/CliArgs.kt
@@ -240,7 +240,8 @@ class CliArgs {
 
                 FailureSeverity.Error,
                 FailureSeverity.Warning,
-                FailureSeverity.Info -> FailOnSeverity(minSeverity.toSeverity())
+                FailureSeverity.Info,
+                -> FailOnSeverity(minSeverity.toSeverity())
             }
         }
 }

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailureSeverity.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/FailureSeverity.kt
@@ -6,7 +6,8 @@ enum class FailureSeverity {
     Error,
     Warning,
     Info,
-    Never;
+    Never,
+    ;
 
     internal fun toSeverity(): Severity =
         when (this) {

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -50,7 +50,7 @@ fun main(args: Array<String>) {
 fun buildRunner(
     args: Array<String>,
     outputPrinter: PrintStream,
-    errorPrinter: PrintStream
+    errorPrinter: PrintStream,
 ): Executable {
     check(KotlinCompilerVersion.VERSION == whichKotlin()) {
         """

--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/runners/Runner.kt
@@ -16,7 +16,7 @@ class Runner(private val spec: ProcessingSpec) : Executable, Callable<AnalysisRe
     constructor(
         arguments: CliArgs,
         outputPrinter: Appendable,
-        errorPrinter: Appendable
+        errorPrinter: Appendable,
     ) : this(arguments.createSpec(outputPrinter, errorPrinter))
 
     override fun execute() {

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektAnalysisExtension.kt
@@ -18,14 +18,14 @@ class DetektAnalysisExtension(
     private val log: MessageCollector,
     private val spec: ProcessingSpec,
     private val rootPath: Path,
-    private val excludes: Collection<String>
+    private val excludes: Collection<String>,
 ) : AnalysisHandlerExtension {
 
     override fun analysisCompleted(
         project: Project,
         module: ModuleDescriptor,
         bindingTrace: BindingTrace,
-        files: Collection<KtFile>
+        files: Collection<KtFile>,
     ): AnalysisResult? {
         if (spec.loggingSpec.debug) {
             log.info("$spec")

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/DetektService.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/DetektService.kt
@@ -11,7 +11,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 
 internal class DetektService(
     private val log: MessageCollector,
-    private val spec: ProcessingSpec
+    private val spec: ProcessingSpec,
 ) {
 
     @Suppress("ForbiddenComment")

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -56,7 +56,7 @@ internal class Analyzer(
     private fun runSync(
         ktFiles: Collection<KtFile>,
         rules: List<RuleDescriptor>,
-        compilerResources: CompilerResources
+        compilerResources: CompilerResources,
     ): List<Issue> =
         ktFiles.flatMap { file ->
             processors.forEach { it.onProcess(file) }
@@ -70,7 +70,7 @@ internal class Analyzer(
     private fun runAsync(
         ktFiles: Collection<KtFile>,
         rules: List<RuleDescriptor>,
-        compilerResources: CompilerResources
+        compilerResources: CompilerResources,
     ): List<Issue> {
         val service = settings.taskPool
         val tasks: TaskList<List<Issue>?> = ktFiles.map { file ->
@@ -87,7 +87,7 @@ internal class Analyzer(
     private fun analyze(
         file: KtFile,
         rules: List<RuleDescriptor>,
-        compilerResources: CompilerResources
+        compilerResources: CompilerResources,
     ): List<Issue> {
         val (correctableRules, otherRules) = rules.asSequence()
             .filter { ruleDescriptor ->

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/DelegatingResult.kt
@@ -5,5 +5,5 @@ import io.gitlab.arturbosch.detekt.api.Issue
 
 class DelegatingResult(
     result: Detektion,
-    override val issues: List<Issue>
+    override val issues: List<Issue>,
 ) : Detektion by result

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TaskPool.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/TaskPool.kt
@@ -20,7 +20,7 @@ fun <T> awaitAll(tasks: TaskList<T>) = tasks.map { it.join() }
  */
 class TaskPool private constructor(
     private val service: ExecutorService,
-    private val shouldClose: Boolean
+    private val shouldClose: Boolean,
 ) : ExecutorService by service, AutoCloseable, Closeable {
 
     constructor(executorService: ExecutorService?) : this(

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/IndentingXMLStreamWriter.kt
@@ -5,7 +5,7 @@ import javax.xml.stream.XMLStreamWriter
 @Suppress("TooManyFunctions")
 internal class IndentingXMLStreamWriter(
     private val writer: XMLStreamWriter,
-    private val indent: String = "  "
+    private val indent: String = "  ",
 ) : XMLStreamWriter by writer {
 
     private var currentState = NOTHING

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/XmlExtensions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/baseline/XmlExtensions.kt
@@ -20,7 +20,7 @@ internal fun XMLStreamWriter.prettyPrinter(): XMLStreamWriter = IndentingXMLStre
 internal inline fun XMLStreamWriter.document(
     version: String? = null,
     encoding: String? = null,
-    init: XMLStreamWriter.() -> Unit
+    init: XMLStreamWriter.() -> Unit,
 ) = apply {
     when {
         encoding != null && version != null -> writeStartDocument(encoding, version)
@@ -33,7 +33,7 @@ internal inline fun XMLStreamWriter.document(
 
 internal inline fun XMLStreamWriter.tag(
     name: String,
-    init: XMLStreamWriter.() -> Unit
+    init: XMLStreamWriter.() -> Unit,
 ) = apply {
     writeStartElement(name)
     init()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/BaseConfig.kt
@@ -13,7 +13,7 @@ fun Config.valueOrDefaultInternal(
     key: String,
     result: Any?,
     default: Any,
-    parser: (result: String, default: Any) -> Any = ::tryParseBasedOnDefault
+    parser: (result: String, default: Any) -> Any = ::tryParseBasedOnDefault,
 ): Any =
     try {
         if (result != null) {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidator.kt
@@ -23,6 +23,6 @@ internal abstract class AbstractYamlConfigValidator : ConfigValidator {
 
     abstract fun validate(
         configToValidate: YamlConfig,
-        settings: ValidationSettings
+        settings: ValidationSettings,
     ): Collection<Notification>
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
@@ -57,7 +57,7 @@ internal fun checkConfiguration(settings: ProcessingSettings, baseline: Config) 
 internal fun validateConfig(
     config: Config,
     baseline: Config,
-    excludePatterns: Set<Regex>
+    excludePatterns: Set<Regex>,
 ): List<Notification> {
     require(baseline != Config.empty) { "Cannot validate configuration based on an empty baseline config." }
     require(baseline is YamlConfig) {
@@ -81,7 +81,7 @@ internal fun validateConfig(
 private fun validateYamlConfig(
     configToValidate: YamlConfig,
     baseline: YamlConfig,
-    excludePatterns: Set<Regex>
+    excludePatterns: Set<Regex>,
 ): List<Notification> {
     val deprecatedProperties = loadDeprecations().filterIsInstance<DeprecatedProperty>().toSet()
     val warningsAsErrors = configToValidate

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/DeprecatedPropertiesConfigValidator.kt
@@ -12,7 +12,7 @@ internal class DeprecatedPropertiesConfigValidator(
 
     override fun validate(
         configToValidate: YamlConfig,
-        settings: ValidationSettings
+        settings: ValidationSettings,
     ): Collection<Notification> {
         val configAsMap = configToValidate.properties
         return deprecatedProperties
@@ -28,7 +28,7 @@ internal class DeprecatedPropertiesConfigValidator(
     }
 
     private fun createNotification(
-        foundProperty: DeprecatedProperty
+        foundProperty: DeprecatedProperty,
     ): Notification {
         val propertyPath = foundProperty.asPath()
         return SimpleNotification(

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/Deprecations.kt
@@ -7,14 +7,14 @@ internal sealed class Deprecation
 internal data class DeprecatedRule(
     val ruleSetId: String,
     val ruleName: String,
-    val description: String
+    val description: String,
 ) : Deprecation()
 
 internal data class DeprecatedProperty(
     val ruleSetId: String,
     val ruleName: String,
     val propertyName: String,
-    val description: String
+    val description: String,
 ) : Deprecation()
 
 internal fun loadDeprecations(): Set<Deprecation> =

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -19,13 +19,13 @@ internal class InvalidPropertiesConfigValidator(
 
     override fun validate(
         configToValidate: YamlConfig,
-        settings: ValidationSettings
+        settings: ValidationSettings,
     ): Collection<Notification> = testKeys(configToValidate.properties, baseline.properties)
 
     private fun testKeys(
         configToValidate: Map<String, Any>,
         baseline: Map<String, Any>,
-        parentPath: String? = null
+        parentPath: String? = null,
     ): List<Notification> {
         val notifications = mutableListOf<Notification>()
         for (prop in configToValidate.keys) {
@@ -52,7 +52,7 @@ internal class InvalidPropertiesConfigValidator(
         propertyName: String,
         propertyPath: String,
         configToValidate: Map<String, Any>,
-        baseline: Map<String, Any>
+        baseline: Map<String, Any>,
     ): List<Notification> {
         if (!baseline.contains(propertyName)) {
             val ruleName = extractRuleName(propertyName)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/MissingRulesConfigValidator.kt
@@ -17,7 +17,7 @@ internal class MissingRulesConfigValidator(
 
     override fun validate(
         configToValidate: YamlConfig,
-        settings: ValidationSettings
+        settings: ValidationSettings,
     ): Collection<Notification> {
         if (!settings.checkExhaustiveness) {
             return emptyList()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/extensions/Loading.kt
@@ -9,7 +9,7 @@ val LIST_ITEM_SPACING = "$NL    "
 
 inline fun <reified T : Extension> loadExtensions(
     settings: ProcessingSettings,
-    predicate: (T) -> Boolean = { true }
+    predicate: (T) -> Boolean = { true },
 ): List<T> =
     ServiceLoader.load(T::class.java, settings.pluginLoader)
         .filterNot { it.id in settings.spec.extensionsSpec.disabledExtensions }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacade.kt
@@ -7,7 +7,7 @@ import io.gitlab.arturbosch.detekt.core.ProcessingSettings
 import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
 
 class OutputFacade(
-    private val settings: ProcessingSettings
+    private val settings: ProcessingSettings,
 ) {
 
     private val reports: Map<String, ReportsSpec.Report> =

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/ClassloaderAware.kt
@@ -15,7 +15,7 @@ interface ClassloaderAware {
 }
 
 class ExtensionFacade(
-    private val plugins: ExtensionsSpec.Plugins?
+    private val plugins: ExtensionsSpec.Plugins?,
 ) : AutoCloseable, Closeable, ClassloaderAware {
 
     init {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/LoggingAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/LoggingAware.kt
@@ -26,7 +26,7 @@ internal fun Throwable.printStacktraceRecursively(logger: Appendable) {
 }
 
 internal class LoggingFacade(
-    val spec: LoggingSpec
+    val spec: LoggingSpec,
 ) : LoggingAware {
 
     override val outputChannel: Appendable = spec.outputChannel

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/AnalysisFacade.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
 class AnalysisFacade(
-    private val spec: ProcessingSpec
+    private val spec: ProcessingSpec,
 ) : Detekt {
 
     override fun run(): AnalysisResult = runAnalysis {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -70,5 +70,5 @@ internal class DefaultLifecycle(
     override val processorsProvider: () -> List<FileProcessListener> =
         { FileProcessorLocator(settings).load() },
     override val ruleSetsProvider: () -> List<RuleSetProvider> =
-        { settings.createRuleProviders() }
+        { settings.createRuleProviders() },
 ) : Lifecycle

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/SimpleNotification.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/util/SimpleNotification.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Notification
 
 internal data class SimpleNotification(
     override val message: String,
-    override val level: Notification.Level = Notification.Level.Error
+    override val level: Notification.Level = Notification.Level.Error,
 ) : Notification {
 
     override fun toString(): String = message

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/AnalyzerSpec.kt
@@ -324,7 +324,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             private fun isPathChecked(
                 path: String,
                 excludes: List<String>? = null,
-                includes: List<String>? = null
+                includes: List<String>? = null,
             ): Boolean {
                 fun List<String>.toYaml() = joinToString(", ", "[", "]") { "\"$it\"" }
 
@@ -378,7 +378,7 @@ class AnalyzerSpec(val env: KotlinCoreEnvironment) {
             private fun isPathChecked(
                 path: String,
                 excludes: List<String>? = null,
-                includes: List<String>? = null
+                includes: List<String>? = null,
             ): Boolean {
                 fun List<String>.toYaml() = joinToString(", ", "[", "]") { "\"$it\"" }
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/AbstractYamlConfigValidatorSpec.kt
@@ -44,7 +44,7 @@ internal class AbstractYamlConfigValidatorSpec {
 
         override fun validate(
             configToValidate: YamlConfig,
-            settings: ValidationSettings
+            settings: ValidationSettings,
         ): Collection<Notification> {
             validationSettings = settings
             return emptyList()

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/KtLintLineColCalculator.kt
@@ -19,7 +19,7 @@ object KtLintLineColCalculator {
             .replaceFirst(UTF8_BOM, "")
 
     private fun buildPositionInTextLocator(
-        text: String
+        text: String,
     ): (offset: Int) -> Pair<Int, Int> {
         val textLength = text.length
         val arr = ArrayList<Int>()
@@ -46,7 +46,7 @@ object KtLintLineColCalculator {
     }
 
     private class SegmentTree(
-        sortedArray: IntArray
+        sortedArray: IntArray,
     ) {
 
         init {
@@ -69,7 +69,7 @@ object KtLintLineColCalculator {
         private fun binarySearch(
             v: Int,
             l: Int,
-            r: Int
+            r: Int,
         ): Int = when {
             l > r -> -1
             else -> {
@@ -86,6 +86,6 @@ object KtLintLineColCalculator {
 
     private data class Segment(
         val left: Int,
-        val right: Int
+        val right: Int,
     )
 }

--- a/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/RuleSetConfigProperty.kt
+++ b/detekt-formatting/src/main/kotlin/io/gitlab/arturbosch/detekt/formatting/RuleSetConfigProperty.kt
@@ -8,7 +8,7 @@ fun <T : Any> ruleSetConfig(defaultValue: T): ReadOnlyProperty<Any?, RuleSetConf
     RuleSetConfigPropertyDelegate(defaultValue)
 
 private class RuleSetConfigPropertyDelegate<T : Any>(
-    val defaultValue: T
+    val defaultValue: T,
 ) : ReadOnlyProperty<Any?, RuleSetConfigProperty<T>> {
 
     @Volatile private var value: RuleSetConfigProperty<T>? = null

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/AutoCorrectLevelSpec.kt
@@ -30,7 +30,7 @@ class AutoCorrectLevelSpec {
     fun autoCorrect(
         ruleSet: AutoCorrectConfig,
         rule: AutoCorrectConfig,
-        wasFormatted: Boolean
+        wasFormatted: Boolean,
     ) {
         val config = yamlConfigFromContent(createConfig(ruleSet, rule))
 
@@ -48,7 +48,8 @@ class AutoCorrectLevelSpec {
 enum class AutoCorrectConfig {
     True,
     False,
-    Undefined;
+    Undefined,
+    ;
 
     override fun toString(): String =
         when (this) {

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/Generator.kt
@@ -15,7 +15,7 @@ class Generator(
     private val textReplacements: Map<String, String>,
     documentationPath: Path?,
     configPath: Path?,
-    private val outPrinter: PrintStream = System.out
+    private val outPrinter: PrintStream = System.out,
 ) {
     private val collector = DetektCollector(textReplacements)
     private val printer = DetektPrinter(documentationPath, configPath)

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Configuration.kt
@@ -5,7 +5,7 @@ data class Configuration(
     val description: String,
     val defaultValue: DefaultValue,
     val defaultAndroidValue: DefaultValue?,
-    val deprecated: String?
+    val deprecated: String?,
 ) {
     fun isDeprecated() = deprecated != null
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/ConfigurationCollector.kt
@@ -249,7 +249,7 @@ class ConfigurationCollector {
 
         private fun KtProperty.getValueArgument(
             name: String,
-            actionForPositionalMatch: (List<KtValueArgument>) -> KtValueArgument?
+            actionForPositionalMatch: (List<KtValueArgument>) -> KtValueArgument?,
         ): KtValueArgument? {
             val callExpression = delegate?.expression as? KtCallExpression ?: return null
             val arguments = callExpression.valueArguments

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/Rule.kt
@@ -11,7 +11,7 @@ data class Rule(
     val configurations: List<Configuration> = emptyList(),
     val autoCorrect: Boolean = false,
     val requiresFullAnalysis: Boolean = false,
-    val deprecationMessage: String? = null
+    val deprecationMessage: String? = null,
 ) {
     fun isDeprecated() = deprecationMessage != null
 }

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetPage.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetPage.kt
@@ -2,5 +2,5 @@ package io.gitlab.arturbosch.detekt.generator.collection
 
 data class RuleSetPage(
     val ruleSet: RuleSetProvider,
-    val rules: List<Rule>
+    val rules: List<Rule>,
 )

--- a/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
+++ b/detekt-generator/src/main/kotlin/io/gitlab/arturbosch/detekt/generator/collection/RuleSetProviderCollector.kt
@@ -24,7 +24,7 @@ data class RuleSetProvider(
     val description: String,
     val defaultActivationStatus: DefaultActivationStatus,
     val rules: List<String> = emptyList(),
-    val configuration: List<Configuration> = emptyList()
+    val configuration: List<Configuration> = emptyList(),
 ) {
     init {
         require(name.length > 1) { "Rule set name must be not empty or less than two symbols." }

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
@@ -13,7 +13,7 @@ import java.lang.reflect.Modifier
 class ConfigAssert(
     private val config: Config,
     private val name: String,
-    private val packageName: String
+    private val packageName: String,
 ) {
     private val allowedOptions = setOf(
         Config.ACTIVE_KEY,

--- a/detekt-gradle-plugin/config/gradle-plugin-detekt.yml
+++ b/detekt-gradle-plugin/config/gradle-plugin-detekt.yml
@@ -33,6 +33,8 @@ formatting:
   active: true
   MaximumLineLength:
     active: false
+  TrailingCommaOnDeclarationSite:
+    active: true
 
 potential-bugs:
   DoubleMutabilityForCollection:

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/DetektReportType.kt
@@ -5,7 +5,8 @@ enum class DetektReportType(val reportId: String, val extension: String) {
     XML("xml", "xml"),
     HTML("html", "html"),
     SARIF("sarif", "sarif"),
-    MD("md", "md");
+    MD("md", "md"),
+    ;
 
     internal companion object {
         fun isWellKnownReportId(reportId: String) = reportId in values().map(DetektReportType::reportId)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/FailOnSeverity.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/extensions/FailOnSeverity.kt
@@ -4,5 +4,5 @@ enum class FailOnSeverity {
     Error,
     Warning,
     Info,
-    Never
+    Never,
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektPlain.kt
@@ -38,6 +38,6 @@ internal class DetektPlain(private val project: Project) {
 
     private fun existingInputDirectoriesProvider(
         project: Project,
-        extension: DetektExtension
+        extension: DetektExtension,
     ): Provider<FileCollection> = project.provider { extension.source.filter { it.exists() } }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -154,11 +154,11 @@ internal data class DebugArgument(override val value: Boolean) : BoolCliArgument
 internal data class ParallelArgument(override val value: Boolean) : BoolCliArgument(value, PARALLEL_PARAMETER)
 
 internal data class DisableDefaultRuleSetArgument(
-    override val value: Boolean
+    override val value: Boolean,
 ) : BoolCliArgument(value, DISABLE_DEFAULT_RULESETS_PARAMETER)
 
 internal data class BuildUponDefaultConfigArgument(
-    override val value: Boolean
+    override val value: Boolean,
 ) : BoolCliArgument(value, BUILD_UPON_DEFAULT_CONFIG_PARAMETER)
 
 internal data class AllRulesArgument(override val value: Boolean) : BoolCliArgument(value, ALL_RULES_PARAMETER)

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/DetektInvoker.kt
@@ -19,7 +19,7 @@ internal interface DetektInvoker {
         arguments: List<String>,
         classpath: Set<File>,
         taskName: String,
-        ignoreFailures: Boolean = false
+        ignoreFailures: Boolean = false,
     )
 
     companion object {
@@ -64,14 +64,14 @@ internal abstract class DetektWorkAction : WorkAction<DetektWorkParameters> {
 }
 
 internal class DefaultCliInvoker(
-    private val classLoaderCache: ClassLoaderCache = GlobalClassLoaderCache
+    private val classLoaderCache: ClassLoaderCache = GlobalClassLoaderCache,
 ) : DetektInvoker {
 
     override fun invokeCli(
         arguments: List<String>,
         classpath: Set<File>,
         taskName: String,
-        ignoreFailures: Boolean
+        ignoreFailures: Boolean,
     ) {
         try {
             val loader = classLoaderCache.getOrCreate(classpath)
@@ -106,7 +106,7 @@ private class DryRunInvoker : DetektInvoker {
         arguments: List<String>,
         classpath: Set<File>,
         taskName: String,
-        ignoreFailures: Boolean
+        ignoreFailures: Boolean,
     ) {
         println("Invoking detekt with dry-run.")
         println("Task: $taskName")

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/report/XmlReportMerger.kt
@@ -122,14 +122,14 @@ internal object XmlReportMerger {
         private class CheckstyleErrorNodeWithFileData(
             val errorID: Any,
             val fileName: String,
-            val errorNode: Node
+            val errorNode: Node,
         )
 
         private data class ErrorID(
             val fileName: String,
             val line: String,
             val column: String,
-            val source: String
+            val source: String,
         )
     }
 

--- a/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -9,7 +9,7 @@ import java.io.PrintStream
 fun buildRunner(
     args: Array<String>,
     outputPrinter: PrintStream,
-    errorPrinter: PrintStream
+    errorPrinter: PrintStream,
 ) = object {
     fun execute(): Unit = throw ClassCastException("testing reflection wrapper...")
 }

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -26,7 +26,7 @@ constructor(
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
     val gradleProperties: Map<String, String> = emptyMap(),
     val customPluginClasspath: List<File> = emptyList(),
-    val projectScript: Project.() -> Unit = {}
+    val projectScript: Project.() -> Unit = {},
 ) {
 
     private val rootDir: File = Files.createTempDirectory("applyPlugin").toFile().apply { deleteOnExit() }

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/ProjectLayout.kt
@@ -5,7 +5,7 @@ import org.intellij.lang.annotations.Language
 class ProjectLayout(
     val numberOfSourceFilesInRootPerSourceDir: Int,
     val numberOfCodeSmellsInRootPerSourceDir: Int = 0,
-    val srcDirs: List<String> = listOf("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin")
+    val srcDirs: List<String> = listOf("src/main/java", "src/test/java", "src/main/kotlin", "src/test/kotlin"),
 ) {
 
     private val mutableSubmodules: MutableList<Submodule> = mutableListOf()

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/CyclomaticComplexity.kt
@@ -28,7 +28,7 @@ class CyclomaticComplexity(private val config: Config) : DetektVisitor() {
         var ignoreSimpleWhenEntries: Boolean = false,
         var ignoreNestingFunctions: Boolean = false,
         var ignoreLocalFunctions: Boolean = false,
-        var nestingFunctions: Set<String> = DEFAULT_NESTING_FUNCTIONS
+        var nestingFunctions: Set<String> = DEFAULT_NESTING_FUNCTIONS,
     )
 
     var complexity: Int = 0

--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/processors/util/LLOC.kt
@@ -8,13 +8,13 @@ object LLOC {
     fun analyze(
         lines: List<String>,
         isCommentMode: Boolean = false,
-        isFullMode: Boolean = false
+        isFullMode: Boolean = false,
     ): Int = LLOCCounter(lines, isCommentMode, isFullMode).run()
 
     private class LLOCCounter(
         private val lines: List<String>,
         private val isCommentMode: Boolean = false,
-        private val isFullMode: Boolean = false
+        private val isFullMode: Boolean = false,
     ) {
 
         private var counter = 0

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/processors/MetricProcessorTester.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class MetricProcessorTester(
     private val file: KtFile,
-    private val result: Detektion = MetricResults()
+    private val result: Detektion = MetricResults(),
 ) {
 
     fun <T : Any> test(processor: AbstractProcessor, key: Key<T>): T {

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -7,7 +7,7 @@ import java.nio.file.Path
 import kotlin.io.path.isRegularFile
 
 open class KtCompiler(
-    protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err)
+    protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err),
 ) {
 
     fun compile(path: Path): KtFile {

--- a/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/FunctionMatcher.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/github/detekt/psi/FunctionMatcher.kt
@@ -15,7 +15,7 @@ sealed class FunctionMatcher {
     abstract fun match(function: KtNamedFunction, bindingContext: BindingContext): Boolean
 
     internal data class NameOnly(
-        private val fullyQualifiedName: String
+        private val fullyQualifiedName: String,
     ) : FunctionMatcher() {
         override fun match(callableDescriptor: CallableDescriptor): Boolean =
             callableDescriptor.fqNameSafe.asString() == fullyQualifiedName
@@ -29,7 +29,7 @@ sealed class FunctionMatcher {
 
     internal data class WithParameters(
         private val fullyQualifiedName: String,
-        private val parameters: List<String>
+        private val parameters: List<String>,
     ) : FunctionMatcher() {
         override fun match(callableDescriptor: CallableDescriptor): Boolean {
             val descriptor = callableDescriptor.original

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtAnnotatedExtensions.kt
@@ -5,7 +5,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtUserType
 
 fun KtAnnotated.hasAnnotation(
-    vararg annotationNames: String
+    vararg annotationNames: String,
 ): Boolean {
     val names = annotationNames.toHashSet()
     val predicate: (KtAnnotationEntry) -> Boolean = {

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtCallExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtCallExpression.kt
@@ -17,7 +17,7 @@ fun KtCallExpression.isCalling(fqNames: List<FqName>, bindingContext: BindingCon
 
 fun KtCallExpression.isCallingWithNonNullCheckArgument(
     fqName: FqName,
-    bindingContext: BindingContext
+    bindingContext: BindingContext,
 ): Boolean {
     val argument = valueArguments.firstOrNull()?.getArgumentExpression() as? KtBinaryExpression ?: return false
     return argument.isNonNullCheck() && isCalling(fqName, bindingContext)

--- a/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KtLambdaExpression.kt
@@ -20,7 +20,7 @@ fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueP
 
 fun KtLambdaExpression.hasImplicitParameterReference(
     implicitParameter: ValueParameterDescriptor,
-    bindingContext: BindingContext
+    bindingContext: BindingContext,
 ): Boolean =
     anyDescendantOfType<KtNameReferenceExpression> {
         it.isImplicitParameterReference(this, implicitParameter, bindingContext)
@@ -29,7 +29,7 @@ fun KtLambdaExpression.hasImplicitParameterReference(
 private fun KtNameReferenceExpression.isImplicitParameterReference(
     lambda: KtLambdaExpression,
     implicitParameter: ValueParameterDescriptor,
-    bindingContext: BindingContext
+    bindingContext: BindingContext,
 ): Boolean =
     text == "it" &&
         getStrictParentOfType<KtLambdaExpression>() == lambda &&

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
@@ -317,7 +317,7 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
             functionSignature: String,
             classSignature: String,
             pattern: String,
-            result: Boolean
+            result: Boolean,
         ) {
             val ktFile = compileContentForTest(
                 """
@@ -347,7 +347,7 @@ private class TestCase(
 private fun buildKtFunction(
     environment: KotlinCoreEnvironment,
     code: String,
-    includePackage: Boolean = true
+    includePackage: Boolean = true,
 ): Pair<KtNamedFunction, BindingContext> {
     val ktFile = compileContentForTest(
         """

--- a/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensionsSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/ThrowExtensionsSpec.kt
@@ -118,7 +118,7 @@ internal class ThrowExtensionsSpec {
 
     private fun verifyThrowExpression(
         @Language("kotlin") code: String,
-        throwingAssertions: KtThrowExpression.() -> Unit
+        throwingAssertions: KtThrowExpression.() -> Unit,
     ) {
         val ktFile = compileContentForTest(code)
         val ktThrowExpression = ktFile.findDescendantOfType<KtThrowExpression>()

--- a/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/io/github/detekt/report/html/HtmlOutputReport.kt
@@ -179,12 +179,12 @@ class HtmlOutputReport : BuiltInOutputReport, OutputReport() {
 @HtmlTagMarker
 private fun FlowOrInteractiveContent.summary(
     classes: String,
-    block: SUMMARY.() -> Unit = {}
+    block: SUMMARY.() -> Unit = {},
 ): Unit = SUMMARY(attributesMapOf("class", classes), consumer).visit(block)
 
 private class SUMMARY(
     initialAttributes: Map<String, String>,
-    override val consumer: TagConsumer<*>
+    override val consumer: TagConsumer<*>,
 ) : HTMLTag("summary", consumer, initialAttributes, null, false, false),
     CommonAttributeGroupFacadeFlowInteractiveContent
 

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTest.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTest.kt
@@ -89,13 +89,13 @@ class FunCoroutineLaunchesTraverseHelper {
 
     fun isFunctionLaunchingCoroutines(
         initialFunction: KtNamedFunction,
-        bindingContext: BindingContext
+        bindingContext: BindingContext,
     ): Boolean {
         val traversedFunctions = mutableSetOf<KtNamedFunction>()
 
         fun checkFunctionAndSaveToCache(
             function: KtNamedFunction,
-            parents: List<KtNamedFunction> = emptyList()
+            parents: List<KtNamedFunction> = emptyList(),
         ) {
             val isLaunching = function.isLaunchingCoroutine(bindingContext)
             exploredFunctionsCache.putIfAbsent(function, isLaunching)
@@ -107,7 +107,7 @@ class FunCoroutineLaunchesTraverseHelper {
 
         fun getChildFunctionsOf(
             function: KtNamedFunction,
-            parents: List<KtNamedFunction> = emptyList()
+            parents: List<KtNamedFunction> = emptyList(),
         ): Set<KtNamedFunction> {
             function.collectDescendantsOfType<KtExpression>().mapNotNull {
                 it.getResolvedCall(bindingContext)

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySection.kt
@@ -56,7 +56,7 @@ class SuspendFunInFinallySection(config: Config) : Rule(
 
     private fun shouldReport(
         expression: KtCallExpression,
-        topParent: KtFinallySection
+        topParent: KtFinallySection,
     ): Boolean {
         if (!expression.isSuspendCall()) {
             return false

--- a/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
+++ b/detekt-rules-documentation/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/OutdatedDocumentation.kt
@@ -233,6 +233,6 @@ class OutdatedDocumentation(config: Config) : Rule(
     enum class DeclarationType {
         PARAM,
         PROPERTY,
-        ANY
+        ANY,
     }
 }

--- a/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
+++ b/detekt-rules-empty/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/empty/EmptyRule.kt
@@ -18,7 +18,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 abstract class EmptyRule(
     config: Config,
     description: String = "Empty block of code detected. As they serve no purpose they should be removed.",
-    private val codeSmellMessage: String = "This empty block of code can be removed."
+    private val codeSmellMessage: String = "This empty block of code can be removed.",
 ) : Rule(
     config,
     description

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -185,7 +185,7 @@ class UnnamedParameterUse(config: Config) : Rule(
     @Suppress("ReturnCount")
     private fun typeCanBeAssigned(
         firstParam: KtValueArgument,
-        secondParam: KtValueArgument
+        secondParam: KtValueArgument,
     ): Boolean {
         val param1Type =
             bindingContext[BindingContext.EXPRESSION_TYPE_INFO, firstParam.getArgumentExpression()]?.type

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -676,7 +676,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
         ignoreSingleParamUse: Boolean = true,
         allowAdjacentDifferentTypeParams: Boolean = true,
         ignoreArgumentsMatchingNames: Boolean = true,
-        ignoredFunctionCalls: List<String> = emptyList()
+        ignoredFunctionCalls: List<String> = emptyList(),
     ): UnnamedParameterUse =
         UnnamedParameterUse(
             TestConfig(

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinally.kt
@@ -74,7 +74,7 @@ class ReturnFromFinally(config: Config) : Rule(
 
     private fun isReturnFromTargetFunction(
         blockExpression: KtBlockExpression,
-        returnStmts: KtReturnExpression
+        returnStmts: KtReturnExpression,
     ): Boolean {
         val targetFunction = returnStmts.getTargetFunction(bindingContext)
             ?: return false
@@ -87,7 +87,7 @@ class ReturnFromFinally(config: Config) : Rule(
     }
 
     private fun canFilterLabeledExpression(
-        returnStmt: KtReturnExpression
+        returnStmt: KtReturnExpression,
     ): Boolean = !ignoreLabeled || returnStmt.labeledExpression == null
 
     private fun KtFinallySection.typeEqualsTo(type: KotlinType?): Boolean {

--- a/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/SwallowedException.kt
@@ -114,7 +114,7 @@ class SwallowedException(config: Config) : Rule(
 
     private fun KtThrowExpression.parameterReferences(
         parameterName: String?,
-        catchBody: KtExpression
+        catchBody: KtExpression,
     ): List<KtExpression> {
         val parameterReferencesInVariables = mutableMapOf<String, KtExpression>()
         return thrownExpression
@@ -136,7 +136,7 @@ class SwallowedException(config: Config) : Rule(
     private fun KtExpression.findReferenceInVariable(
         referenceName: String?,
         variableName: String,
-        catchBody: KtExpression
+        catchBody: KtExpression,
     ): KtExpression? {
         val block = getStrictParentOfType<KtBlockExpression>() ?: return null
         fun find(block: KtBlockExpression): KtExpression? {

--- a/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNaming.kt
@@ -63,7 +63,7 @@ class BooleanPropertyNaming(config: Config) : Rule(
 
     private fun reportCodeSmell(
         declaration: KtCallableDeclaration,
-        name: String
+        name: String,
     ): CodeSmell {
         val description = "Boolean property name should match a $allowedPattern pattern."
         return CodeSmell(

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClass.kt
@@ -69,7 +69,7 @@ class AbstractClassCanBeConcreteClass(config: Config) : Rule(
 
     private fun KtClass.checkMembers(
         members: List<KtCallableDeclaration>,
-        nameIdentifier: PsiElement
+        nameIdentifier: PsiElement,
     ) {
         val (abstractMembers, _) = members.partition { it.isAbstract() }
         if (abstractMembers.isEmpty() && !hasInheritedMember(true)) {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -72,7 +72,7 @@ class AbstractClassCanBeInterface(config: Config) : Rule(
 
     private fun KtClass.checkMembers(
         members: List<KtCallableDeclaration>,
-        nameIdentifier: PsiElement
+        nameIdentifier: PsiElement,
     ) {
         val (abstractMembers, concreteMembers) = members.partition { it.isAbstract() }
         when {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatements.kt
@@ -260,7 +260,8 @@ class BracesOnIfStatements(config: Config) : Rule(
         Always("always"),
         Consistent("consistent"),
         Necessary("necessary"),
-        Never("never");
+        Never("never"),
+        ;
 
         companion object {
             fun getValue(arg: String): BracePolicy =

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatements.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatements.kt
@@ -228,7 +228,8 @@ class BracesOnWhenStatements(config: Config) : Rule(
             BracePolicy.Consistent -> (violator.parent as KtWhenExpression).whenKeyword
             BracePolicy.Always,
             BracePolicy.Necessary,
-            BracePolicy.Never -> requireNotNull(violator.arrow) { "When branch ${violator.text} has no arrow!" }
+            BracePolicy.Never,
+            -> requireNotNull(violator.arrow) { "When branch ${violator.text} has no arrow!" }
         }
         report(CodeSmell(Entity.from(reported), policy.message))
     }
@@ -237,7 +238,8 @@ class BracesOnWhenStatements(config: Config) : Rule(
         Always("always", "Missing braces on this branch, add them."),
         Consistent("consistent", "Inconsistent braces, make sure all branches either have or don't have braces."),
         Necessary("necessary", "Extra braces exist on this branch, remove them."),
-        Never("never", "Extra braces exist on this branch, remove them.");
+        Never("never", "Extra braces exist on this branch, remove them."),
+        ;
 
         companion object {
             fun getValue(arg: String): BracePolicy =

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnnotationUseSiteTarget.kt
@@ -72,6 +72,6 @@ class UnnecessaryAnnotationUseSiteTarget(config: Config) : Rule(
         PROPERTY(
             "property",
             "An annotation over a property, that it's not a parameter, doesn't need the use-site target @property."
-        )
+        ),
     }
 }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAny.kt
@@ -95,7 +95,7 @@ class UnnecessaryAny(config: Config) : Rule(
     }
 
     private fun KtBlockExpression.shouldBlockExpressionBeReported(
-        descriptor: VariableDescriptor
+        descriptor: VariableDescriptor,
     ): String? {
         if (this.statements.isEmpty()) return null
         if (descriptor is WithDestructuringDeclaration) {
@@ -141,7 +141,7 @@ class UnnecessaryAny(config: Config) : Rule(
     private fun isUsageOfValueAndItEligible(
         descriptor: VariableDescriptor,
         leftExpression: KtExpression?,
-        rightExpression: KtExpression?
+        rightExpression: KtExpression?,
     ): String? {
         leftExpression ?: return null
         rightExpression ?: return null

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilter.kt
@@ -111,7 +111,7 @@ class UnnecessaryFilter(config: Config) : Rule(
 
     private fun getReferrers(
         property: KtProperty,
-        propertyDescriptor: DeclarationDescriptor
+        propertyDescriptor: DeclarationDescriptor,
     ): Sequence<KtNameReferenceExpression> =
         property.siblings(forward = true, withItself = false).flatMap { sibling ->
             sibling.collectDescendantsOfType<KtNameReferenceExpression> { it.descriptor() == propertyDescriptor }

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClass.kt
@@ -136,7 +136,7 @@ class UseDataClass(config: Config) : Rule(
 
     private fun KtNamedFunction.isDefaultFunction(
         classType: KotlinType?,
-        primaryConstructorParameterTypes: List<KotlinType>
+        primaryConstructorParameterTypes: List<KotlinType>,
     ): Boolean =
         when (name) {
             !in DEFAULT_FUNCTION_NAMES -> false

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlank.kt
@@ -103,7 +103,7 @@ class UseIfEmptyOrIfBlank(config: Config) : Rule(
     private data class Replacement(
         val conditionFunctionFqName: FqName,
         val replacementFunctionName: String,
-        val negativeCondition: Boolean = false
+        val negativeCondition: Boolean = false,
     )
 
     companion object {

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeVal.kt
@@ -85,7 +85,7 @@ class VarCouldBeVal(config: Config) : Rule(
     @Suppress("TooManyFunctions")
     private class AssignmentVisitor(
         private val bindingContext: BindingContext,
-        private val ignoreLateinitVar: Boolean
+        private val ignoreLateinitVar: Boolean,
     ) : DetektVisitor() {
 
         private val declarationCandidates = mutableSetOf<KtNamedDeclaration>()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnIfStatementsSpec.kt
@@ -2189,7 +2189,7 @@ class BracesOnIfStatementsSpec {
             singleLine: String,
             multiLine: String,
             code: String,
-            vararg locations: (String) -> Pair<Int, Int>
+            vararg locations: (String) -> Pair<Int, Int>,
         ): DynamicNode {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
@@ -2228,7 +2228,7 @@ class BracesOnIfStatementsSpec {
         private fun createBraceTests(
             singleLine: String,
             multiLine: String,
-            test: (BracesOnIfStatements) -> Unit
+            test: (BracesOnIfStatements) -> Unit,
         ): List<DynamicNode> {
             val singleOptions = options(singleLine)
             val multiOptions = options(multiLine)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/BracesOnWhenStatementsSpec.kt
@@ -1211,7 +1211,7 @@ class BracesOnWhenStatementsSpec {
             singleLine: String,
             multiLine: String,
             code: String,
-            vararg locations: (String) -> Pair<Int, Int>
+            vararg locations: (String) -> Pair<Int, Int>,
         ): DynamicNode {
             val codeLocation = locations.map { it(code) }.toTypedArray()
             // Separately compile the code because otherwise all the combinations would compile them again and again.
@@ -1250,7 +1250,7 @@ class BracesOnWhenStatementsSpec {
         private fun createBraceTests(
             singleLine: String,
             multiLine: String,
-            test: (BracesOnWhenStatements) -> Unit
+            test: (BracesOnWhenStatements) -> Unit,
         ): List<DynamicNode> {
             val singleOptions = options(singleLine)
             val multiOptions = options(multiLine)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryParenthesesSpec.kt
@@ -154,7 +154,7 @@ class UnnecessaryParenthesesSpec {
     @ParameterizedTest
     @MethodSource("cases")
     fun `should not report call to function with two lambda parameters with one as block body`(
-        testCase: RuleTestCase
+        testCase: RuleTestCase,
     ) {
         val code = """
             class Clazz {
@@ -466,7 +466,7 @@ class UnnecessaryParenthesesSpec {
     @ParameterizedTest
     @MethodSource("cases")
     fun `does report unnecessary parens in case of constant literal when using inc operator`(
-        testCase: RuleTestCase
+        testCase: RuleTestCase,
     ) {
         val code = """
             class Foo(var value: Int) {
@@ -592,7 +592,7 @@ class UnnecessaryParenthesesSpec {
     @ParameterizedTest
     @MethodSource("cases")
     fun `float literals closed range without integer part with braces on the right side - #7640`(
-        testCase: RuleTestCase
+        testCase: RuleTestCase,
     ) {
         val code = """
             val a = .1F..(.2F)

--- a/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidator.kt
+++ b/detekt-sample-extensions/src/main/kotlin/io/gitlab/arturbosch/detekt/sample/extensions/SampleConfigValidator.kt
@@ -23,5 +23,5 @@ class SampleConfigValidator : ConfigValidator {
 
 class SampleMessage(
     override val message: String,
-    override val level: Notification.Level = Notification.Level.Error
+    override val level: Notification.Level = Notification.Level.Error,
 ) : Notification

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -10,7 +10,7 @@ import java.io.File
  */
 class KotlinCoreEnvironmentWrapper(
     private var environment: KotlinCoreEnvironment?,
-    private val disposable: Disposable
+    private val disposable: Disposable,
 ) {
 
     val env: KotlinCoreEnvironment
@@ -29,5 +29,5 @@ class KotlinCoreEnvironmentWrapper(
  */
 fun createEnvironment(
     additionalRootPaths: List<File> = emptyList(),
-    additionalJavaSourceRootPaths: List<File> = emptyList()
+    additionalJavaSourceRootPaths: List<File> = emptyList(),
 ): KotlinCoreEnvironmentWrapper = KtTestCompiler.createEnvironment(additionalRootPaths, additionalJavaSourceRootPaths)

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -34,7 +34,7 @@ internal object KtTestCompiler : KtCompiler() {
      */
     fun createEnvironment(
         additionalRootPaths: List<File> = emptyList(),
-        additionalJavaSourceRootPaths: List<File> = emptyList()
+        additionalJavaSourceRootPaths: List<File> = emptyList(),
     ): KotlinCoreEnvironmentWrapper {
         val configuration = CompilerConfiguration()
         configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/StringPrintStream.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/StringPrintStream.kt
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 import java.io.PrintStream
 
 class StringPrintStream private constructor(
-    private val stream: ByteArrayOutputStream
+    private val stream: ByteArrayOutputStream,
 ) : PrintStream(stream) {
 
     constructor() : this(ByteArrayOutputStream())

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakeKtElement.kt
@@ -221,7 +221,7 @@ class FakeKtElement(private val psiFile: PsiFile = FakePsiFile("")) : KtElement 
         p0: PsiScopeProcessor,
         p1: ResolveState,
         p2: PsiElement?,
-        p3: PsiElement
+        p3: PsiElement,
     ): Boolean = false
 
     override fun <T : Any?> putCopyableUserData(p0: Key<T>, p1: T?) {

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakePsiFile.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/internal/FakePsiFile.kt
@@ -195,7 +195,7 @@ class FakePsiFile(private val text: String = "", private val name: String = "") 
         p0: PsiScopeProcessor,
         p1: ResolveState,
         p2: PsiElement?,
-        p3: PsiElement
+        p3: PsiElement,
     ): Boolean = false
 
     override fun getContext(): PsiElement? = null

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -15,7 +15,7 @@ import kotlin.script.experimental.jvm.util.classpathFromClassloader
 @Target(AnnotationTarget.CLASS)
 @ExtendWith(KotlinEnvironmentResolver::class)
 annotation class KotlinCoreEnvironmentTest(
-    val additionalJavaSourcePaths: Array<String> = []
+    val additionalJavaSourcePaths: Array<String> = [],
 )
 
 internal class KotlinEnvironmentResolver : ParameterResolver {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -34,7 +34,7 @@ fun Rule.compileAndLint(
 
 fun Rule.lint(
     @Language("kotlin") content: String,
-    compilerResources: CompilerResources = FakeCompilerResources()
+    compilerResources: CompilerResources = FakeCompilerResources(),
 ): List<Finding> {
     require(!this::class.hasAnnotation<RequiresFullAnalysis>()) {
         "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
@@ -50,7 +50,7 @@ fun Rule.lintWithContext(
     compilerResources: CompilerResources = CompilerResources(
         environment.configuration.languageVersionSettings,
         DataFlowValueFactoryImpl(environment.configuration.languageVersionSettings)
-    )
+    ),
 ): List<Finding> {
     require(this::class.hasAnnotation<RequiresFullAnalysis>()) {
         "${this.ruleName} doesn't require full analysis so you should use lint instead of lintWithContext"
@@ -70,7 +70,7 @@ fun Rule.compileAndLintWithContext(
     compilerResources: CompilerResources = CompilerResources(
         environment.configuration.languageVersionSettings,
         DataFlowValueFactoryImpl(environment.configuration.languageVersionSettings)
-    )
+    ),
 ): List<Finding> {
     require(this::class.hasAnnotation<RequiresFullAnalysis>()) {
         "${this.ruleName} doesn't require full analysis so you should use compileAndLintWithContext instead of " +

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektCli.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektCli.kt
@@ -11,7 +11,7 @@ interface DetektCli {
     companion object {
 
         fun load(
-            classLoader: ClassLoader = DetektCli::class.java.classLoader
+            classLoader: ClassLoader = DetektCli::class.java.classLoader,
         ): DetektCli =
             ServiceLoader.load(DetektCli::class.java, classLoader).first()
     }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektError.kt
@@ -2,7 +2,7 @@ package io.github.detekt.tooling.api
 
 sealed class DetektError(
     message: String?,
-    cause: Throwable? = null
+    cause: Throwable? = null,
 ) : RuntimeException(message, cause)
 
 class IssuesFound(message: String) : DetektError(message)

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/DetektProvider.kt
@@ -26,7 +26,7 @@ interface DetektProvider {
          * Looks for a provider on the classpath which is able to load [Detekt] instances.
          */
         fun load(
-            classLoader: ClassLoader = DetektProvider::class.java.classLoader
+            classLoader: ClassLoader = DetektProvider::class.java.classLoader,
         ): DetektProvider =
             ServiceLoader.load(DetektProvider::class.java, classLoader)
                 .maxByOrNull { it.priority }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/VersionProvider.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/api/VersionProvider.kt
@@ -9,7 +9,7 @@ interface VersionProvider {
     companion object {
 
         fun load(
-            classLoader: ClassLoader = VersionProvider::class.java.classLoader
+            classLoader: ClassLoader = VersionProvider::class.java.classLoader,
         ): VersionProvider =
             ServiceLoader.load(VersionProvider::class.java, classLoader).first()
     }

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/BaselineSpecBuilder.kt
@@ -14,5 +14,5 @@ class BaselineSpecBuilder : Builder<BaselineSpec> {
 
 private data class BaselineModel(
     override val path: Path?,
-    override val shouldCreateDuringAnalysis: Boolean
+    override val shouldCreateDuringAnalysis: Boolean,
 ) : BaselineSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ConfigSpecBuilder.kt
@@ -25,5 +25,5 @@ private data class ConfigModel(
     override val shouldValidateBeforeAnalysis: Boolean?,
     override val useDefaultConfig: Boolean,
     override val resources: Collection<URL>,
-    override val configPaths: Collection<Path>
+    override val configPaths: Collection<Path>,
 ) : ConfigSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExecutionSpecBuilder.kt
@@ -15,5 +15,5 @@ class ExecutionSpecBuilder : Builder<ExecutionSpec> {
 private data class ExecutionModel(
     override val executorService: ExecutorService?,
     override val parallelParsing: Boolean,
-    override val parallelAnalysis: Boolean
+    override val parallelAnalysis: Boolean,
 ) : ExecutionSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ExtensionsSpecBuilder.kt
@@ -34,5 +34,5 @@ class ExtensionsSpecBuilder : Builder<ExtensionsSpec> {
 
 private data class ExtensionsModel(
     override val plugins: ExtensionsSpec.Plugins?,
-    override val disabledExtensions: Set<ExtensionId>
+    override val disabledExtensions: Set<ExtensionId>,
 ) : ExtensionsSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/LoggingSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/LoggingSpecBuilder.kt
@@ -14,5 +14,5 @@ class LoggingSpecBuilder : Builder<LoggingSpec> {
 private data class LoggingModel(
     override val debug: Boolean,
     override val outputChannel: Appendable,
-    override val errorChannel: Appendable
+    override val errorChannel: Appendable,
 ) : LoggingSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/ProcessingSpecBuilder.kt
@@ -59,5 +59,5 @@ private data class ProcessingModel(
     override val rulesSpec: RulesSpec,
     override val loggingSpec: LoggingSpec,
     override val projectSpec: ProjectSpec,
-    override val reportsSpec: ReportsSpec
+    override val reportsSpec: ReportsSpec,
 ) : ProcessingSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/dsl/RulesSpecBuilder.kt
@@ -23,5 +23,5 @@ private data class RulesModel(
     override val activateAllRules: Boolean,
     override val failurePolicy: FailurePolicy,
     override val autoCorrect: Boolean,
-    override val runPolicy: RulesSpec.RunPolicy
+    override val runPolicy: RulesSpec.RunPolicy,
 ) : RulesSpec

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/DefaultAnalysisResult.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/DefaultAnalysisResult.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 
 class DefaultAnalysisResult(
     override val container: Detektion?,
-    override val error: DetektError? = null
+    override val error: DetektError? = null,
 ) : AnalysisResult {
 
     init {

--- a/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/PluginsHolder.kt
+++ b/detekt-tooling/src/main/kotlin/io/github/detekt/tooling/internal/PluginsHolder.kt
@@ -6,7 +6,7 @@ import kotlin.io.path.exists
 
 internal data class PluginsHolder(
     override val paths: Collection<Path>?,
-    override val loader: ClassLoader?
+    override val loader: ClassLoader?,
 ) : ExtensionsSpec.Plugins {
 
     init {

--- a/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
+++ b/detekt-utils/src/main/kotlin/io/github/detekt/utils/PathFilters.kt
@@ -8,7 +8,7 @@ import java.nio.file.PathMatcher
  */
 class PathFilters internal constructor(
     private val includes: Set<PathMatcher>?,
-    private val excludes: Set<PathMatcher>?
+    private val excludes: Set<PathMatcher>?,
 ) {
 
     /**


### PR DESCRIPTION
I enabled the TrailingCommaOnDeclarationSite rule and ran autocorrect without making any manual adjustments.

I also had a look at enabling TrailingCommaOnCallSite but I'm less convinced about that one. There was no obvious improvement to the code style in my opinion (it asks for commas when passing a single parameter to a function for example - there will be lots of these).

The Kotlin coding conventions also say:

> The Kotlin style guide encourages the use of trailing commas at the declaration site and _**leaves it at your discretion for the call site**_.

Emphasis is mine.

I won't submit a PR for that and personally don't think that's a good improvement.