### PR TITLE
Simplify test api with context

### DIFF
--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -27,7 +27,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report function parameter list that has exactly the allowed amount`() {
         val code = "fun long(a: Int, b: Int) {}"
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }
@@ -35,7 +35,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
     @Test
     fun `reports too long parameter list`() {
         val code = "fun long(a: Int, b: Int, c: Int) {}"
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(reportMessageForFunction)
     }
@@ -43,13 +43,13 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
     @Test
     fun `does not report short parameter list`() {
         val code = "fun long(a: Int) {}"
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports too long parameter list event for parameters with defaults`() {
         val code = "fun long(a: Int, b: Int = 1, c: Int) {}"
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -57,13 +57,13 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
         val config = TestConfig("ignoreDefaultParameters" to "true")
         val rule = LongParameterList(config)
         val code = "fun long(a: Int, b: Int, c: Int = 2) {}"
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports too long parameter list for primary constructors`() {
         val code = "class LongCtor(a: Int, b: Int, c: Int)"
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(reportMessageForConstructor)
     }
@@ -71,13 +71,13 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
     @Test
     fun `does not report short parameter list for primary constructors`() {
         val code = "class LongCtor(a: Int)"
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports too long parameter list for secondary constructors`() {
         val code = "class LongCtor() { constructor(a: Int, b: Int, c: Int) : this() }"
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo(reportMessageForConstructor)
     }
@@ -85,7 +85,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
     @Test
     fun `does not report short parameter list for secondary constructors`() {
         val code = "class LongCtor() { constructor(a: Int) : this() }"
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -93,14 +93,14 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
         val config = TestConfig("allowedConstructorParameters" to "1")
         val rule = LongParameterList(config)
         val code = "class LongCtor(a: Int, b: Int)"
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
     fun `does not report constructor parameter list that has exactly the allowed amount`() {
         val code = "data class Data(val a: Int, val b: Int)"
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }
@@ -113,7 +113,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
         )
         val rule = LongParameterList(config)
         val code = "data class Data(val a: Int)"
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Nested
@@ -139,7 +139,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
                 
                 class Data constructor(@CustomAnnotation val a: Int, @CustomAnnotation val b: Int)
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(rule.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -150,13 +150,13 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
                 
                 class Data { fun foo(@CustomAnnotation a: Int, @CustomAnnotation b: Int) {} }
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(rule.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `does not report long parameter list for constructors if enough constructor parameters are annotated with ignored annotation`() {
             val code = "class Data constructor(@kotlin.Suppress(\"\") val a: Int)"
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -166,7 +166,7 @@ class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
                     fun foo(@kotlin.Suppress("") a: Int) {}
                 }
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -24,7 +24,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 sum(1, 2, 3)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -38,7 +38,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 sum(a = 1, b = 2, c = 3)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -52,7 +52,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 sum(1, b = 2, c = 3)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -66,7 +66,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 sum(1, 2)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -80,7 +80,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 sum(a = 1, b = 2)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -91,7 +91,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             
             val obj = C(1, 2, 3)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -102,7 +102,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             
             val obj = C(a = 1, b = 2, c= 3)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -113,7 +113,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
             
             val obj = C(1, 2)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -126,7 +126,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 LocalDateTime.of(2020, 3, 13, 14, 0, 0)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -140,7 +140,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 bar(1, 2, 3, "a")
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -155,7 +155,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 varargFun("a", *nums1, *nums2, *nums3)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -167,7 +167,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 bar(1, 2, 3, *arrayOf("a"))
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -182,7 +182,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     foo(a = 1, b = 2, c = 3, { it })
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -195,7 +195,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     foo(a = 1, b = 2, c = 3) { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -208,7 +208,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                     foo(a = 1, b = 2, 3) { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -220,7 +220,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val subject = NamedArguments(TestConfig("threshold" to 1))
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -240,7 +240,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                         foo(a, b, c)
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -252,7 +252,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                         foo(a, c, b)
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -267,7 +267,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -280,7 +280,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                         baz?.let { foo(a, it.b, c) }
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -295,7 +295,7 @@ class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
                         foo(a, b, c)
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -104,7 +104,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
     }
 
     private fun whenLintRuns() {
-        actual = subject.compileAndLintWithContext(env, givenCode)
+        actual = subject.lintWithContext(env, givenCode)
     }
 
     private fun expectSourceLocation(location: Pair<Int, Int>) {

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.complexity
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -25,7 +25,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
                 ?.forEach(::println)
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -38,7 +38,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
                 ?.map { it }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -50,7 +50,7 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
                 ?.asSequence()
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -69,6 +69,6 @@ class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.createBindingContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -617,6 +616,6 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code, file)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, code, file, compile = false)).hasSize(1)
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -3,8 +3,8 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.createBindingContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -36,7 +36,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -63,7 +63,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -85,7 +85,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -107,7 +107,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -133,7 +133,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -158,7 +158,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -185,7 +185,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -214,7 +214,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -243,7 +243,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -265,7 +265,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -288,7 +288,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -303,7 +303,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -396,7 +396,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(2)
         assert(findings.any { it.location.source.line == 9 })
         assert(findings.any { it.location.source.line == 14 })
@@ -460,7 +460,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -499,7 +499,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -518,7 +518,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -541,7 +541,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -562,7 +562,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -587,7 +587,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -616,6 +616,6 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code, file, compile = false)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code, file, compile = false)).hasSize(1)
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -30,7 +30,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -47,7 +47,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -58,7 +58,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 
                 class MyRepository(dispatcher: CoroutineDispatcher = Dispatchers.IO)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -71,7 +71,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     constructor() : this(Dispatchers.IO)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -82,7 +82,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                 
                 class MyRepository(private val dispatcher: CoroutineDispatcher = Dispatchers.IO)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -98,7 +98,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -123,7 +123,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -148,7 +148,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -173,7 +173,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -196,7 +196,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     constructor() : this(Dispatchers)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -221,7 +221,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -246,7 +246,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -268,7 +268,7 @@ class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -100,7 +99,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 actual suspend fun bar() {}
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -47,7 +47,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 suspendCoroutine()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -59,7 +59,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -69,7 +69,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 suspend fun empty()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -85,7 +85,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -99,7 +99,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 actual suspend fun bar() {}
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test
@@ -115,7 +115,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -136,7 +136,7 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -149,6 +149,6 @@ class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
             }
             suspend fun  String.baz() = foo()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
@@ -23,7 +23,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 delay(1000L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -34,7 +34,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 Thread.sleep(1000L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -44,7 +44,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 Thread.sleep(1000L, 1000)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -61,7 +61,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -79,7 +79,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -101,7 +101,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -122,7 +122,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -143,7 +143,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -164,7 +164,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -185,7 +185,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -206,7 +206,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -227,7 +227,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 })
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -248,7 +248,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 })
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -269,7 +269,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }))
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -288,7 +288,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 suspendBlock(lambda = Thread::sleep)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -308,7 +308,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 suspendBlock(lambda = ::delay)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -329,7 +329,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -350,7 +350,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -368,7 +368,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -388,7 +388,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -408,7 +408,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -430,7 +430,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -448,7 +448,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -468,7 +468,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -489,7 +489,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -514,7 +514,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -531,7 +531,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 inlineFun { Thread.sleep(1000L) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -545,7 +545,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -559,7 +559,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -574,7 +574,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -587,7 +587,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -604,7 +604,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -621,7 +621,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -638,7 +638,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -656,7 +656,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -672,7 +672,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -686,7 +686,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Nested
@@ -698,7 +698,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -708,7 +708,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -718,7 +718,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -728,7 +728,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 })
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -738,7 +738,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -748,7 +748,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     Thread.sleep(1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -760,7 +760,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -772,7 +772,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Nested
@@ -787,7 +787,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                         Thread.sleep(1000L)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -806,7 +806,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -823,7 +823,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -841,7 +841,7 @@ class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
     }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -32,7 +32,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
 
         assertFindingsForSuspendCall(
-            findings = subject.compileAndLintWithContext(env, code),
+            findings = subject.lintWithContext(env, code),
             "test".find(1)(code),
             "test".find(2)(code)
         )
@@ -61,7 +61,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
 
         assertFindingsForSuspendCall(
-            findings = subject.compileAndLintWithContext(env, code),
+            findings = subject.lintWithContext(env, code),
             *NOTHING
         )
     }
@@ -85,7 +85,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
 
         assertFindingsForSuspendCall(
-            findings = subject.compileAndLintWithContext(env, code),
+            findings = subject.lintWithContext(env, code),
             "test".find(1)(code),
             "withContext".find(1)(code),
         )
@@ -110,7 +110,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
 
         assertFindingsForSuspendCall(
-            findings = subject.compileAndLintWithContext(env, code),
+            findings = subject.lintWithContext(env, code),
             *NOTHING
         )
     }
@@ -143,7 +143,7 @@ class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
 
         assertFindingsForSuspendCall(
-            findings = subject.compileAndLintWithContext(env, code),
+            findings = subject.lintWithContext(env, code),
             "wrapper".find(2)(code),
             "test".find(1)(code),
             "block".find(2)(code),

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -370,7 +370,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(4, 5)),
@@ -394,7 +394,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(6, 5), SourceLocation(8, 9)),
@@ -422,7 +422,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(11, 13)),
@@ -450,7 +450,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(8, 5)),
@@ -469,7 +469,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(4, 5)),
@@ -489,7 +489,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(5, 5)),
@@ -507,7 +507,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -525,7 +525,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 return result
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(4, 18)),
@@ -544,7 +544,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(4, 5)),
@@ -559,7 +559,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             suspend fun bar() = delay(1000L)
             suspend fun foo() = runCatching { bar() }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(3, 21)),
@@ -583,7 +583,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(4, 5)),
@@ -610,7 +610,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -631,7 +631,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -663,7 +663,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -687,7 +687,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(8, 5)),
@@ -721,7 +721,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -740,7 +740,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(5, 5)),
@@ -762,7 +762,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertFindingsForSuspendCall(
                 findings,
@@ -803,7 +803,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(17, 5)),
@@ -843,7 +843,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(17, 5)),
@@ -867,7 +867,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(5, 5)),
@@ -891,7 +891,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(6, 5)),
@@ -912,7 +912,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(5, 5)),
@@ -933,7 +933,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(5, 5)),
@@ -957,7 +957,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -977,7 +977,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(6, 5)),
@@ -1001,7 +1001,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -1022,7 +1022,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(6, 5)),
@@ -1045,7 +1045,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -1061,7 +1061,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings,
             listOf(SourceLocation(4, 5)),
@@ -1088,7 +1088,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(8, 5)),
@@ -1117,7 +1117,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(8, 5), SourceLocation(12, 5)),
@@ -1146,7 +1146,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(8, 5), SourceLocation(12, 5)),
@@ -1170,7 +1170,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1194,7 +1194,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1219,7 +1219,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1243,7 +1243,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1268,7 +1268,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1293,7 +1293,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1317,7 +1317,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(6, 5)),
@@ -1344,7 +1344,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(9, 5)),
@@ -1369,7 +1369,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1394,7 +1394,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingsForSuspendCall(
                 findings,
                 listOf(SourceLocation(7, 5)),
@@ -1423,7 +1423,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingsForSuspendCall(
                     findings,
                     listOf(SourceLocation(8, 5)),
@@ -1451,7 +1451,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingsForSuspendCall(
                     findings,
                     listOf(SourceLocation(8, 5)),
@@ -1479,7 +1479,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingsForSuspendCall(
                     findings,
                     listOf(SourceLocation(8, 5)),
@@ -1513,7 +1513,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingsForSuspendCall(
                     findings,
                     listOf(SourceLocation(14, 5)),
@@ -1543,7 +1543,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -1560,7 +1560,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingsForSuspendCall(
                     findings,
                     listOf(SourceLocation(5, 5)),
@@ -1588,7 +1588,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
                     }
                 """.trimIndent()
 
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -1606,7 +1606,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
     }
 
     private fun assertOneFindingAt(@Language("kotlin") code: String, start: SourceLocation, end: SourceLocation) {
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertFindingsForSuspendCall(
             findings = findings,
             listOfStartLocation = listOf(start),
@@ -1615,7 +1615,7 @@ class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment
     }
 
     private fun assertNoFindings(@Language("kotlin") code: String) {
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -29,7 +29,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -43,7 +43,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -58,7 +58,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -76,7 +76,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -92,7 +92,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -109,7 +109,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -126,7 +126,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -140,7 +140,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     delay(timeMillis = 1000)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -159,7 +159,7 @@ class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnviro
                     action()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 }

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.coroutines
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 return MutableStateFlow(value = 1L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -60,7 +60,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 return MutableStateFlow(value = 1L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -83,7 +83,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 return kotlinx.coroutines.flow.MutableStateFlow(value = 1L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -95,7 +95,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             suspend fun flowValues() = flowOf(1L, 2L, 3L)
             suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -111,7 +111,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 suspend fun mutableStateFlowValues(): MutableStateFlow<Long>
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -140,7 +140,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -154,7 +154,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 suspend fun mutableStateFlowValues() = MutableStateFlow(value = 1L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -181,7 +181,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 return MutableStateFlow(value = this)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+        assertThat(subject.lintWithContext(env, code)).hasSize(3)
     }
 
     @Test
@@ -193,7 +193,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             suspend fun Long.flowValues() = (0..this).asFlow()
             suspend fun Long.mutableStateFlowValues() = MutableStateFlow(value = this)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -214,7 +214,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 TODO()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -251,7 +251,7 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 suspend fun getValue() = 5L.apply { delay(1_000L) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -274,6 +274,6 @@ class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
                 return MutableStateFlow(value = 1L)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEqualitySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEqualitySpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -25,7 +25,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 fun g(other: String) = if (s === other) 1 else 2
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).hasSize(3)
         }
@@ -40,7 +40,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 fun g(other: String?) = s === other
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).hasSize(4)
         }
@@ -52,7 +52,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = s !== "something"
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).hasSize(1)
         }
@@ -66,7 +66,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = i === 1 || l === 100L || c === 'b'
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).isEmpty()
         }
@@ -80,7 +80,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 fun g(other: String) = if (s == other) 1 else 2
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).isEmpty()
         }
@@ -92,7 +92,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = same("this", "that")
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).isEmpty()
         }
@@ -111,7 +111,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = s === "other" || i === 42 || list === listOf(2)
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).hasSize(3)
         }
@@ -132,7 +132,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = listOf(2) === listA || listA === listB || mutableList === mutableListOf(2)
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).hasSize(3)
         }
@@ -146,7 +146,7 @@ class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
                 val b = listOf(2) == listA || listA == listB || mutableList == mutableListOf(2)
             """.trimIndent()
 
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
 
             assertThat(actual).isEmpty()
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = bar as String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(bar ?: error(\"null assertion message\")) as String') instead of 'bar as String'."
@@ -38,7 +38,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 return null
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(bar() ?: error(\"null assertion message\")) as Int') instead of 'bar() as Int'."
@@ -57,7 +57,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -76,7 +76,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
             TestConfig(
                 IGNORE_PLATFORM_TYPES to true
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -95,7 +95,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
             TestConfig(
                 IGNORE_PLATFORM_TYPES to false
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -108,7 +108,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -119,7 +119,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = (bar ?: error("null assertion message")) as String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -130,7 +130,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = bar!! as String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -141,7 +141,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = bar as String?
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -152,7 +152,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = bar as? String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -163,7 +163,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 val x = null as String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -177,7 +177,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 array[0] as T
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -191,7 +191,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) 
                 array[0] as T
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(
             "Use separate `null` assertion and type cast like " +
                 "('(array[0] ?: error(\"null assertion message\")) as T') instead of 'array[0] as T'."

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 val x: String? = a as String?
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
         assertThat(findings).hasStartSourceLocation(2, 24)
     }
@@ -30,7 +30,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 val x = a as CharSequence?
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -41,7 +41,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 val x: String? = a as? String
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -52,7 +52,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 val x = a is String?
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -63,7 +63,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 val x = null as String?
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -79,7 +79,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 print(a)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -93,7 +93,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 print(a)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -107,7 +107,7 @@ class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 print(a)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -27,7 +27,7 @@ class CharArrayToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println(s + "hello".toCharArray())
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(6)
     }
 
@@ -39,7 +39,7 @@ class CharArrayToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println(charArray)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -55,7 +55,7 @@ class CharArrayToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println(s + charArray.concatToString())
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings.first().message).isEqualTo("""Foo is deprecated with message "deprecation message"""")
     }
@@ -46,6 +46,6 @@ class DeprecationSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -204,7 +203,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val params = tooltip_guide.layoutParams as LayoutParams
                 }
             """.trimIndent()
-            val result = subject.lintWithContext(env, code)
+            val result = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(result).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -22,7 +22,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutList = myList as MutableList<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
@@ -37,7 +37,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutList = myList as? MutableList<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
@@ -54,7 +54,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to MutableList is risky. Use `toMutableList()` instead."
@@ -69,7 +69,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as MutableSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
@@ -84,7 +84,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as? MutableSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
@@ -101,7 +101,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to MutableSet is risky. Use `toMutableSet()` instead."
@@ -116,7 +116,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as MutableMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
@@ -131,7 +131,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as? MutableMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
@@ -148,7 +148,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to MutableMap is risky. Use `toMutableMap()` instead."
@@ -167,7 +167,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutList = myList as MutableList<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).isEmpty()
         }
 
@@ -179,7 +179,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as MutableSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).isEmpty()
         }
 
@@ -191,7 +191,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as MutableMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).isEmpty()
         }
 
@@ -203,7 +203,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val params = tooltip_guide.layoutParams as LayoutParams
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code, compile = false)
+            val result = subject.lintWithContext(env, code, compile = false)
             assertThat(result).isEmpty()
         }
     }
@@ -219,7 +219,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutList = myList as ArrayList<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to ArrayList is risky."
@@ -234,7 +234,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutList = myList as? ArrayList<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to ArrayList is risky."
@@ -251,7 +251,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type List to ArrayList is risky."
@@ -266,7 +266,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as LinkedHashSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to LinkedHashSet is risky."
@@ -281,7 +281,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as? LinkedHashSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to LinkedHashSet is risky."
@@ -298,7 +298,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to LinkedHashSet is risky."
@@ -313,7 +313,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as HashSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to HashSet is risky."
@@ -328,7 +328,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutSet = mySet as? HashSet<Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to HashSet is risky."
@@ -345,7 +345,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Set to HashSet is risky."
@@ -360,7 +360,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as HashMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to HashMap is risky."
@@ -375,7 +375,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as? HashMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to HashMap is risky."
@@ -392,7 +392,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to HashMap is risky."
@@ -407,7 +407,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as LinkedHashMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to LinkedHashMap is risky."
@@ -422,7 +422,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     val mutMap = myMap as? LinkedHashMap<Int, Int>
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to LinkedHashMap is risky."
@@ -439,7 +439,7 @@ class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val result = subject.compileAndLintWithContext(env, code)
+            val result = subject.lintWithContext(env, code)
             assertThat(result).hasSize(1)
             assertThat(result.first().message).isEqualTo(
                 "Down-casting from type Map to LinkedHashMap is risky."

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -28,7 +28,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myList = mutableListOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -40,7 +40,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var mySet = mutableSetOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -52,7 +52,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myMap = mutableMapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -64,7 +64,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myArrayList = ArrayList<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -76,7 +76,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myLinkedHashSet = LinkedHashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -88,7 +88,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myHashSet = HashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -100,7 +100,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myLinkedHashMap = LinkedHashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -112,7 +112,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myHashMap = HashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -129,7 +129,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = MutableState("foo")
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 5)
             }
@@ -147,7 +147,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = mutableStateOf("foo")
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 5)
             }
@@ -164,7 +164,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = remember { mutableStateOf("foo") }
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(5, 5)
             }
@@ -180,7 +180,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myList = mutableListOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -191,7 +191,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val mySet = mutableSetOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -202,7 +202,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myMap = mutableMapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -213,7 +213,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myArrayList = ArrayList<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -224,7 +224,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myLinkedHashSet = LinkedHashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -235,7 +235,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myHashSet = HashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -246,7 +246,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myLinkedHashMap = LinkedHashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -257,7 +257,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myHashMap = HashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -272,7 +272,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myList = listOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -283,7 +283,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val mySet = setOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -294,7 +294,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myMap = mapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -320,7 +320,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState by remember { mutableStateOf("foo") }
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -337,7 +337,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myList = mutableListOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -347,7 +347,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var mySet = mutableSetOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -357,7 +357,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myMap = mutableMapOf("answer" to 42)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -367,7 +367,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myArrayList = ArrayList<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -377,7 +377,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myLinkedHashSet = LinkedHashSet<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -387,7 +387,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myHashSet = HashSet<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -397,7 +397,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myLinkedHashMap = LinkedHashMap<String, Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -407,7 +407,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     var myHashMap = HashMap<String, Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(1, 1)
             }
@@ -422,7 +422,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                     data class MutableState<T>(var state: T)
                     var myState = MutableState("foo")
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 1)
             }
@@ -438,7 +438,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                     fun <T> mutableStateOf(value: T): MutableState<T> = MutableState(value)
                     var myState = mutableStateOf("foo")
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 1)
             }
@@ -455,7 +455,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                     fun <T> remember(calculation: () -> T): T = calculation()
                     var myState = remember { mutableStateOf("foo") }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 1)
             }
@@ -469,7 +469,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myList = mutableListOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -478,7 +478,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val mySet = mutableSetOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -487,7 +487,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myMap = mutableMapOf("answer" to 42)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -496,7 +496,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myArrayList = ArrayList<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -505,7 +505,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myLinkedHashSet = LinkedHashSet<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -514,7 +514,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myHashSet = HashSet<Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -523,7 +523,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myLinkedHashMap = LinkedHashMap<String, Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -532,7 +532,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myHashMap = HashMap<String, Int>()
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -545,7 +545,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myList = listOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -554,7 +554,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val mySet = setOf(1, 2, 3)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -563,7 +563,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                 val code = """
                     val myMap = mapOf("answer" to 42)
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -587,7 +587,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                     }
                     var myState by remember { mutableStateOf("foo") }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -606,7 +606,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myOtherList = mutableListOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -618,7 +618,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var mySet = mutableSetOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -630,7 +630,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myMap = mutableMapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -642,7 +642,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myArrayList = ArrayList<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -654,7 +654,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myLinkedHashSet = LinkedHashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -666,7 +666,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myHashSet = HashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -678,7 +678,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myLinkedHashMap = LinkedHashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -690,7 +690,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myHashMap = HashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(2, 5)
             }
@@ -707,7 +707,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = MutableState("foo")
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(3, 5)
             }
@@ -725,7 +725,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = mutableStateOf("foo")
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(4, 5)
             }
@@ -744,7 +744,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState = remember { mutableStateOf("foo") }
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).hasSize(1)
                 assertThat(result).hasStartSourceLocation(5, 5)
             }
@@ -760,7 +760,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myList = mutableListOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -771,7 +771,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val mySet = mutableSetOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -782,7 +782,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myMap = mutableMapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -793,7 +793,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myArrayList = ArrayList<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -804,7 +804,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myLinkedHashSet = LinkedHashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -815,7 +815,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myHashSet = HashSet<Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -826,7 +826,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myLinkedHashMap = LinkedHashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -837,7 +837,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myHashMap = HashMap<String, Int>()
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -852,7 +852,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myList = listOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -863,7 +863,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val mySet = setOf(1, 2, 3)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
 
@@ -874,7 +874,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         val myMap = mapOf("answer" to 42)
                     }
                 """.trimIndent()
-                val result = subject.compileAndLintWithContext(env, code)
+                val result = subject.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }
@@ -900,7 +900,7 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) 
                         var myState by remember { mutableStateOf("foo") }
                     }
                 """.trimIndent()
-                val result = rule.compileAndLintWithContext(env, code)
+                val result = rule.lintWithContext(env, code)
                 assertThat(result).isEmpty()
             }
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -32,7 +32,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
 
@@ -53,7 +53,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
 
@@ -87,7 +87,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -110,7 +110,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -130,7 +130,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -149,7 +149,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -178,7 +178,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
                     TestConfig("ignoredSubjectTypes" to listOf("com.example.Color"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).isEmpty()
         }
 
@@ -204,7 +204,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
                     TestConfig("ignoredSubjectTypes" to listOf("com.example.Variant"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).isEmpty()
         }
 
@@ -230,7 +230,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
                     TestConfig("ignoredSubjectTypes" to listOf("com.example.Class"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).hasSize(1)
         }
 
@@ -256,7 +256,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
             assertThat(
                 ElseCaseInsteadOfExhaustiveWhen(
                     TestConfig("ignoredSubjectTypes" to listOf("com.example.Class"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).hasSize(1)
         }
     }
@@ -280,7 +280,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -300,7 +300,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -316,7 +316,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
 
@@ -331,7 +331,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).hasSize(1)
         }
 
@@ -350,7 +350,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -370,7 +370,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -411,7 +411,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -88,7 +87,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -281,7 +280,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -301,7 +300,7 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 exitProcess(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -29,7 +29,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 System.exit(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -39,7 +39,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 Runtime.getRuntime().exit(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -49,7 +49,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 Runtime.getRuntime().halt(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -60,7 +60,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 exitProcess(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -70,7 +70,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 System.exit(0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -83,7 +83,7 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -95,6 +95,6 @@ class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun apiCall() = System.getProperty("propertyName")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -28,7 +28,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 private fun apiCall() = System.getProperty("propertyName")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 fun apiCall(): String = System.getProperty("propertyName")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -48,7 +48,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 val name = System.getProperty("name")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -58,7 +58,7 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 private val name = System.getProperty("name")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -68,6 +68,6 @@ class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
                 val name: String = System.getProperty("name")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -221,7 +220,7 @@ class IgnoredReturnValueSpec {
                 annotation class CheckReturnValue
             """.trimIndent()
 
-            val findings = subject.lintWithContext(env, code, annotationClass)
+            val findings = subject.compileAndLintWithContext(env, code, annotationClass, compile = false)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(7, 5)
@@ -1161,7 +1160,7 @@ class IgnoredReturnValueSpec {
                     foo.foo()
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
@@ -1174,7 +1173,7 @@ class IgnoredReturnValueSpec {
                     bar.bar()
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
@@ -1189,7 +1188,7 @@ class IgnoredReturnValueSpec {
                     map.put("another-key", foo.foo())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class IgnoredReturnValueSpec {
                     listOf("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -35,7 +35,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -46,7 +46,7 @@ class IgnoredReturnValueSpec {
                     listOf("hello").isEmpty().not()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -57,7 +57,7 @@ class IgnoredReturnValueSpec {
                     listOf("hello");println("foo")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -68,7 +68,7 @@ class IgnoredReturnValueSpec {
                     println("foo");listOf("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -79,7 +79,7 @@ class IgnoredReturnValueSpec {
                     listOf("hello")//foo
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -91,7 +91,7 @@ class IgnoredReturnValueSpec {
                     input.isTheAnswer()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -111,7 +111,7 @@ class IgnoredReturnValueSpec {
                     x = listA()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -124,7 +124,7 @@ class IgnoredReturnValueSpec {
                     noReturnValue()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -137,7 +137,7 @@ class IgnoredReturnValueSpec {
                     if (returnsBoolean()) {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -150,7 +150,7 @@ class IgnoredReturnValueSpec {
                     if (42 == returnsInt()) {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -163,7 +163,7 @@ class IgnoredReturnValueSpec {
                     println(returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -176,7 +176,7 @@ class IgnoredReturnValueSpec {
                     println(message = returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -191,7 +191,7 @@ class IgnoredReturnValueSpec {
                     map.put("another-key", returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -220,7 +220,7 @@ class IgnoredReturnValueSpec {
                 annotation class CheckReturnValue
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code, annotationClass, compile = false)
+            val findings = subject.lintWithContext(env, code, annotationClass, compile = false)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(7, 5)
@@ -241,7 +241,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -262,7 +262,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -286,7 +286,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -308,7 +308,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(12, 10)
@@ -328,7 +328,7 @@ class IgnoredReturnValueSpec {
                     listOfChecked("hello");println("foo")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -349,7 +349,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 20)
@@ -370,7 +370,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 14)
@@ -390,7 +390,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call isTheAnswer is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(8, 11)
@@ -412,7 +412,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -431,7 +431,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -449,7 +449,7 @@ class IgnoredReturnValueSpec {
                     if (returnsBoolean()) {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -467,7 +467,7 @@ class IgnoredReturnValueSpec {
                     if (42 == returnsInt()) {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -485,7 +485,7 @@ class IgnoredReturnValueSpec {
                     println(returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -503,7 +503,7 @@ class IgnoredReturnValueSpec {
                     println(message = returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -523,7 +523,7 @@ class IgnoredReturnValueSpec {
                     returnsInt()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -544,7 +544,7 @@ class IgnoredReturnValueSpec {
                     2
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -566,7 +566,7 @@ class IgnoredReturnValueSpec {
                     }.plus(1)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -589,7 +589,7 @@ class IgnoredReturnValueSpec {
                     }.plus(1)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -611,7 +611,7 @@ class IgnoredReturnValueSpec {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -635,7 +635,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -653,7 +653,7 @@ class IgnoredReturnValueSpec {
                     map.put("another-key", returnsInt())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -673,7 +673,7 @@ class IgnoredReturnValueSpec {
                     Assertions().listOfChecked("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -693,7 +693,7 @@ class IgnoredReturnValueSpec {
                     Assertions.listOfChecked("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -715,7 +715,7 @@ class IgnoredReturnValueSpec {
                     Assertions().listOfChecked("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -737,7 +737,7 @@ class IgnoredReturnValueSpec {
                     Parent.Child().listOfChecked("hello")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -771,7 +771,7 @@ class IgnoredReturnValueSpec {
 
                 fun foo(insert: Insert) {}
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(2)
         }
 
@@ -795,7 +795,7 @@ class IgnoredReturnValueSpec {
                     fun execute(): Int = TODO()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -819,7 +819,7 @@ class IgnoredReturnValueSpec {
                      fun execute(): Int = TODO()
                  }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -845,7 +845,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(8, 5)
@@ -866,7 +866,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -882,7 +882,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -907,7 +907,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(9, 5)
@@ -923,7 +923,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(4, 5)
@@ -938,7 +938,7 @@ class IgnoredReturnValueSpec {
                 
                 fun ignoredReturn(): String = "asd"
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call ignoredReturn is returning a value that is ignored.")
             assertThat(findings).hasStartSourceLocation(2, 5)
@@ -956,7 +956,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings)
                 .singleElement()
                 .hasSourceLocation(6, 5)
@@ -978,7 +978,7 @@ class IgnoredReturnValueSpec {
                     return 42
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1003,7 +1003,7 @@ class IgnoredReturnValueSpec {
                     "restrictToConfig" to false,
                 )
             )
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1030,7 +1030,7 @@ class IgnoredReturnValueSpec {
                     "restrictToConfig" to false,
                 )
             )
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1052,7 +1052,7 @@ class IgnoredReturnValueSpec {
                     "restrictToConfig" to false,
                 )
             )
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1063,7 +1063,7 @@ class IgnoredReturnValueSpec {
                     println(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1074,7 +1074,7 @@ class IgnoredReturnValueSpec {
                     TODO("tbd")
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -1093,7 +1093,7 @@ class IgnoredReturnValueSpec {
                     flowOf(1, 2, 3)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings)
                 .singleElement()
@@ -1111,7 +1111,7 @@ class IgnoredReturnValueSpec {
                         .onEach { println(it) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings)
                 .singleElement()
@@ -1126,7 +1126,7 @@ class IgnoredReturnValueSpec {
                 
                 fun foo() = flowOf(1, 2, 3)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -1141,7 +1141,7 @@ class IgnoredReturnValueSpec {
                         .collect()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -1160,7 +1160,7 @@ class IgnoredReturnValueSpec {
                     foo.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
@@ -1173,7 +1173,7 @@ class IgnoredReturnValueSpec {
                     bar.bar()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
@@ -1188,7 +1188,7 @@ class IgnoredReturnValueSpec {
                     map.put("another-key", foo.foo())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 String.format("%d", 1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -29,7 +29,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 String.format(Locale.US, "%d", 1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -41,7 +41,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 String.format("%d", 1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -51,7 +51,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 "%d".format(1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -62,7 +62,7 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 "%d".format(Locale.US, 1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -75,6 +75,6 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
                 "%d".format(1)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             fun String.errorProneUnitWithReceiver() = run { println(this) }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings).hasSize(3)
     }
@@ -29,7 +29,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report explicit Unit return type by default`() {
         val code = """fun safeUnitReturn(): Unit = println("Hello Unit")"""
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }
@@ -39,7 +39,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
         val code = """fun safeButStillReported(): Unit = println("Hello Unit")"""
 
         val findings = ImplicitUnitReturnType(TestConfig("allowExplicitReturnType" to "false"))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
 
         assertThat(findings).hasSize(1)
     }
@@ -52,7 +52,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }
@@ -62,7 +62,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
         val code = """
             fun foo() = Unit
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 val value = map["key"]!!
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -30,7 +30,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 val value = map.get("key")!!
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -41,7 +41,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 map["key"]
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 map.getValue("key")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -63,7 +63,7 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 map.getOrDefault("key", "")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -74,6 +74,6 @@ class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironm
                 map.getOrElse("key", { "" })
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCallSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -30,7 +30,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -52,7 +52,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -81,7 +81,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -109,7 +109,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -130,7 +130,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -167,7 +167,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -192,7 +192,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -215,7 +215,7 @@ class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
@@ -4,7 +4,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -25,7 +25,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 MyCloseable(0).use { /*no-op*/ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -39,7 +39,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
 
             ${myClosable(clazz)}
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasSourceLocation(2, 23)
     }
@@ -57,7 +57,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -71,7 +71,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 return bar
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -85,7 +85,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 return this
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -100,7 +100,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 FileReader("some_file.txt")
             )
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage(
             "BufferedReader doesn't call `use` to access the `Closeable`"
@@ -120,7 +120,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 ).use { val lines = it.lines() }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -146,7 +146,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 )
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasMessage("MyCloseable doesn't call `use` to access the `Closeable`")
     }
@@ -171,7 +171,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 getSomeValueButGenerateException()
             ).use { /* no-op */ }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -198,7 +198,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 ).use { myClosable -> whatever(myClosable) }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -214,7 +214,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
             val lines2 = FileReader("some_file.txt").use { fileReader -> fileReader.buffered().lines().collect(Collectors.toList()) }
             val linesStream = FileReader("some_file.txt").use { fileReader -> fileReader.buffered().lines() }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -230,7 +230,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
             val lines2 = FileReader("some_file.txt").buffered().lines().collect(Collectors.toList())
             val linesStream = FileReader("some_file.txt").buffered().lines()
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -254,7 +254,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable2 = AutoCloseable()
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -267,7 +267,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = Closeable { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -280,7 +280,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = Closeable { /* no-op */ }.use { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -291,7 +291,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = java.io.Closeable { /* no-op */ }.use { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -302,7 +302,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = java.io.Closeable { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -313,7 +313,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = java.io.Closeable { /* no-op */ }.use { mutableListOf<Int>() }.also { it.add(0) }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -324,7 +324,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 val myCloseable = java.io.Closeable { /* no-op */ }.use { 1 } + 2
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -339,7 +339,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -353,7 +353,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }.use { /* no-op */ }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -366,7 +366,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 object : MyCloseable(0) {}.use { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -379,7 +379,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 object : MyCloseable(0) {}
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -393,7 +393,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 foo()!!.use { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -409,7 +409,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                 bar?.foo()!!.use { /* no-op */ }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -430,7 +430,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -459,7 +459,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -478,7 +478,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -493,7 +493,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -508,7 +508,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -524,7 +524,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -548,7 +548,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closeable3.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -567,7 +567,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closable.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -591,7 +591,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closeable3?.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -607,7 +607,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     if (Random(0L).nextBoolean()) { closable.use { /* no-op */ } }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(2)
         }
 
@@ -627,7 +627,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closable.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -647,7 +647,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closable.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -661,7 +661,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     closable.use { /* no-op */ }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -679,7 +679,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     functionThatReturnsClosable().doStuff()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -700,7 +700,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -716,7 +716,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -730,7 +730,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -748,7 +748,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -770,7 +770,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -790,7 +790,7 @@ class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
                     return MyCloseable(0)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -36,7 +36,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -50,7 +50,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -64,7 +64,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -81,7 +81,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -95,7 +95,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -110,7 +110,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -124,7 +124,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -139,7 +139,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -154,7 +154,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -176,7 +176,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -192,7 +192,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -214,7 +214,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -230,7 +230,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -246,7 +246,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -260,7 +260,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -275,7 +275,7 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -292,6 +292,6 @@ class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println(a.toString())
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call 'a.toString()' may return the string \"null\".")
     }
@@ -30,7 +30,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println("${'$'}a")
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\$a' may return the string \"null\".")
     }
@@ -42,7 +42,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println("${'$'}{a}")
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\${a}' may return the string \"null\".")
     }
@@ -54,7 +54,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 println(${'"'}""${'$'}a""${'"'})
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo("This call '\$a' may return the string \"null\".")
     }
@@ -73,7 +73,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val z = baz().toString()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(3)
         assertThat(actual[0].message).isEqualTo("This call 'foo.a.toString()' may return the string \"null\".")
         assertThat(actual[1].message).isEqualTo("This call 'foo.bar().toString()' may return the string \"null\".")
@@ -94,7 +94,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val z = "${'$'}{baz()}"
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(3)
         assertThat(actual[0].message).isEqualTo("This call '\${foo.a}' may return the string \"null\".")
         assertThat(actual[1].message).isEqualTo("This call '\${foo.bar()}' may return the string \"null\".")
@@ -110,7 +110,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val y = "${'$'}{foo?.a}"
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("This call '\${foo?.a}' may return the string \"null\".")
     }
@@ -157,7 +157,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 val y = "${'$'}{bar?.a}"
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -175,7 +175,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -207,7 +207,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(4)
     }
 
@@ -223,7 +223,7 @@ class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
                 foo.bar(x.toString())
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -23,7 +23,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 println(C().list) // [0]
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(45 to 52)
         assertThat(findings.first()).hasMessage("'isValid' is used before declaration.")
@@ -44,7 +44,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 C()
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -56,7 +56,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 private val isValid = true
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -69,7 +69,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 val list = listOf(number)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -84,7 +84,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 private val isValid = true
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -110,7 +110,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 const val outer3 = "value3"
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -124,7 +124,7 @@ class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) 
                 val outer = "value"
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -24,7 +24,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f(true)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -52,7 +52,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f(true)
             }
         """.trimIndent()
-        assertThat(getSubject(ignoreSingleParamUse = true).compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(getSubject(ignoreSingleParamUse = true).lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -70,7 +70,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             getSubject(
                 ignoreSingleParamUse = true,
                 ignoreArgumentsMatchingNames = false
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -89,7 +89,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             getSubject(
                 ignoreSingleParamUse = true,
                 allowAdjacentDifferentTypeParams = false
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -105,7 +105,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            subject.compileAndLintWithContext(env, code)
+            subject.lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -120,7 +120,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f(enabled, active)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -136,7 +136,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
         assertThat(
             getSubject(allowAdjacentDifferentTypeParams = false)
-                .compileAndLintWithContext(env, code)
+                .lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -151,7 +151,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f(active, enabled)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -167,7 +167,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
         """.trimIndent()
         assertThat(
             getSubject(allowAdjacentDifferentTypeParams = false)
-                .compileAndLintWithContext(env, code)
+                .lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -183,7 +183,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(
                 env,
                 code
             )
@@ -202,7 +202,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = false).compileAndLintWithContext(
+            getSubject(allowAdjacentDifferentTypeParams = false).lintWithContext(
                 env,
                 code
             )
@@ -220,7 +220,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 f(false, true)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code))
+        assertThat(subject.lintWithContext(env, code))
             .hasTextLocations(102 to 103)
             .singleElement()
             .hasMessage("Consider using named parameters in f as they make usage of the function more safe.")
@@ -238,7 +238,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            subject.compileAndLintWithContext(env, code)
+            subject.lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -254,7 +254,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            subject.compileAndLintWithContext(env, code)
+            subject.lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -270,7 +270,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject().compileAndLintWithContext(
+            getSubject().lintWithContext(
                 env,
                 code
             )
@@ -289,7 +289,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = false).compileAndLintWithContext(
+            getSubject(allowAdjacentDifferentTypeParams = false).lintWithContext(
                 env,
                 code
             )
@@ -308,7 +308,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject().compileAndLintWithContext(
+            getSubject().lintWithContext(
                 env,
                 code
             )
@@ -327,7 +327,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            subject.compileAndLintWithContext(env, code)
+            subject.lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -344,7 +344,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -360,7 +360,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -376,7 +376,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -388,7 +388,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -409,7 +409,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             getSubject(
                 ignoreSingleParamUse = false,
                 allowAdjacentDifferentTypeParams = false
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
         ).isEmpty()
     }
 
@@ -430,7 +430,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             getSubject(
                 ignoreSingleParamUse = false,
                 allowAdjacentDifferentTypeParams = false
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -449,7 +449,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            subject.compileAndLintWithContext(env, code)
+            subject.lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -468,7 +468,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -482,7 +482,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -500,7 +500,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
         assertThat(
-            getSubject(allowAdjacentDifferentTypeParams = true).compileAndLintWithContext(env, code)
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
         ).hasSize(1)
     }
 
@@ -517,7 +517,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                     a(9, 0)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -531,7 +531,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                     a(a = 9, 0)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -549,7 +549,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 getSubject(
                     ignoreSingleParamUse = false,
                     allowAdjacentDifferentTypeParams = false
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).hasSize(1)
         }
 
@@ -564,7 +564,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                     a(9, 0, 0, 0)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -582,7 +582,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 getSubject(
                     ignoreSingleParamUse = false,
                     allowAdjacentDifferentTypeParams = false
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
             ).hasSize(1)
         }
 
@@ -597,7 +597,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                     a("", "", "")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -612,7 +612,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             assertThat(
-                getSubject(ignoreSingleParamUse = false).compileAndLintWithContext(
+                getSubject(ignoreSingleParamUse = false).lintWithContext(
                     env,
                     code
                 )
@@ -631,7 +631,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             assertThat(
-                getSubject(ignoreSingleParamUse = false).compileAndLintWithContext(
+                getSubject(ignoreSingleParamUse = false).lintWithContext(
                     env,
                     code
                 )
@@ -654,7 +654,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val findings = getSubject(
                 ignoredFunctionCalls = listOf("foo.listOfChecked")
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -667,7 +667,7 @@ class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val findings = getSubject(
                 ignoredFunctionCalls = listOf("kotlin.comparisons.maxOf(kotlin.Int, kotlin.Int, kotlin.Int)")
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x = 5
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 35)
         }
@@ -32,7 +32,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x = 5
                 val y = checkNotNull(x)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 33)
         }
@@ -47,7 +47,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 69)
         }
@@ -62,7 +62,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo(5))
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(66 to 88)
         }
@@ -74,7 +74,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(System.currentTimeMillis())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(16 to 58)
         }
@@ -88,7 +88,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -101,7 +101,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -115,7 +115,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x: Int? = 5
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -125,7 +125,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                 val x: Int? = null
                 val y = requireNotNull(x)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -139,7 +139,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -153,7 +153,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -167,7 +167,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(foo<Int?>(5))
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -178,7 +178,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(System.getLogger())
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -179,7 +178,7 @@ class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
                     requireNotNull(System.getLogger())
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val a = 1
                 val b = a!!
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
         }
@@ -32,7 +32,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val a = 1
                 val b = a!!.plus(42)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(18 to 21)
         }
@@ -43,7 +43,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val a = 1
                 val b = a!!.plus(42)!!
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings).hasTextLocations(18 to 21, 18 to 32)
         }
@@ -58,7 +58,7 @@ class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val a : Int? = 1
                 val b = a!!
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.toString()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 61)
         }
@@ -36,7 +36,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 59)
         }
@@ -49,7 +49,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)?.minus(24)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(48 to 59)
         }
@@ -66,7 +66,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -84,7 +84,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
 
@@ -98,7 +98,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
 
@@ -112,7 +112,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(103 to 114)
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -85,7 +84,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
 
@@ -99,7 +98,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).isEmpty()
         }
 
@@ -113,7 +112,7 @@ class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
                     val b = a?.plus(42)
                 }
             """.trimIndent()
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(findings).hasSize(1)
             assertThat(findings).hasTextLocations(103 to 114)
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -22,7 +22,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(4, 7)
     }
@@ -37,7 +37,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(4, 7)
     }
@@ -53,7 +53,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(2)
         assertThat(findings).hasStartSourceLocations(
             SourceLocation(4, 7),
@@ -72,7 +72,7 @@ class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -35,7 +35,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 return false
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -51,7 +51,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -64,7 +64,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -81,7 +81,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -94,7 +94,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -107,7 +107,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 throw IllegalArgumentException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -121,7 +121,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 println()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -136,7 +136,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -152,7 +152,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -167,7 +167,7 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 return 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -179,6 +179,6 @@ class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 println(str!!.length)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -28,7 +28,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
             
             val version = UUID.randomUUID()!!
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -38,7 +38,7 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 println(str?.length)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -48,6 +48,6 @@ class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
                 println(str?.length ?: 0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
                 println(s as Int)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -28,7 +28,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
                 println((s as? Int) ?: 0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -38,7 +38,7 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
                 println(s as Int)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -48,6 +48,6 @@ class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
                 println((s as? Int) ?: 0)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.bugs
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     + 3
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement()
             .hasMessage("This '+ 3' is not used")
         assertThat(findings).hasStartSourceLocation(3, 9)
@@ -33,7 +33,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     - 3
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement()
             .hasMessage("This '- 3' is not used")
         assertThat(findings).hasStartSourceLocation(3, 9)
@@ -47,7 +47,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     + 3 + 4 + 5
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement()
             .hasMessage("This '+ 3 + 4 + 5' is not used")
     }
@@ -60,7 +60,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     + 3 + 4 + 5)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -71,7 +71,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 val x = -1
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -82,7 +82,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 return -1
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -94,7 +94,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 foo(x = -1)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -105,7 +105,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
             @Ann(x = -1)
             val y = 2
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -120,7 +120,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                     - Foo(3)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -136,7 +136,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ErrorUsageWithThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ErrorUsageWithThrowableSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -23,7 +23,7 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasSourceLocation(6, 15)
     }
@@ -40,7 +40,7 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -55,7 +55,7 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -72,7 +72,7 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -89,7 +89,7 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -106,6 +106,6 @@ class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -38,7 +38,7 @@ class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
     }
 
     @Test
@@ -55,7 +55,7 @@ class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -71,6 +71,6 @@ class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.exceptions
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -20,7 +20,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             object ReportedException : Exception()
             object FatalException : Error()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+        assertThat(subject.lintWithContext(env, code)).hasSize(4)
     }
 
     @Test
@@ -32,7 +32,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
                 object Exception3 : DomainException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -42,7 +42,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             
             open class CustomException(message: String) : RuntimeException(message)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -72,7 +72,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+        assertThat(subject.lintWithContext(env, code)).hasSize(4)
     }
 
     @Test
@@ -89,7 +89,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             
             open class CustomException(message: String)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -107,7 +107,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -127,7 +127,7 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             
             open class CustomException(message: String)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -137,6 +137,6 @@ class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
             
             abstract class AbstractCustomException : RuntimeException()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should report`() {
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -43,7 +43,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should not report`() {
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -63,7 +63,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should report`() {
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -84,7 +84,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should not report`() {
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -104,14 +104,14 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `should report when ignoreLabeled is false`() {
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should not report when ignoreLabeled is true`() {
             val config = TestConfig("ignoreLabeled" to "true")
-            val findings = ReturnFromFinally(config).compileAndLintWithContext(env, code)
+            val findings = ReturnFromFinally(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -130,7 +130,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).hasSize(1)
         }
@@ -150,7 +150,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).hasSize(1)
         }
@@ -172,7 +172,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 fun compute(): String = "value"
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).hasSize(1)
         }
@@ -190,7 +190,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).isEmpty()
         }
@@ -209,7 +209,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).isEmpty()
         }
@@ -231,7 +231,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).isEmpty()
         }
@@ -251,7 +251,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).isEmpty()
         }
@@ -273,7 +273,7 @@ class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val finding = subject.compileAndLintWithContext(env, code)
+            val finding = subject.lintWithContext(env, code)
 
             assertThat(finding).hasSize(1)
         }

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +20,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report a top level function`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo() = 5
@@ -32,7 +32,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report a top level function returning Unit with default allowOmitUnit value of false`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo() = println("")
@@ -45,7 +45,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         fun `should report a top level function returning Unit when allowOmitUnit is false`() {
             val subject = LibraryCodeMustSpecifyReturnType(TestConfig(ALLOW_OMIT_UNIT to false))
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo() = println("")
@@ -57,7 +57,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report a top level property`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         val foo = 5
@@ -69,7 +69,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report a public class with public members`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class A {
@@ -84,7 +84,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report a public class with protected members`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         open class A {
@@ -104,7 +104,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a top level function`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo(): Int = 5
@@ -116,7 +116,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a non expression function`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo() {}
@@ -129,7 +129,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         fun `should not report a top level function returning Unit when allowOmitUnit is true`() {
             val subject = LibraryCodeMustSpecifyReturnType(TestConfig(ALLOW_OMIT_UNIT to true))
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun foo() = println("")
@@ -141,7 +141,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a top level property`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         val foo: Int = 5
@@ -153,7 +153,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a public class with public members`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class A {
@@ -178,7 +178,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
                     ALLOW_OMIT_UNIT to allowOmitUnit
                 )
             )
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -190,7 +190,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a private top level function`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         internal fun bar() = 5
@@ -203,7 +203,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report a internal top level property`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         internal val foo = 5
@@ -215,7 +215,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report members and local variables`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         internal class A {
@@ -233,7 +233,7 @@ class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report effectively private properties and functions`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         internal class A {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should warn about Kotlin Boolean`() {
             val code = """data class Test (var default: Boolean)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -32,7 +32,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean) : Test
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -40,7 +40,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should warn about Kotlin Boolean nullable`() {
             val code = """data class Test (var default: Boolean?)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -54,7 +54,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean?) : Test
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -62,7 +62,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should warn about Kotlin Boolean initialized`() {
             val code = """data class Test (var default: Boolean = false)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -76,7 +76,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: Boolean = false) : Test
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -84,7 +84,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should warn about Java Boolean`() {
             val code = """data class Test (var default: java.lang.Boolean)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -98,7 +98,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                 
                 data class TestImpl (override var default: java.lang.Boolean) : Test
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -114,7 +114,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override val default: java.lang.Boolean = java.lang.Boolean(true)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -122,7 +122,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect primitive types`() {
             val code = """data class Test (var count: Int)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -130,7 +130,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect names that match an allowed pattern`() {
             val code = """data class Test (var isEnabled: Boolean, var hasDefault: Boolean)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -146,7 +146,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     val emailVerified: Boolean?,
                 )
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings)
                 .hasSize(1)
@@ -163,7 +163,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var default: Boolean = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -179,7 +179,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -191,7 +191,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     const val CONSTANT_VAL_BOOLEAN = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -203,7 +203,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var default: Boolean? = null
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -219,7 +219,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean? = null
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -231,7 +231,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var default: Boolean = false
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -247,7 +247,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: Boolean = false
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -259,7 +259,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var default = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -275,7 +275,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -287,7 +287,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -303,7 +303,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     override var default: java.lang.Boolean = java.lang.Boolean(true)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -315,7 +315,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var count: Int = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -328,7 +328,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var hasDefault: Boolean = true
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -342,7 +342,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             val config = TestConfig(ALLOWED_PATTERN to "^(is|has|are|need)")
-            assertThat(BooleanPropertyNaming(config).compileAndLintWithContext(env, code))
+            assertThat(BooleanPropertyNaming(config).lintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -357,7 +357,7 @@ class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
                     var emailVerified: Boolean? = false
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings)
                 .hasSize(1)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -39,7 +39,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -51,7 +51,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -66,7 +66,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun methodNameEqualsClassName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -76,7 +76,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsObjectName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -86,7 +86,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsClassName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -96,7 +96,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     val propertyNameEqualsObjectName = 0
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -108,7 +108,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -120,7 +120,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -133,7 +133,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -143,7 +143,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     fun MethodNameEqualsInterfaceName() {}
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -156,7 +156,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract fun AbstractMethodNameEqualsClassName()
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -169,7 +169,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -182,7 +182,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     abstract val AbstractMethodNameEqualsClassName: String
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(noIgnoreOverridden).lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -199,7 +199,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -214,7 +214,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -227,7 +227,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -245,7 +245,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 
                 class C: A()
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -262,7 +262,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -279,7 +279,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
                 class C: A()
             """.trimIndent()
 
-            assertThat(MemberNameEqualsClassName(Config.empty).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(MemberNameEqualsClassName(Config.empty).lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 val i = 1
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage("Name shadowed: i")
         assertThat(findings).hasStartSourceLocation(2, 9)
     }
@@ -30,7 +30,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 val (j, _) = 1 to 2
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage("Name shadowed: j")
     }
 
@@ -42,7 +42,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage("Name shadowed: k")
     }
 
@@ -56,7 +56,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage("Name shadowed: it")
     }
 
@@ -70,7 +70,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -81,7 +81,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 val j = i
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -312,7 +311,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             // BuildConfig is missing in this test so we can't compile it
-            val findings = subject.lintWithContext(env, code)
+            val findings = subject.compileAndLintWithContext(env, code, compile = false)
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.naming
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -17,7 +17,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect Kotlin Boolean`() {
             val code = """data class O (var isDefault: Boolean)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -25,7 +25,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect Kotlin Boolean nullable`() {
             val code = """data class O (var isDefault: Boolean?)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -33,7 +33,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect Kotlin Boolean initialized`() {
             val code = """data class O (var isDefault: Boolean = false)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -41,7 +41,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect Java Boolean`() {
             val code = """data class O (var isDefault: java.lang.Boolean)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -52,7 +52,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 import java.util.concurrent.atomic.AtomicBoolean
                 data class O (var isDefault: AtomicBoolean)
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -60,7 +60,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should warn about primitive types`() {
             val code = """data class O (var isDefault: Int)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -72,7 +72,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class Inner
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -80,7 +80,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect short names`() {
             val code = """class O (var `is`: Int)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -88,7 +88,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not detect titles, starting with 'is'`() {
             val code = """class O (var isengardTowerHeightInFeet: Int)"""
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -103,7 +103,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault = false
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -119,7 +119,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -131,7 +131,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault: Boolean? = null
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -143,7 +143,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault: java.lang.Boolean = java.lang.Boolean(false)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -159,7 +159,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                      }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -171,7 +171,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault: java.lang.Boolean? = null
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -184,7 +184,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault = AtomicBoolean()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -196,7 +196,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault: Int = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -208,7 +208,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -220,7 +220,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault = listOf(1, 2, 3)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -234,7 +234,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     class Inner
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -246,7 +246,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var `is`: Int = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -258,7 +258,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isengardTowerHeightInFeet: Int = 500
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -270,7 +270,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     var isDefault: Int = 0
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
         }
@@ -282,7 +282,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     val isEnabled: () -> Boolean = { true }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -294,7 +294,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                     val isEnabled: (String) -> Boolean = { true }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }
@@ -311,7 +311,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
 
             // BuildConfig is missing in this test so we can't compile it
-            val findings = subject.compileAndLintWithContext(env, code, compile = false)
+            val findings = subject.lintWithContext(env, code, compile = false)
 
             assertThat(findings).isEmpty()
         }
@@ -324,7 +324,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
                 fun trueFun() = true
                 val isReferenceBoolean = ::trueFun
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
@@ -19,49 +19,49 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `is an array of primitive type`() {
             val code = "fun function(array: Array<Int>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is not an array`() {
             val code = "fun function(i: Int) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is a specialized array`() {
             val code = "fun function(array: ByteArray) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is a star-projected array`() {
             val code = "fun function(array: Array<*>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is not present`() {
             val code = "fun function() {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is an array of a non-primitive type`() {
             val code = "fun function(array: Array<String>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is an array of an array of a primitive type`() {
             val code = "fun function(array: Array<Array<Int>>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is a dictionary with an array of a primitive type as key`() {
             val code = "fun function(dict: java.util.Dictionary<Int, Array<Int>>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -71,13 +71,13 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @DisplayName("one is Array<Primitive> and the other is not")
         fun oneArrayPrimitive() {
             val code = "fun function(array: Array<Int>, array2: IntArray) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `both are arrays of primitive types`() {
             val code = "fun function(array: Array<Int>, array2: Array<Double>) {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
     }
 
@@ -87,31 +87,31 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @DisplayName("is Array<Primitive>")
         fun isArrayPrimitive() {
             val code = "fun returningFunction(): Array<Float> { return emptyArray() }"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
         fun `is not an array`() {
             val code = "fun returningFunction(): Int { return 1 }"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is a specialized array`() {
             val code = "fun returningFunction(): CharArray { return CharArray(0) }"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is a star-projected array`() {
             val code = "fun returningFunction(): Array<*> { return emptyArray<Any>() }"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is not explicitly set`() {
             val code = "fun returningFunction() {}"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -121,7 +121,7 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @DisplayName("is Array<Primitive>")
         fun isArrayPrimitive() {
             val code = "val foo: Array<Int>? = null"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -131,7 +131,7 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @DisplayName("is Array<Primitive>")
         fun isArrayPrimitive() {
             val code = "fun Array<Boolean>.foo() { println(this) }"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -140,61 +140,61 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `is arrayOf(Char)`() {
             val code = "fun foo(x: Char) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Byte)`() {
             val code = "fun foo(x: Byte) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Short)`() {
             val code = "fun foo(x: Short) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Int)`() {
             val code = "fun foo(x: Int) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Long)`() {
             val code = "fun foo(x: Long) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Float)`() {
             val code = "fun foo(x: Float) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Double)`() {
             val code = "fun foo(x: Double) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(Boolean)`() {
             val code = "fun foo(x: Boolean) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `is arrayOf(String)`() {
             val code = "fun foo(x: String) = arrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
         fun `is intArrayOf()`() {
             val code = "fun test(x: Int) = intArrayOf(x)"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -204,63 +204,63 @@ class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
         @DisplayName("is emptyArray<Char>()")
         fun isEmptyArrayChar() {
             val code = "val a = emptyArray<Char>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Byte>()")
         fun isEmptyArrayByte() {
             val code = "val a = emptyArray<Byte>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Short>()")
         fun isEmptyArrayShort() {
             val code = "val a = emptyArray<Short>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Int>()")
         fun isEmptyArrayInt() {
             val code = "val a = emptyArray<Int>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Long>()")
         fun isEmptyArrayLong() {
             val code = "val a = emptyArray<Long>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Float>()")
         fun isEmptyArrayFloat() {
             val code = "val a = emptyArray<Float>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Double>()")
         fun isEmptyArrayDouble() {
             val code = "val a = emptyArray<Double>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<Boolean>()")
         fun isEmptyArrayBoolean() {
             val code = "val a = emptyArray<Boolean>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         @DisplayName("is emptyArray<String>()")
         fun isEmptyArrayString() {
             val code = "val a = emptyArray<String>()"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
                 it > 5
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -36,7 +36,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
                 it*2
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -47,7 +47,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
                 it % 2 == 0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -62,7 +62,7 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
                 it > 5
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -77,6 +77,6 @@ class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
                 it > 5
             }.toList()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.performance
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun foo(vararg xs: Int) {}
             val testVal = foo(xs = *xsArray)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo(errorMessage)
     }
@@ -34,7 +34,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun foo(vararg xs: Int) {}
             val testVal = foo(*xsArray)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual.first().message).isEqualTo(errorMessage)
     }
@@ -45,7 +45,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun foo(vararg xs: Int) {}
             val testVal = foo(xs = *intArrayOf(1))
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -54,7 +54,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
             val list = asList(-1, 0, *arrayOf(1, 2, 3), 4, stringValue = "5")
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -63,7 +63,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
             fun <T> asList(vararg ts: T, stringValue: String): List<Int> = listOf(1,2,3)
             val list = asList(-1, 0, 1, 2, 3, 4, stringValue = "5")
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -77,7 +77,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 strs.forEach { println(it) }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -91,7 +91,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 println(test)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -102,7 +102,7 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 b(*bla)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -115,6 +115,6 @@ class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
                 b(*bla)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -28,7 +28,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     public abstract fun f2()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -37,28 +37,28 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
             @Test
             fun `case 1`() {
                 val code = "abstract class A"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
             @Test
             fun `case 2`() {
                 val code = "abstract class A()"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
             @Test
             fun `case 3`() {
                 val code = "abstract class A {}"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
             @Test
             fun `case 4`() {
                 val code = "abstract class A() {}"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -70,7 +70,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B : A
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -83,7 +83,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B : A()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -97,7 +97,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B: A(), I
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -112,7 +112,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B: I, A()
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -129,7 +129,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     abstract fun g()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -139,7 +139,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     internal abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -149,7 +149,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     protected abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -166,7 +166,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     fun f() {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
 
@@ -179,7 +179,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
 
@@ -192,14 +192,14 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor`() {
             val code = "abstract class A(val i: Int)"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
@@ -207,14 +207,14 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report no abstract members in an abstract class with a body and a constructor`() {
             val code = "abstract class A(val i: Int) {}"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor parameter`() {
             val code = "abstract class A(i: Int)"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
@@ -237,7 +237,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
         }
     }
@@ -257,7 +257,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -271,7 +271,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -285,7 +285,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -301,7 +301,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                     abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -312,7 +312,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
                 }
                 abstract class Test(val x: Int) : I
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -26,7 +26,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     public abstract fun f2()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertFindingMessage(findings, message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
@@ -36,7 +36,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
             @Test
             fun `case 1`() {
                 val code = "abstract class A"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingMessage(findings, message)
                 assertThat(findings).hasStartSourceLocation(1, 16)
             }
@@ -44,21 +44,21 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
             @Test
             fun `case 2`() {
                 val code = "abstract class A()"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingMessage(findings, message)
             }
 
             @Test
             fun `case 3`() {
                 val code = "abstract class A {}"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingMessage(findings, message)
             }
 
             @Test
             fun `case 4`() {
                 val code = "abstract class A() {}"
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingMessage(findings, message)
             }
 
@@ -70,7 +70,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B : A
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertFindingMessage(findings, message)
             }
 
@@ -85,7 +85,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B : A()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -101,7 +101,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B: A(), I
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -118,7 +118,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                     abstract class B: I, A()
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -135,7 +135,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     abstract fun g()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -145,7 +145,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     internal abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -155,7 +155,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     protected abstract fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -172,7 +172,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     fun f() {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -185,7 +185,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -198,28 +198,28 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor`() {
             val code = "abstract class A(val i: Int)"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with a body and a constructor`() {
             val code = "abstract class A(val i: Int) {}"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor parameter`() {
             val code = "abstract class A(i: Int)"
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -241,7 +241,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -261,7 +261,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -275,7 +275,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     fun g() {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -289,7 +289,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                     fun f()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -300,7 +300,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
                 }
                 abstract class Test(val x: Int) : I
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.intellij.lang.annotations.Language
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -35,7 +35,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -55,7 +55,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+            assertThat(subject.lintWithContext(env, code)).hasSize(3)
         }
 
         @Test
@@ -86,7 +86,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -99,7 +99,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     fileB = 6
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -123,7 +123,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     private var g: Int? = 0 // never assigned
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(8, 5),
@@ -180,7 +180,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     private var g: Int? = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -201,7 +201,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -211,7 +211,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     private var a: Int? by this::aDelegate
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -233,7 +233,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -247,7 +247,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -261,7 +261,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -274,7 +274,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -288,7 +288,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -300,7 +300,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -320,7 +320,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+            assertThat(subject.lintWithContext(env, code)).hasSize(3)
         }
 
         @Test
@@ -332,7 +332,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -340,7 +340,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 val fileA: Int? = 5
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -357,7 +357,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -377,7 +377,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -392,7 +392,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -400,7 +400,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 val fileA: Int? = null
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -410,7 +410,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     val a: Int = 5
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -418,7 +418,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class A(private val a: Int?)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -439,7 +439,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(3)
+            assertThat(subject.lintWithContext(env, code)).hasSize(3)
         }
 
         @Test
@@ -463,7 +463,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -475,7 +475,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -486,7 +486,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -497,7 +497,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -514,7 +514,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -526,7 +526,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -538,7 +538,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -550,7 +550,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 open var b: Int? = 5
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -561,7 +561,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 abstract var b: Int?
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -575,7 +575,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 private var a: String? = e.localizedMessage
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -586,7 +586,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                 var b: Int?
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Nested
@@ -600,7 +600,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         val b = a!! + 2
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -612,7 +612,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                     
                     fun fizz(b: Int?) = b!!.plus(2)
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+                assertThat(subject.lintWithContext(env, code)).hasSize(2)
             }
 
             @Test
@@ -623,7 +623,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         val c = aNonNull + checkNotNull(b)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+                assertThat(subject.lintWithContext(env, code)).hasSize(2)
             }
 
             @Test
@@ -635,7 +635,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         val b = a.a!! + 2
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -651,7 +651,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -668,7 +668,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         
                         fun foo(a: A?) = a?.foo
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -680,7 +680,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         fun foo2(bar: RandomBar?) = bar?.nonNullId?.nullable()
                         fun foo3(bar: RandomBar?) = bar?.nonNullId.nonNullable()
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
             }
 
@@ -695,7 +695,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             a?.let { println(it.foo) }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -713,7 +713,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -728,7 +728,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             val b = 5 + 2
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
             }
 
@@ -745,7 +745,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             return aObj?.foo
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
             }
         }
@@ -763,7 +763,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -775,7 +775,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -787,7 +787,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -799,7 +799,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -811,7 +811,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -823,7 +823,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -835,7 +835,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -847,7 +847,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -860,7 +860,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -874,7 +874,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -899,7 +899,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -916,7 +916,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -933,7 +933,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -951,7 +951,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -963,7 +963,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -975,7 +975,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -988,7 +988,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
             }
 
@@ -1115,7 +1115,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                           }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1127,7 +1127,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1141,7 +1141,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1155,7 +1155,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1168,7 +1168,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -1181,7 +1181,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1194,7 +1194,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -1207,7 +1207,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -1222,7 +1222,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1236,7 +1236,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -1251,7 +1251,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1269,7 +1269,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -1281,7 +1281,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -1294,7 +1294,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                             }
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
             }
         }
@@ -1316,7 +1316,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1330,7 +1330,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1348,7 +1348,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+                assertThat(subject.lintWithContext(env, code)).hasSize(2)
             }
 
             @Test
@@ -1360,7 +1360,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -1371,7 +1371,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         println(a)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -1382,7 +1382,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         println(a)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -1394,7 +1394,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         println(a)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1406,7 +1406,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         return a
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1420,7 +1420,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -1433,7 +1433,7 @@ class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
                         val b = 5 + 2
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpressionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpressionSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -18,7 +18,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return b.not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -29,7 +29,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return b.not().not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return b.not().not().not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -51,7 +51,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return !b
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -62,7 +62,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return !!b
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -73,7 +73,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return !!!b
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -84,7 +84,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return !b.not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -95,7 +95,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 return !!b.not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -107,7 +107,7 @@ class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
                 val y = not().not()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(2)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
@@ -322,7 +321,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         buffer.get(byteArrayOf(0x42))
                     }
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
             }
 
             @Test
@@ -557,7 +556,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                        val value = unknownType.put("answer", 42)
                     }
                 """.trimIndent()
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
             }
 
             @Test
@@ -587,7 +586,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     rect.set(0, 1, 2)
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
@@ -26,7 +26,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map.get("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -37,7 +37,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map?.get("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -48,7 +48,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.set("key", "value")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -59,7 +59,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.put("key", "val")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -70,7 +70,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val oldValue = map.put("key", "val")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -86,7 +86,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.put("a", "b", 1)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -97,7 +97,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         return map.put("key", "val") == null
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -108,7 +108,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map.get("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -119,7 +119,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.put("key", "value")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -131,7 +131,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map["key"]
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -143,7 +143,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map["key"] = "value"
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -154,7 +154,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = listOf("1", "2").associateBy { it }.get("1")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -165,7 +165,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map.get("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -176,7 +176,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         with(map) { get("a") }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -190,7 +190,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -201,7 +201,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -213,7 +213,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list[0]
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -224,7 +224,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -235,7 +235,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = with(list) { get(0) }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -250,7 +250,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map.get("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -261,7 +261,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.set("key", "val")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -272,7 +272,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map.put("key", "val")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -284,7 +284,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = map["key"]
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -296,7 +296,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         map["key"] = "value"
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -307,7 +307,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = listOf("1", "2").associateBy { it }.get("1")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
         }
 
@@ -321,7 +321,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         buffer.get(byteArrayOf(0x42))
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+                assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
             }
 
             @Test
@@ -331,7 +331,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = field.get(null) // access static field
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -347,7 +347,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = custom.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -359,7 +359,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = custom.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -371,7 +371,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         custom.set("key", "value")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -383,7 +383,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         custom.set("key", "value")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -396,7 +396,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         c.get<Int>("key")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Nested
@@ -412,7 +412,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get("key", *objects)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -426,7 +426,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get("key", 1, *objects)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -440,7 +440,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get(*objects)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -454,7 +454,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get("key", *objects, 1)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                    assertThat(subject.lintWithContext(env, code)).isEmpty()
                 }
 
                 @Test
@@ -467,7 +467,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get("key")
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -480,7 +480,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get("key", 1)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
 
                 @Test
@@ -493,7 +493,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                             c.get(0)
                         }
                     """.trimIndent()
-                    assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                    assertThat(subject.lintWithContext(env, code)).hasSize(1)
                 }
             }
         }
@@ -509,7 +509,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list.get(0)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
             }
 
             @Test
@@ -521,7 +521,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val value = list[0]
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -536,7 +536,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         val c: Char? get() = "".first() ?: throw IllegalArgumentException("getter")
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -545,7 +545,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     val string = ""
                         .toString()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -556,7 +556,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                        val value = unknownType.put("answer", 42)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+                assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
             }
 
             @Test
@@ -567,7 +567,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                         put()
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
     }
@@ -586,7 +586,7 @@ class ExplicitCollectionElementAccessMethodSpec {
                     rect.set(0, 1, 2)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -20,7 +20,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @SuppressWarnings("unused")
             fun main() {}
         """.trimIndent()
-        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).lintWithContext(env, code)
 
         assertThat(findings)
             .hasSize(1)
@@ -53,7 +53,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @Inherited
             annotation class SomeClass(val value: Array<SomeClass>)
         """.trimIndent()
-        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).lintWithContext(env, code)
         assertThat(findings).hasSize(6)
             .hasTextLocations(
                 "@Deprecated",
@@ -73,7 +73,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("kotlin.jvm.Transient"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -85,7 +85,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@java.lang.SuppressWarnings")
     }
@@ -108,7 +108,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
                     "kotlin.jvm.Volatile",
                 )
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(3)
             .hasTextLocations("@SuppressWarnings", "@Transient", "@Volatile")
     }
@@ -121,7 +121,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -136,7 +136,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -151,7 +151,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -163,7 +163,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -179,7 +179,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -195,7 +195,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("java.lang.SuppressWarnings"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@SuppressWarnings")
     }
@@ -209,7 +209,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("kotlin.ReplaceWith"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("ReplaceWith")
     }
@@ -221,7 +221,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
             @Dep
             fun f() = Unit
         """.trimIndent()
-        val findings = ForbiddenAnnotation(Config.empty).compileAndLintWithContext(env, code)
+        val findings = ForbiddenAnnotation(Config.empty).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Dep")
     }
@@ -233,7 +233,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("kotlin.Suppress"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Suppress")
     }
@@ -247,7 +247,7 @@ class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenAnnotation(
             TestConfig(ANNOTATIONS to listOf("kotlin.Suppress"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
             .hasTextLocations("@Suppress")
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -22,7 +22,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 println("4")
             }
         """.trimIndent()
-        val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+        val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
 
         assertThat(findings)
             .hasSize(2)
@@ -47,7 +47,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("  "))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -61,7 +61,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.lang.System.gc"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -74,7 +74,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.io.PrintStream.println"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(38 to 54)
     }
@@ -89,7 +89,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.io.PrintStream.println"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasTextLocations(49 to 65)
     }
@@ -110,7 +110,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                     "java.lang.System.gc",
                 )
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
         assertThat(findings).hasTextLocations(48 to 64, 76 to 80)
     }
@@ -124,7 +124,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.math.BigDecimal.equals"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -138,7 +138,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("kotlin.Int.inc"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -152,7 +152,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("kotlin.Int.dec"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -169,7 +169,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.now"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
 
@@ -186,7 +186,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.now()"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasStartSourceLocation(5, 26)
         assertThat(findings).singleElement()
             .hasMessage("The method `java.time.LocalDate.now()` has been forbidden in the detekt config.")
@@ -205,7 +205,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(6, 27)
     }
@@ -220,7 +220,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 26)
     }
@@ -235,7 +235,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(3, 26)
     }
@@ -253,7 +253,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(6, 13)
     }
@@ -274,7 +274,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 METHODS to
                     listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).hasStartSourceLocation(6, 13)
     }
@@ -292,7 +292,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.arrayMethod(kotlin.Array)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
 
@@ -309,7 +309,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.listMethod(kotlin.collections.List)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
 
@@ -326,7 +326,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.varargMethod(kotlin.Array)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
 
@@ -347,7 +347,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(10, 15)
     }
 
@@ -369,7 +369,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(11, 15)
     }
 
@@ -393,7 +393,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("org.example.com.I.f"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
 
@@ -408,7 +408,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -429,7 +429,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -457,7 +457,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
 
@@ -485,7 +485,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Comparator.reversed"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -502,7 +502,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -519,7 +519,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("org.example.bar(kotlin.String)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -539,7 +539,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `raise the issue`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("org.example.bar(T, U, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -547,7 +547,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `It doesn't raise any issue because the generics don't match`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("org.example.bar(U, T, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -568,7 +568,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `raise the issue`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("org.example.bar(R, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -576,7 +576,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `It doesn't raise any issue because the type doesn't match`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("org.example.bar(kotlin.Int, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -598,7 +598,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `forbid the one without receiver`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("kotlin.runCatching(() -> R)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(5, 16)
@@ -608,7 +608,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         fun `forbid the one with receiver`() {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("kotlin.runCatching(T, (T) -> R)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings)
                 .hasSize(1)
                 .hasStartSourceLocation(6, 9)
@@ -630,7 +630,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -646,7 +646,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
             """.trimIndent()
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -663,7 +663,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -679,7 +679,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.util.Calendar.compareTo"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -696,7 +696,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenMethodCall(
                     TestConfig(METHODS to listOf("java.util.Date.<init>"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -709,7 +709,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenMethodCall(
                     TestConfig(METHODS to listOf("java.util.Date.<init>"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -725,7 +725,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenMethodCall(
                     TestConfig(METHODS to listOf("java.util.Date.<init>()"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -738,7 +738,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenMethodCall(
                     TestConfig(METHODS to listOf("java.util.Date.<init>(kotlin.Int, kotlin.Int, kotlin.Int)"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -749,7 +749,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
 
                     val x = BigDecimal(3.14)
                 """.trimIndent()
-                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -760,7 +760,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
 
                     val x = BigDecimal("3.14")
                 """.trimIndent()
-                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
                 assertThat(findings.first()).hasMessage(
                     "The method `java.math.BigDecimal.<init>(kotlin.String)` has " +
@@ -774,7 +774,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
                 val code = """
                     val x = "3.14".toBigDecimalOrNull()
                 """.trimIndent()
-                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -785,7 +785,7 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
 
                     val x = BigDecimal(3)
                 """.trimIndent()
-                val findings = ForbiddenMethodCall(TestConfig()).compileAndLintWithContext(env, code)
+                val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("  "))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -36,7 +36,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.io.println(kotlin.Double)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -51,7 +51,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.io.println"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(3)
         assertThat(findings).hasTextLocations(17 to 38, 43 to 63, 68 to 90)
     }
@@ -74,7 +74,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                     )
                 )
             )
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(3)
         assertThat(findings).hasTextLocations(17 to 38, 43 to 63, 68 to 90)
         assertThat(findings[0]).hasMessage(
@@ -94,7 +94,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.io.println"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -108,7 +108,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.io.println"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -122,7 +122,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.math.atan2(kotlin.Double, kotlin.Double)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -136,7 +136,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.math.atan2(kotlin.Double, kotlin.Double)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0]).hasSourceLocation(3, 16)
     }
@@ -152,7 +152,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("kotlin.math.atan2(kotlin.Double, kotlin.Double)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
 
@@ -169,7 +169,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "com.example.arrayMethod(kotlin.Array)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
 
@@ -186,7 +186,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val methodName = "com.example.varargMethod(kotlin.Array)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
     }
 
@@ -209,7 +209,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         val methodName =
             "com.example.TestClass.Companion.staticMethod(kotlin.Int)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
-            .compileAndLintWithContext(env, code)
+            .lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(11, 15)
     }
 
@@ -233,7 +233,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("org.example.com.I.f"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(2)
     }
 
@@ -250,7 +250,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -267,7 +267,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("org.example.bar((kotlin.String) -> kotlin.String)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -284,7 +284,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         """.trimIndent()
         val findings = ForbiddenNamedParam(
             TestConfig(METHODS to listOf("org.example.bar(kotlin.String, kotlin.Int)"))
-        ).compileAndLintWithContext(env, code)
+        ).lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -304,7 +304,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         fun `raise the issue`() {
             val findings = ForbiddenNamedParam(
                 TestConfig(METHODS to listOf("org.example.bar(T, U, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -312,7 +312,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         fun `doesn't raise any issue because the generics don't match`() {
             val findings = ForbiddenNamedParam(
                 TestConfig(METHODS to listOf("org.example.bar(U, T, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -333,7 +333,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         fun `raise the issue`() {
             val findings = ForbiddenNamedParam(
                 TestConfig(METHODS to listOf("org.example.bar(R, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -341,7 +341,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
         fun `doesn't raise any issue because the type doesn't match`() {
             val findings = ForbiddenNamedParam(
                 TestConfig(METHODS to listOf("org.example.bar(kotlin.Int, kotlin.String)"))
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -368,7 +368,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -381,7 +381,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(2)
             }
         }
@@ -396,7 +396,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>()"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -408,7 +408,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>(kotlin.Int, kotlin.Int)"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -420,7 +420,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>(kotlin.Int, kotlin.Int)"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -432,7 +432,7 @@ class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
                 """.trimIndent()
                 val findings = ForbiddenNamedParam(
                     TestConfig(METHODS to listOf("org.example.A.<init>(kotlin.Int, kotlin.Int)"))
-                ).compileAndLintWithContext(env, code)
+                ).lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -27,7 +27,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+        assertThat(subject.lintWithContext(env, code)).hasSize(4)
     }
 
     @Test
@@ -37,7 +37,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
             val klass = Void::class
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -56,7 +56,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Nested
@@ -79,7 +79,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -100,7 +100,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -118,7 +118,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -130,7 +130,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).hasSize(2)
         }
     }
@@ -158,7 +158,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 class D : A<Void>
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -170,7 +170,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 class C : A<B<Void>>
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -180,7 +180,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 val foo = mutableMapOf<Int, Void>()
             """.trimIndent()
 
-            val findings = ForbiddenVoid(config).compileAndLintWithContext(env, code)
+            val findings = ForbiddenVoid(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -195,7 +195,7 @@ class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+            assertThat(subject.lintWithContext(env, code)).hasSize(4)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -16,35 +16,35 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report 2 calls on a single line with a max of 3`() {
         val code = "val a = 0.plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not report 3 calls on a single line with a max of 3`() {
         val code = "val a = 0.plus(0).plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports 4 calls on a single line with a max of 3`() {
         val code = "val a = 0.plus(0).plus(0).plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
     fun `reports 4 calls on a single line with a max of 3 but with inlined lambda`() {
         val code = "val a = 0.plus(0).let { it }.plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
     fun `reports 4 safe qualified calls on a single line with a max of 3`() {
         val code = "val a = 0?.plus(0)?.plus(0)?.plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -52,7 +52,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = "val a = 0?.plus(0)"
 
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
@@ -61,7 +61,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
     fun `reports 4 non-null asserted calls on a single line with a max of 3`() {
         val code = "val a = 0!!.plus(0)!!.plus(0)!!.plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -69,7 +69,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = "val a = 0!!.plus(0)"
 
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
 
@@ -77,7 +77,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
     fun `reports once for 7 calls on a single line with a max of 3`() {
         val code = "val a = 0.plus(0).plus(0).plus(0).plus(0).plus(0).plus(0)"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -85,7 +85,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = "val a = 0.plus(0)"
 
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
     }
 
@@ -99,7 +99,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """.trimIndent()
 
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -110,7 +110,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0).plus(0).plus(0)
         """.trimIndent()
 
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -121,7 +121,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """.trimIndent()
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -133,21 +133,21 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .plus(0)
         """.trimIndent()
 
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(rule.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
     fun `does not report long imports`() {
         val code = "import a.b.c.d.e"
 
-        assertThat(rule.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+        assertThat(rule.lintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test
     fun `does not report long package declarations`() {
         val code = "package a.b.c.d.e"
 
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -166,7 +166,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             }
             val x = Nav.List.Params.Groups.Source.Profiles
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -174,7 +174,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = """
             val x = kotlin.math.floor(1.0).plus(1).plus(1)
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -182,7 +182,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = """
             val x = kotlin.math.floor(1.0).plus(1).plus(1).plus(1)
         """.trimIndent()
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
@@ -191,7 +191,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
         val code = """
             val x = kotlin.run { 1 }.plus(1).plus(1)
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -200,7 +200,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
             @Suppress("RemoveRedundantQualifierName")
             val x = kotlin.run { 1 }.plus(1).plus(1).plus(1)
         """.trimIndent()
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
@@ -211,7 +211,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
 
             val x = 1.0.ulp.ulp
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -221,7 +221,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
 
             val x = 1.0.ulp.ulp.ulp
         """.trimIndent()
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
@@ -236,7 +236,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .ulp
         """.trimIndent()
         val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -249,7 +249,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .ulp.ulp.ulp
                 .plus(0)
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -262,7 +262,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 .ulp.ulp.ulp.ulp
                 .plus(0)
         """.trimIndent()
-        val findings = rule.compileAndLintWithContext(env, code)
+        val findings = rule.lintWithContext(env, code)
         assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
     }
 
@@ -283,7 +283,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -300,7 +300,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 2))
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -311,7 +311,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                 )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage(getTestMessage(2, 1))
         }
 
@@ -330,7 +330,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -348,7 +348,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -366,7 +366,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     )
             """.trimIndent()
             val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 1))
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -379,7 +379,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                         0
                     }.plus(0).plus(0).plus(0)
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -395,7 +395,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                         1
                     )
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -412,7 +412,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                         0
                     )
             """.trimIndent()
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
@@ -430,7 +430,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                         0
                     )
             """.trimIndent()
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
@@ -447,7 +447,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     1
                 ).plus(1).plus(1).plus(1)
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -466,7 +466,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     1
                 )
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -479,7 +479,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     1
                 ).ulp.ulp.ulp
             """.trimIndent()
-            assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(rule.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -492,7 +492,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                     1
                 ).ulp.ulp.ulp.ulp
             """.trimIndent()
-            val findings = rule.compileAndLintWithContext(env, code)
+            val findings = rule.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
         }
 
@@ -512,7 +512,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                             0
                         )
                 """.trimIndent()
-                val findings = rule.compileAndLintWithContext(env, code)
+                val findings = rule.lintWithContext(env, code)
                 assertThat(findings).singleElement().hasMessage(getTestMessage(4, 3))
             }
 
@@ -530,7 +530,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                             0
                         )
                 """.trimIndent()
-                val findings = rule.compileAndLintWithContext(env, code)
+                val findings = rule.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -556,7 +556,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
                             0
                         )
                 """.trimIndent()
-                val findings = rule.compileAndLintWithContext(env, code)
+                val findings = rule.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -141,7 +140,7 @@ class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
     fun `does not report long imports`() {
         val code = "import a.b.c.d.e"
 
-        assertThat(rule.lintWithContext(env, code)).isEmpty()
+        assertThat(rule.compileAndLintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -24,7 +24,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -38,7 +38,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -52,7 +52,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -69,7 +69,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -85,7 +85,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -98,7 +98,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -111,7 +111,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -126,7 +126,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -144,7 +144,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -160,7 +160,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -174,7 +174,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     val digits = 1234.let { listOf(it) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -185,7 +185,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     val digits = 1234.let { listOf(it) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -196,7 +196,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     val digits = 1234.let { it -> listOf(it) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -207,7 +207,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     val digits = 1234.let { param -> listOf(param) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -220,7 +220,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -237,7 +237,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -251,7 +251,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -268,7 +268,7 @@ class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -31,7 +31,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).first().extracting { it.message }.isEqualTo(
             "The nullable boolean check `nullableBoolean() ?: $bool` should use " +
@@ -52,7 +52,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings).first().extracting { it.message }.isEqualTo(
             "The nullable boolean check `nullableBoolean() ?: $bool` should use " +
@@ -72,7 +72,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @ParameterizedTest
@@ -88,7 +88,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -103,7 +103,7 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -116,6 +116,6 @@ class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(4, 9))
             }
@@ -47,7 +47,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(5, 5))
             }
@@ -67,7 +67,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(6, 9))
             }
@@ -84,7 +84,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(4, 9))
             }
@@ -101,7 +101,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(5, 9))
             }
@@ -121,7 +121,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(7, 5))
             }
@@ -136,7 +136,7 @@ class ObjectLiteralToLambdaSpec {
                         override fun foo() = 3
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(4, 9))
             }
@@ -150,7 +150,7 @@ class ObjectLiteralToLambdaSpec {
                     interface Sam
                     val a = object : Sam {}
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -162,7 +162,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -175,7 +175,7 @@ class ObjectLiteralToLambdaSpec {
                         override val foo = 1
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -186,7 +186,7 @@ class ObjectLiteralToLambdaSpec {
                         val b = 1
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -200,7 +200,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -214,7 +214,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -230,7 +230,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -248,7 +248,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -267,7 +267,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -282,7 +282,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -298,7 +298,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -312,7 +312,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(1, 9))
             }
@@ -327,7 +327,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(2, 9))
             }
@@ -341,7 +341,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -358,7 +358,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -379,7 +379,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -399,7 +399,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -417,7 +417,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -439,7 +439,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(6, 5))
             }
@@ -461,7 +461,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(7, 9))
             }
@@ -481,7 +481,7 @@ class ObjectLiteralToLambdaSpec {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -505,7 +505,7 @@ class ObjectLiteralToLambdaSpec {
                     val a = newObject() === newObject() // false
                     val b = lambda() === lambda() // true
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(SourceLocation(5, 19))
             }
@@ -530,7 +530,7 @@ class ObjectLiteralToLambdaSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code, compile = false)).hasSize(1)
         }
 
         @Test
@@ -543,7 +543,7 @@ class ObjectLiteralToLambdaSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -559,7 +559,7 @@ class ObjectLiteralToLambdaSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -531,7 +530,7 @@ class ObjectLiteralToLambdaSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).hasSize(1)
         }
 
         @Test
@@ -544,7 +543,7 @@ class ObjectLiteralToLambdaSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -560,7 +559,7 @@ class ObjectLiteralToLambdaSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Boolean = true
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -28,7 +28,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Int = 3
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -38,7 +38,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Long = 3L
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -48,7 +48,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Float = 3.0f
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -58,7 +58,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Double = 3.0
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -68,7 +68,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val x: Char = 'f'
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -80,7 +80,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val y: String = "$substitute"
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -92,7 +92,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val o: Test = Test
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -108,7 +108,7 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val t: TallPerson = TallPerson("first", 3)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -124,6 +124,6 @@ class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
                 val t: Person = TallPerson("first", 3)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         .map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'map' call can be removed.")
             assertThat(findings).hasStartSourceLocation(4, 10)
         }
@@ -42,7 +42,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         .filter { it > 1 }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("This 'map' call can be replaced with 'onEach' or 'forEach'.")
             assertThat(findings).hasStartSourceLocation(5, 10)
@@ -55,7 +55,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     listOf(1, 2, 3).map { foo -> foo }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -66,7 +66,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     listOf(1).map({ it })
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -81,7 +81,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -98,7 +98,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -114,7 +114,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -125,7 +125,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -136,7 +136,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     this.map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -147,7 +147,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     mutableListOf(1).map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -158,7 +158,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     val x:Sequence<Int> = sequenceOf(1).map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -169,7 +169,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     setOf(1).map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'map' call can be replaced with 'toList'.")
         }
     }
@@ -185,7 +185,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                         .map { it + 1 }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -199,7 +199,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -210,7 +210,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     listOf(1 to 2).map { (a, b) -> a }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -221,7 +221,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
                     val x: List<Map.Entry<Int, String>> = mapOf(1 to "a").map { it }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -19,7 +19,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual)
             .hasSize(1)
             .allMatch {
@@ -34,7 +34,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.contains(value)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -48,7 +48,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -59,7 +59,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it == value * value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -70,7 +70,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it * it == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -81,7 +81,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it.also { println(it) } == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -93,7 +93,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it * value == it }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { return@any it == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -115,7 +115,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it.equals(value) }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -126,7 +126,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value.equals(it) }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -140,7 +140,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 fun equals(value: Custom) = false
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -151,7 +151,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value?.equals(it) == true }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -162,7 +162,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value.equals(2 * it) }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -174,7 +174,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { 2 == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(2)
             .allMatch { it.message == "`any {  }` expression can be omitted" }
     }
@@ -189,7 +189,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
             .allMatch { it.message == "`any {  }` expression can be omitted" }
     }
@@ -207,7 +207,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -224,7 +224,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual)
             .hasSize(2)
             .allMatch { it.message == "`any {  }` expression can be omitted" }
@@ -237,7 +237,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value.also { println(it) } == 2 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -250,7 +250,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value.also { println(it) } }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(3)
     }
 
@@ -261,7 +261,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it == values.any { it == value } }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(2)
     }
 
@@ -272,7 +272,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
             list.any { outerIt -> outerIt == values.any { it == value } }
         }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(2)
     }
 
@@ -283,7 +283,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it.equals(2 * value) }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -294,7 +294,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { value == it }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -308,7 +308,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -319,7 +319,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any { it: Int -> it == value }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -330,7 +330,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any(predicate = { it == value })
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -341,7 +341,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any({ it == value })
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -354,7 +354,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 })
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -365,7 +365,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any(fun(it: Int) = it == value)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -376,7 +376,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any(fun(value: Int) = false)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
             .allMatch { it.message == "`any {  }` expression can be omitted" }
     }
@@ -388,7 +388,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 list.any()
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -402,7 +402,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -415,7 +415,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -428,7 +428,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -441,7 +441,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -454,7 +454,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -467,7 +467,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -480,7 +480,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -494,7 +494,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
 
@@ -506,7 +506,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
 
@@ -520,7 +520,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
 
@@ -532,7 +532,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
 
@@ -543,7 +543,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
 
@@ -554,7 +554,7 @@ class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
                     list.any(predicate)
                 }
             """.trimIndent()
-            val actual = subject.compileAndLintWithContext(env, code)
+            val actual = subject.lintWithContext(env, code)
             assertThat(actual).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -18,7 +18,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports an apply on non-nullable type`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     fun f() {
@@ -35,7 +35,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports an apply on nullable type`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     fun f() {
@@ -55,7 +55,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `reports a false negative apply on nullable type - #1485`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         val a: Any? = Any()
@@ -74,7 +74,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report an apply with lambda block`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun f() {
@@ -91,7 +91,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report single statement in apply used as function argument`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun b(i: Int?) {}
@@ -110,7 +110,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report single assignment statement in apply used as function argument - #1517`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -137,7 +137,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report if result of apply is used - #2938`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun main() {
@@ -152,7 +152,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report applies with lambda body containing more than one statement`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun b(i: Int?) {}
@@ -179,7 +179,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports when lambda has a dot qualified expression`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     fun test(foo: Foo) {
@@ -200,7 +200,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports when lambda has a dot qualified expression which has 'this' receiver`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     fun test(foo: Foo) {
@@ -221,7 +221,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports when lambda has a 'this' expression`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     fun test() {
@@ -240,7 +240,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `reports apply with a single assignment whose result is unused`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -261,7 +261,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `does not report apply with a single assignment whose result is used`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -285,7 +285,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `is used within an assignment expr itself`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -301,7 +301,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `is used as return type of extension function`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C(var prop: Int)
@@ -315,7 +315,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not flag apply when assigning property on this`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C(var prop: Int) {
@@ -331,7 +331,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report apply when using it after returning something`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C(var prop: Int)
@@ -345,7 +345,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report apply usage inside safe chained expressions`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun f() {
@@ -366,7 +366,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report the if expression`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -388,7 +388,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should report reference expressions`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -416,7 +416,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `do not report when it's used as an assignment`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -438,7 +438,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `do not report when it's used as the last statement of a block inside lambda`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         class C {
@@ -467,7 +467,7 @@ class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `do not report when lambda has multiple member references`() {
             assertThat(
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     """
                         fun test(foo: Foo) {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -23,7 +23,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .size
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("'filter { it > 1 }' can be replaced by 'count { it > 1 }'")
         }
 
@@ -35,7 +35,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val z = "abc".filter { it > 'a' }.count()
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -48,7 +48,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
         }
 
@@ -62,7 +62,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("'filter { it > 2 }' can be replaced by 'count { it > 2 }'")
         }
 
@@ -73,7 +73,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = "abc".filter { it > 'a' }.isEmpty()
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings[0]).hasMessage("'filter { it > 2 }' can be replaced by 'none { it > 2 }'")
             assertThat(findings[1]).hasMessage("'filter { it > 'a' }' can be replaced by 'none { it > 'a' }'")
@@ -86,7 +86,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = "abc".filter { it > 'a' }.isNotEmpty()
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(2)
             assertThat(findings[0]).hasMessage("'filter { it > 2 }' can be replaced by 'any { it > 2 }'")
             assertThat(findings[1]).hasMessage("'filter { it > 'a' }' can be replaced by 'any { it > 'a' }'")
@@ -99,7 +99,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.any()
                 val z = "abc".filter { it > 'a' }.any()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -110,7 +110,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.none()
                 val z = "abc".filter { it > 'a' }.none()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -121,7 +121,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.first()
                 val z = "abc".filter { it > 'a' }.first()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -132,7 +132,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.firstOrNull()
                 val z = "abc".filter { it > 'a' }.firstOrNull()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -143,7 +143,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.last()
                 val z = "abc".filter { it > 'a' }.last()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -154,7 +154,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.lastOrNull()
                 val z = "abc".filter { it > 'a' }.lastOrNull()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -165,7 +165,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.single()
                 val z = "abc".filter { it > 'a' }.single()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
 
@@ -176,7 +176,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = sequenceOf(1, 2, 3).filter { it > 2 }.singleOrNull()
                 val z = "abc".filter { it > 'a' }.singleOrNull()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(3)
         }
     }
@@ -194,7 +194,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = listOf<Int>().filter { it > 0 }.count()
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -209,7 +209,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = listOf<Int>().asSequence().filter { it > 0 }.count()
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -223,7 +223,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val x = filter().size
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -234,7 +234,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .count { it > 2 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -250,7 +250,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 fun foo(list: List<Int>) {}
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -261,7 +261,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .none { it > 2 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -272,7 +272,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .any { it > 2 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -285,7 +285,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     .count { it > 1 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -302,7 +302,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -318,7 +318,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                     c.isNotEmpty()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -329,7 +329,7 @@ class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
                 val y = listOf(1, 2, 3).filter { it > 1 }.singleOrNull { it > 2 }
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -35,7 +35,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Nested
@@ -50,7 +50,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -65,7 +65,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Nested
@@ -85,7 +85,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -103,7 +103,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -121,7 +121,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -142,7 +142,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -161,7 +161,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -180,7 +180,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -200,7 +200,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+                assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
             }
         }
 
@@ -218,7 +218,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -237,7 +237,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -254,7 +254,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -271,7 +271,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -288,7 +288,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -311,7 +311,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -328,7 +328,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -352,7 +352,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -371,7 +371,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -388,7 +388,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -414,7 +414,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -429,7 +429,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -444,7 +444,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -459,6 +459,6 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -201,7 +200,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code)).isEmpty()
+                assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
             }
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -14,7 +14,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 1`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -30,7 +30,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 2`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -46,7 +46,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 3`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -62,7 +62,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 4`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -77,7 +77,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 5`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -93,7 +93,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 6`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -109,7 +109,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be replaced with an if`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -125,7 +125,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports unnecessary lets that can be changed to ordinary method call 7`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -141,7 +141,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports use of let without the safe call operator when we use an argument`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -157,7 +157,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report lets used for function calls 1`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -172,7 +172,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report lets used for function calls 2`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -186,7 +186,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report 'can be replaced by if' because you will need an else too`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -201,7 +201,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report a let where returned value is used - #2987`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -215,7 +215,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report use of let with the safe call operator when we use an argument`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -230,7 +230,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report lets with lambda body containing more than one statement`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -271,7 +271,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report lets with lambda body containing more than one statement with one ref count`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -288,7 +288,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report lets where it is used multiple times`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f() {
@@ -315,7 +315,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo.let { (a, b) -> a + b }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
 
@@ -328,7 +328,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo.let { (a, _) -> a + a }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
 
@@ -341,7 +341,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo.let { (a: Int, b: Int) -> a + b }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).isEmpty()
         }
 
@@ -354,7 +354,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo.let { (a, _) -> a }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
@@ -368,7 +368,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo?.let { (_, b) -> b.plus(1) }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
@@ -382,7 +382,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo.let { (_, _) -> 0 }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_OMIT_LET }
         }
@@ -396,7 +396,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                     foo?.let { (_, _) -> 0 }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, content)
+            val findings = subject.lintWithContext(env, content)
             assertThat(findings).hasSize(1)
             assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
         }
@@ -411,7 +411,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, content)
+        val findings = subject.lintWithContext(env, content)
         assertThat(findings).hasSize(1)
         assertThat(findings).allMatch { it.message == MESSAGE_USE_IF }
     }
@@ -431,13 +431,13 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, content)
+        val findings = subject.lintWithContext(env, content)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `does not report lets with invoke operator calls`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun f(callback: ((Int) -> Int)?) {
@@ -452,7 +452,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `does not report when let call in call chains`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun test(list: List<Any?>) {
@@ -476,7 +476,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
     @Test
     fun `reports when let call in call chains`() {
-        val findings = subject.compileAndLintWithContext(
+        val findings = subject.lintWithContext(
             env,
             """
                 fun test(list: List<String?>) {
@@ -495,7 +495,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
     inner class `nested lets` {
         @Test
         fun `does not report nested nullable properties used with safe operator - #6373`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)
@@ -512,7 +512,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports nested nullable properties - #6373`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)
@@ -531,7 +531,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `does not report nested nullable properties when multiple expression are present`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)
@@ -552,7 +552,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports nested nullable properties when first let add more chain`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)
@@ -571,7 +571,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `does not reports nested nullable properties when first let calls a fun`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)
@@ -592,7 +592,7 @@ class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports double nested nullable properties`() {
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 """
                     class Dialog(val window: Int?)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -24,7 +24,7 @@ class UnnecessaryReversedSpec(
                 }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty
@@ -44,7 +44,7 @@ class UnnecessaryReversedSpec(
             }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isEmpty()
@@ -61,7 +61,7 @@ class UnnecessaryReversedSpec(
             }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isEmpty()
@@ -78,7 +78,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty
@@ -98,7 +98,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty
@@ -118,7 +118,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty
@@ -138,7 +138,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty
@@ -159,7 +159,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty()
@@ -179,7 +179,7 @@ class UnnecessaryReversedSpec(
              }
             """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
 
         assertThat(findings)
             .isNotEmpty()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -37,7 +36,7 @@ class UnusedImportSpec(
             
             infix fun Int.success(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -60,7 +59,7 @@ class UnusedImportSpec(
             operator fun LocalDate.rangeTo(that: LocalDate) = TODO()
             operator fun LocalDate.rangeUntil(that: LocalDate) = TODO()
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -82,7 +81,7 @@ class UnusedImportSpec(
             }
             """.trimIndent()
         val configuredSubject = UnusedImport(TestConfig(ADDITIONAL_OPERATOR_SET to listOf("assign")))
-        assertThat(configuredSubject.lintWithContext(env, main)).isEmpty()
+        assertThat(configuredSubject.compileAndLintWithContext(env, main, compile = false)).isEmpty()
     }
 
     @Test
@@ -103,7 +102,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main)
+        val lint = subject.compileAndLintWithContext(env, main, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import org.gradle.kotlin.dsl.assign")
@@ -140,7 +139,7 @@ class UnusedImportSpec(
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -170,7 +169,7 @@ class UnusedImportSpec(
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main, additional)
+        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import tasks.undefined")
@@ -192,7 +191,7 @@ class UnusedImportSpec(
             
             class SomeClass
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main, additional)
+        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import test.SomeClass")
@@ -224,7 +223,7 @@ class UnusedImportSpec(
                 fun beforeTextChanged() {}
             }
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -252,7 +251,7 @@ class UnusedImportSpec(
                 fun beforeTextChanged() {}
             }
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -285,7 +284,7 @@ class UnusedImportSpec(
 
             fun TextWatcher.beforeTextChanged() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional1, additional2)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
     }
 
     @Test
@@ -320,7 +319,7 @@ class UnusedImportSpec(
             fun TextWatcher.beforeTextChanged() {}
             fun TextWatcher.afterTextChanged() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional1, additional2)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).hasSize(1)
     }
 
     @Test
@@ -373,7 +372,7 @@ class UnusedImportSpec(
             fun `when`() {}
             fun `foo`() {}
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main, p, p2, escaped)
+        val lint = subject.compileAndLintWithContext(env, main, p, p2, escaped, compile = false)
         with(lint) {
             assertThat(this).hasSize(3)
             assertThat(this[0].entity.signature).contains("import p.B6")
@@ -402,7 +401,7 @@ class UnusedImportSpec(
                 class Inner
             }
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main, additional)
+        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).isEmpty()
         }
@@ -426,7 +425,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -447,7 +446,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -468,7 +467,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).hasSize(1)
     }
 
     @Test
@@ -489,7 +488,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).hasSize(1)
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).hasSize(1)
     }
 
     @Test
@@ -515,7 +514,7 @@ class UnusedImportSpec(
             fun success() {}
             fun undefined() {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -530,7 +529,7 @@ class UnusedImportSpec(
             package test
             fun Iterator<Int>.forEach(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -556,7 +555,7 @@ class UnusedImportSpec(
             package com.example.other
             fun foo() = 1
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional1, additional2)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
     }
 
     @Test
@@ -583,7 +582,7 @@ class UnusedImportSpec(
                 prop: KProperty<*>
             ) = lazy { "" }
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -604,7 +603,7 @@ class UnusedImportSpec(
             data class MyClass(val a: Int, val b: Int)
             """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, main, additional)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -632,7 +631,7 @@ class UnusedImportSpec(
             package com.example.component1
             class Unused
             """.trimIndent()
-        val lint = subject.lintWithContext(env, main, additional1, additional2)
+        val lint = subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)
 
         with(lint) {
             assertThat(this).hasSize(4)
@@ -663,7 +662,7 @@ class UnusedImportSpec(
             package bar
             fun test(s: String) {}
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile1, additionalFile2)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile1, additionalFile2, compile = false)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].entity.signature).endsWith("import bar.test")
     }
@@ -711,7 +710,7 @@ class UnusedImportSpec(
             
             class Foo
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -730,7 +729,7 @@ class UnusedImportSpec(
             
             annotation class Ann
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -750,7 +749,7 @@ class UnusedImportSpec(
                 companion object
             }
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -772,7 +771,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -794,7 +793,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -814,7 +813,7 @@ class UnusedImportSpec(
                 LAZY
             }
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -836,7 +835,7 @@ class UnusedImportSpec(
             annotation class AnnotationA
             annotation class AnnotationB(val attribute: AnnotationA)
             """.trimIndent()
-        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -863,7 +862,7 @@ class UnusedImportSpec(
             class SomeClass
             """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -882,7 +881,7 @@ class UnusedImportSpec(
             }
             """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, mainFile)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, mainFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -897,6 +896,6 @@ class UnusedImportSpec(
             }
             """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, mainFile)).hasSize(2)
+        assertThat(subject.compileAndLintWithContext(env, mainFile, compile = false)).hasSize(2)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -36,7 +36,7 @@ class UnusedImportSpec(
             
             infix fun Int.success(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -59,7 +59,7 @@ class UnusedImportSpec(
             operator fun LocalDate.rangeTo(that: LocalDate) = TODO()
             operator fun LocalDate.rangeUntil(that: LocalDate) = TODO()
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -81,7 +81,7 @@ class UnusedImportSpec(
             }
             """.trimIndent()
         val configuredSubject = UnusedImport(TestConfig(ADDITIONAL_OPERATOR_SET to listOf("assign")))
-        assertThat(configuredSubject.compileAndLintWithContext(env, main, compile = false)).isEmpty()
+        assertThat(configuredSubject.lintWithContext(env, main, compile = false)).isEmpty()
     }
 
     @Test
@@ -102,7 +102,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, compile = false)
+        val lint = subject.lintWithContext(env, main, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import org.gradle.kotlin.dsl.assign")
@@ -139,7 +139,7 @@ class UnusedImportSpec(
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -169,7 +169,7 @@ class UnusedImportSpec(
             infix fun Int.failure(f: () -> Unit) {}
             infix fun Int.undefined(f: () -> Unit) {}
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
+        val lint = subject.lintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import tasks.undefined")
@@ -191,7 +191,7 @@ class UnusedImportSpec(
             
             class SomeClass
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
+        val lint = subject.lintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).hasSize(1)
             assertThat(this[0].entity.signature).endsWith("import test.SomeClass")
@@ -223,7 +223,7 @@ class UnusedImportSpec(
                 fun beforeTextChanged() {}
             }
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -251,7 +251,7 @@ class UnusedImportSpec(
                 fun beforeTextChanged() {}
             }
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -284,7 +284,7 @@ class UnusedImportSpec(
 
             fun TextWatcher.beforeTextChanged() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
     }
 
     @Test
@@ -319,7 +319,7 @@ class UnusedImportSpec(
             fun TextWatcher.beforeTextChanged() {}
             fun TextWatcher.afterTextChanged() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).hasSize(1)
+        assertThat(subject.lintWithContext(env, main, additional1, additional2, compile = false)).hasSize(1)
     }
 
     @Test
@@ -372,7 +372,7 @@ class UnusedImportSpec(
             fun `when`() {}
             fun `foo`() {}
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, p, p2, escaped, compile = false)
+        val lint = subject.lintWithContext(env, main, p, p2, escaped, compile = false)
         with(lint) {
             assertThat(this).hasSize(3)
             assertThat(this[0].entity.signature).contains("import p.B6")
@@ -401,7 +401,7 @@ class UnusedImportSpec(
                 class Inner
             }
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, additional, compile = false)
+        val lint = subject.lintWithContext(env, main, additional, compile = false)
         with(lint) {
             assertThat(this).isEmpty()
         }
@@ -425,7 +425,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -446,7 +446,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -467,7 +467,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).hasSize(1)
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).hasSize(1)
     }
 
     @Test
@@ -488,7 +488,7 @@ class UnusedImportSpec(
             
             fun success() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).hasSize(1)
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).hasSize(1)
     }
 
     @Test
@@ -514,7 +514,7 @@ class UnusedImportSpec(
             fun success() {}
             fun undefined() {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -529,7 +529,7 @@ class UnusedImportSpec(
             package test
             fun Iterator<Int>.forEach(f: () -> Unit) {}
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -555,7 +555,7 @@ class UnusedImportSpec(
             package com.example.other
             fun foo() = 1
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional1, additional2, compile = false)).isEmpty()
     }
 
     @Test
@@ -582,7 +582,7 @@ class UnusedImportSpec(
                 prop: KProperty<*>
             ) = lazy { "" }
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -603,7 +603,7 @@ class UnusedImportSpec(
             data class MyClass(val a: Int, val b: Int)
             """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, main, additional, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, main, additional, compile = false)).isEmpty()
     }
 
     @Test
@@ -631,7 +631,7 @@ class UnusedImportSpec(
             package com.example.component1
             class Unused
             """.trimIndent()
-        val lint = subject.compileAndLintWithContext(env, main, additional1, additional2, compile = false)
+        val lint = subject.lintWithContext(env, main, additional1, additional2, compile = false)
 
         with(lint) {
             assertThat(this).hasSize(4)
@@ -662,7 +662,7 @@ class UnusedImportSpec(
             package bar
             fun test(s: String) {}
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile1, additionalFile2, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile1, additionalFile2, compile = false)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].entity.signature).endsWith("import bar.test")
     }
@@ -676,7 +676,7 @@ class UnusedImportSpec(
             fun doesNothing(thing: HashMap<String, String>) {
             }
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -692,7 +692,7 @@ class UnusedImportSpec(
             @Ann(HashMap::class)
             fun foo() {}
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -710,7 +710,7 @@ class UnusedImportSpec(
             
             class Foo
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -729,7 +729,7 @@ class UnusedImportSpec(
             
             annotation class Ann
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -749,7 +749,7 @@ class UnusedImportSpec(
                 companion object
             }
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -771,7 +771,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -793,7 +793,7 @@ class UnusedImportSpec(
                 }
             }
             """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)
+        val findings = subject.lintWithContext(env, mainFile, additionalFile, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -813,7 +813,7 @@ class UnusedImportSpec(
                 LAZY
             }
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -835,7 +835,7 @@ class UnusedImportSpec(
             annotation class AnnotationA
             annotation class AnnotationB(val attribute: AnnotationA)
             """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -862,7 +862,7 @@ class UnusedImportSpec(
             class SomeClass
             """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -881,7 +881,7 @@ class UnusedImportSpec(
             }
             """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, mainFile, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, mainFile, compile = false)).isEmpty()
     }
 
     @Test
@@ -896,6 +896,6 @@ class UnusedImportSpec(
             }
             """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, mainFile, compile = false)).hasSize(2)
+        assertThat(subject.lintWithContext(env, mainFile, compile = false)).hasSize(2)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -25,7 +25,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun unplug()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -40,7 +40,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun baz(i: Int, s: String)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -51,7 +51,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun baz(i: Int, s: String)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -60,7 +60,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 expect fun bar(i: Int)
                 expect fun baz(i: Int, s: String)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -69,7 +69,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 expect class Foo1(private val bar: String) {}
                 expect class Foo2(bar: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -79,7 +79,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
         @Test
         fun `should not report parameters in external functions`() {
             val code = "external fun foo(bar: String)"
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -96,7 +96,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -110,7 +110,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     protected fun fee(bar: String) {}
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -128,7 +128,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     })
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -150,7 +150,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -161,7 +161,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 internal class IC // unused but internal
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -181,7 +181,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -193,7 +193,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 private fun unusedTopLevelFunction() = 5
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -205,7 +205,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     calledFromMain()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -223,7 +223,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -236,7 +236,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -250,7 +250,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun doSomethingElse() {}
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -271,7 +271,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -288,7 +288,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val lint = subject.compileAndLintWithContext(env, code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint.first().message).startsWith("Private function")
         }
@@ -303,7 +303,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): String = ""
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -312,7 +312,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): String = ""
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].message).isEqualTo("Private function `foo` is unused.")
@@ -327,7 +327,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -344,7 +344,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -362,7 +362,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Suppress("ClassName")
@@ -379,7 +379,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     
                     val answer = Test.answer()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -392,7 +392,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         val answer = A(1)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -403,7 +403,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -414,7 +414,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -425,7 +425,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     private operator fun A.invoke(i: Int): Int = i
                     val answer = B()(1)
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -439,7 +439,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         val answer = A(1, 1)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(
                         SourceLocation(3, 30)
@@ -455,7 +455,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(9)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(
                         SourceLocation(3, 24)
@@ -472,7 +472,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun answer() = A()(nullableInt)
                     val answer = answer()
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code))
+                assertThat(subject.lintWithContext(env, code))
                     .hasSize(1)
                     .hasStartSourceLocations(
                         SourceLocation(2, 24)
@@ -488,7 +488,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         val answer = A()(1)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -502,7 +502,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         val answer = A()(1)
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -515,7 +515,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         override operator fun invoke() = "A"
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 
@@ -538,7 +538,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     private operator fun Int?.rem(other: Int) = 5
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -552,7 +552,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -566,7 +566,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -579,7 +579,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -601,7 +601,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -623,7 +623,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -645,7 +645,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
     }
 
@@ -663,7 +663,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -678,7 +678,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1).hasStartSourceLocations(
                 SourceLocation(3, 30),
             )
@@ -713,7 +713,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -737,7 +737,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -755,7 +755,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -773,7 +773,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
     }
 
@@ -791,7 +791,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == s }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -810,7 +810,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == s }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -829,7 +829,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == b }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -848,7 +848,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                         this.firstOrNull { it.s == s }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -861,7 +861,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -880,7 +880,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -899,7 +899,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private operator fun List<StringWrapper>.get(s: String) =
                     this.firstOrNull { it.s == s }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -915,7 +915,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     private fun foo() = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -26,7 +25,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun unplug()
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -41,7 +40,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun baz(i: Int, s: String)
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -52,7 +51,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     fun baz(i: Int, s: String)
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -61,7 +60,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 expect fun bar(i: Int)
                 expect fun baz(i: Int, s: String)
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -70,7 +69,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 expect class Foo1(private val bar: String) {}
                 expect class Foo2(bar: String) {}
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -97,7 +96,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 
@@ -129,7 +128,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                     })
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -251,7 +250,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
                 private fun doSomethingElse() {}
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -5,7 +5,7 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -44,7 +44,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -58,7 +58,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -72,7 +72,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -87,14 +87,14 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `does fail when enabled with invalid regex`() {
             val config = TestConfig(ALLOWED_NAMES_PATTERN to "*foo")
             assertThatExceptionOfType(PatternSyntaxException::class.java)
-                .isThrownBy { UnusedPrivateProperty(config).compileAndLintWithContext(env, regexTestingCode) }
+                .isThrownBy { UnusedPrivateProperty(config).lintWithContext(env, regexTestingCode) }
         }
     }
 
@@ -113,7 +113,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(0)
         }
 
@@ -128,7 +128,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocation(4, 21)
         }
@@ -145,7 +145,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -160,7 +160,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -175,7 +175,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -211,7 +211,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -236,7 +236,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     println(o("$\\{PC.Companion.OO.BLA.toString()}"))
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.lintWithContext(env, code)).hasSize(0)
         }
     }
 
@@ -257,7 +257,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(4)
+            assertThat(subject.lintWithContext(env, code)).hasSize(4)
         }
 
         @Test
@@ -271,7 +271,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     const val TEXT = "text"
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -290,7 +290,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -304,7 +304,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -320,7 +320,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -331,7 +331,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 private const val unusedTopLevelConst = 1
                 private val unusedTopLevelVal = usedTopLevelVal
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 19),
@@ -348,7 +348,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -361,7 +361,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(1, 13))
         }
@@ -373,7 +373,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                private val ignored = 3 // ignored   
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
         }
     }
@@ -388,7 +388,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val ignored = ""
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -406,7 +406,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 27),
@@ -428,7 +428,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 17),
@@ -445,7 +445,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -458,7 +458,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -470,7 +470,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Test(@Suppress("UnusedPrivateProperty") private val foo: String) {}
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -482,7 +482,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 ) {}
             """.trimIndent()
 
-            val lint = subject.compileAndLintWithContext(env, code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].message).isEqualTo("Private property `bar` is unused.")
@@ -498,7 +498,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 ) {}
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -515,7 +515,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -526,7 +526,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -538,7 +538,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val lint = subject.compileAndLintWithContext(env, code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
             assertThat(lint[0].message).isEqualTo("Private property `bar` is unused.")
@@ -554,7 +554,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -572,7 +572,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -588,7 +588,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val foo = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
         }
     }
 
@@ -600,7 +600,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 actual class Foo actual constructor(actual val bar: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -608,7 +608,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 actual class Foo actual constructor(private val bar: String) {}
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code, compile = false)).hasSize(1)
         }
     }
 
@@ -621,7 +621,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                class Test(vararg unused: Any)
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -632,7 +632,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Child(private vararg val used: Any) : Parent(used)
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -643,7 +643,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 class Foo(private vararg val used: Any) : Super(used)
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .isEmpty()
         }
 
@@ -655,7 +655,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .hasSize(0)
         }
 
@@ -664,7 +664,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(private val unused: Any)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -679,7 +679,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isNotEmpty()
+            assertThat(subject.lintWithContext(env, code)).isNotEmpty()
         }
 
         @Test
@@ -687,7 +687,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(val unused: Any)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -697,7 +697,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     init { used.toString() }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -709,7 +709,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -720,7 +720,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val bar: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -731,7 +731,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     private val bar: String,
                 )
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -740,7 +740,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 @JvmInline value class Foo(private val value: String)
                 inline class Bar(private val value: String)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -751,7 +751,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class Test(unused: Any)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -760,7 +760,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 open class Parent(val ignored: Any)
                 class Test(used: Any) : Parent(used)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -772,7 +772,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -782,7 +782,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     val usedString = used.toString()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -794,7 +794,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     val findings: Map<Any,Any>
                 ) : Detektion by result
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -811,7 +811,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                     constructor(used: Any)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
@@ -332,7 +331,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 private const val unusedTopLevelConst = 1
                 private val unusedTopLevelVal = usedTopLevelVal
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(2, 19),
@@ -601,7 +600,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 actual class Foo actual constructor(actual val bar: String) {}
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -609,7 +608,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
             val code = """
                 actual class Foo actual constructor(private val bar: String) {}
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).hasSize(1)
         }
     }
 
@@ -656,7 +655,7 @@ class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .hasSize(0)
         }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -28,7 +27,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .hasSize(1)
         }
     }
@@ -145,7 +144,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .isEmpty()
         }
     }
@@ -298,7 +297,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val results = subject.lintWithContext(env, code)
+            val results = subject.compileAndLintWithContext(env, code, compile = false)
             assertThat(results).hasSize(2)
             assertThat(results).anyMatch { it.message == "Variable `org` is unused." }
             assertThat(results).anyMatch { it.message == "Variable `detekt` is unused." }
@@ -318,7 +317,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }
@@ -333,7 +332,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -27,7 +27,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .hasSize(1)
         }
     }
@@ -40,7 +40,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 fun foo() { val unused = 1 }
             """.trimIndent()
 
-            val lint = subject.compileAndLintWithContext(env, code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint.first())
                 .hasMessage("Variable `unused` is unused.")
@@ -60,7 +60,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }
@@ -75,7 +75,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(2)
                 .hasStartSourceLocations(
                     SourceLocation(3, 9),
@@ -89,7 +89,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 fun foo(bar:Int) { }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(0)
+            assertThat(subject.lintWithContext(env, code)).hasSize(0)
         }
     }
 
@@ -106,7 +106,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(4, 13))
         }
@@ -129,7 +129,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(5, 11))
         }
@@ -144,7 +144,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .isEmpty()
         }
     }
@@ -161,7 +161,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -171,7 +171,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                   for (i in 0 until 10) { }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(2, 8))
         }
@@ -186,7 +186,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -199,7 +199,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -213,7 +213,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -227,7 +227,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     val `in` = "foo"
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -239,7 +239,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     println(expected == `in`)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -251,7 +251,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     println(expected == `actual`)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -263,7 +263,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                     println(expected == actual)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -280,7 +280,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val results = subject.compileAndLintWithContext(env, code)
+            val results = subject.lintWithContext(env, code)
             assertThat(results).hasSize(2)
             assertThat(results).anyMatch { it.message == "Variable `org` is unused." }
             assertThat(results).anyMatch { it.message == "Variable `detekt` is unused." }
@@ -297,7 +297,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            val results = subject.compileAndLintWithContext(env, code, compile = false)
+            val results = subject.lintWithContext(env, code, compile = false)
             assertThat(results).hasSize(2)
             assertThat(results).anyMatch { it.message == "Variable `org` is unused." }
             assertThat(results).anyMatch { it.message == "Variable `detekt` is unused." }
@@ -317,7 +317,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }
@@ -332,7 +332,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false))
+            assertThat(subject.lintWithContext(env, code, compile = false))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(3, 9))
         }
@@ -349,7 +349,7 @@ class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
                }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
                 .hasStartSourceLocations(SourceLocation(2, 16))
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
@@ -16,7 +16,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports collections.find != null")
     fun reportCollectionsFindNotEqualToNull() {
         val code = "val x = listOf(1, 2, 3).find { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'any' instead of 'find'")
     }
@@ -25,7 +25,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports sequences.find != null")
     fun reportSequencesFindNotEqualToNull() {
         val code = "val x = sequenceOf(1, 2, 3).find { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -33,7 +33,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports text.find != null")
     fun reportTextFindNotEqualToNull() {
         val code = "val x = \"123\".find { it == '4' } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -41,7 +41,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports collections.firstOrNull != null")
     fun reportCollectionsFirstOrNullNotEqualToNull() {
         val code = "val x = arrayOf(1, 2, 3).firstOrNull { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'any' instead of 'firstOrNull'")
     }
@@ -50,7 +50,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports sequences.firstOrNull != null")
     fun reportSequencesFirstOrNullNotEqualToNull() {
         val code = "val x = sequenceOf(1, 2, 3).firstOrNull { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -58,7 +58,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports text.firstOrNull != null")
     fun reportTextFirstOrNullNotEqualToNull() {
         val code = "val x = \"123\".firstOrNull { it == '4' } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -66,7 +66,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports collections.find == null")
     fun reportCollectionsFindEqualToNull() {
         val code = "val x = setOf(1, 2, 3).find { it == 4 } == null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'none' instead of 'find'")
     }
@@ -75,7 +75,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports null != collections.find")
     fun reportNullNotEqualToCollectionsFind() {
         val code = "val x = null != listOf(1, 2, 3).find { it == 4 }"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'any' instead of 'find'")
     }
@@ -84,7 +84,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports collections.find != null in extension")
     fun reportCollectionsFindNotEqualToNullInExtension() {
         val code = "fun List<Int>.test(): Boolean = find { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -92,7 +92,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Reports collections.lastOrNull != null")
     fun reportCollectionsLastOrNullNotEqualToNull() {
         val code = "val x = listOf(1, 2, 3).lastOrNull { it == 4 } != null"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'any' instead of 'lastOrNull'")
     }
@@ -101,7 +101,7 @@ class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
     @DisplayName("Does not report collections.find")
     fun noReportCollectionsFind() {
         val code = "val x = listOf(1, 2, 3).find { it == 4 }"
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
                 check(i != null)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -29,7 +29,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
                 check(null != i)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
                 check(i > 0)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -114,7 +113,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 unsafeRunTimed(Duration.INFINITE)
                     .fold({ throw IllegalStateException("message") }, ::identity)
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -19,7 +19,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -32,7 +32,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(4, 9)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(4, 9)
     }
 
     @Test
@@ -43,7 +43,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw IllegalStateException("More details")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -55,7 +55,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalStateException()
                 }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(4, 17)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(4, 17)
     }
 
     @Test
@@ -66,7 +66,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw java.lang.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -77,7 +77,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw kotlin.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -90,7 +90,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 if (a < 0) throw SomeBusinessException()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -103,7 +103,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 throw Exception()
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -113,19 +113,19 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 unsafeRunTimed(Duration.INFINITE)
                     .fold({ throw IllegalStateException("message") }, ::identity)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function`() {
         val code = """fun doThrow(): Nothing = throw IllegalStateException("message")"""
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(1, 26)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(1, 26)
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function block`() {
         val code = """fun doThrow(): Nothing { throw IllegalStateException("message") }"""
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(1, 26)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(1, 26)
     }
 
     @Test
@@ -138,7 +138,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -151,7 +151,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -164,7 +164,7 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -177,6 +177,6 @@ class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -29,7 +29,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     object Obj
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -39,7 +39,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     val c = 2 * b
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -51,7 +51,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -59,7 +59,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 class NoDataClassCandidateWithOnlyPrivateCtor1 private constructor(val i: Int)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -69,7 +69,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     private constructor(i: Int)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -80,7 +80,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     data class Error(val error: Throwable) : NoDataClassBecauseItsSealed()
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -90,7 +90,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     FIRST(1), SECOND(2);
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -98,7 +98,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 annotation class AnnotationNoDataClass(val i: Int)
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -113,7 +113,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -126,7 +126,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 data class DataClass(override val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -141,7 +141,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(override val i: Int, override val j: Int): SimpleInterface, BaseClass(j)
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -152,7 +152,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class A(val b: B) : I by b
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -165,7 +165,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClassCandidate1(val i: Int)
             """.trimIndent()
 
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings).hasStartSourceLocation(1, 7)
@@ -179,7 +179,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     val i2: Int = 0
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -189,7 +189,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     private constructor(i: Int) : this(i.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -199,7 +199,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     constructor(i: Int) : this(i.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -217,7 +217,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -227,7 +227,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -240,7 +240,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 class DataClass(override val i: Int): SimpleInterface
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -254,7 +254,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: String): D = D(a, b)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -264,7 +264,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: String) = D(a, b)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -274,7 +274,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(): D = D(0, "")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -284,7 +284,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: String, c: String): D = D(a, b + c)
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -294,7 +294,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: Int): D = D(a, b.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -304,7 +304,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     fun copy(a: Int, b: String?): D = D(a, b.toString())
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -315,7 +315,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -326,7 +326,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
         fun `does not report class with mutable constructor parameter`() {
             val code = """class DataClassCandidateWithVar(var i: Int)"""
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -337,7 +337,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -348,7 +348,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -359,13 +359,13 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
             val config = TestConfig(ALLOW_VARS to "true")
-            assertThat(UseDataClass(config).compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
     }
 
     @Test
     fun `does not report inline classes`() {
-        assertThat(subject.compileAndLintWithContext(env, "inline class A(val x: Int)")).isEmpty()
+        assertThat(subject.lintWithContext(env, "inline class A(val x: Int)")).isEmpty()
     }
 
     @Test
@@ -374,7 +374,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
             @JvmInline
             value class A(val x: Int)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -387,7 +387,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -402,7 +402,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -412,7 +412,7 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 inner class Inner(val x: Int)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -422,6 +422,6 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 val bar: String
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+        assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -423,6 +422,6 @@ class UseDataClassSpec(val env: KotlinCoreEnvironment) {
                 val bar: String
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).isEmpty()
+        assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -21,7 +21,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val sequence = sequenceOf<Any>()
             val set = setOf<Any>()
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(6)
+        assertThat(rule.lintWithContext(env, code)).hasSize(6)
     }
 
     @Test
@@ -34,7 +34,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val sequence: Sequence<Any> = sequenceOf()
             val set: Set<Any> = setOf()
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).hasSize(6)
+        assertThat(rule.lintWithContext(env, code)).hasSize(6)
     }
 
     @Test
@@ -46,7 +46,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val sequence = emptySequence<Any>()
             val set = emptySet<Any>()
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -59,7 +59,7 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val sequence = sequenceOf(0)
             val set = setOf(0)
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -79,6 +79,6 @@ class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
             val sequence = sequenceOf<Any>()
             val set = setOf<Any>()
         """.trimIndent()
-        assertThat(rule.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(rule.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -25,7 +25,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     val name = if (api.name.isBlank()) "John" else api.name
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isBlank' call can be replaced with 'ifBlank'")
             assertThat(findings).hasStartSourceLocation(4, 29)
         }
@@ -43,7 +43,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         "John"
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isNotBlank' call can be replaced with 'ifBlank'")
             assertThat(findings).hasStartSourceLocation(4, 29)
         }
@@ -58,7 +58,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     val name = if (api.name.isEmpty()) "John" else api.name
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
             assertThat(findings).hasStartSourceLocation(4, 29)
         }
@@ -76,7 +76,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                         "John"
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
             assertThat(findings).hasStartSourceLocation(4, 29)
         }
@@ -93,7 +93,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -109,7 +109,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -125,7 +125,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -141,7 +141,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -157,7 +157,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -173,7 +173,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -189,7 +189,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -205,7 +205,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -220,7 +220,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -236,7 +236,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -251,7 +251,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
         }
 
@@ -266,7 +266,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
         }
     }
@@ -283,7 +283,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     val name = if (api.name.isNullOrBlank()) "John" else api.name
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -299,7 +299,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -315,7 +315,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -331,7 +331,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -347,7 +347,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -363,7 +363,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -380,7 +380,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -393,7 +393,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -408,7 +408,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -424,7 +424,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -439,7 +439,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -23,7 +23,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement().hasMessage(
                     "This 'x == null || x.isEmpty()' can be replaced with 'isNullOrEmpty()' call"
                 )
@@ -37,7 +37,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -48,7 +48,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -59,7 +59,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (null == x || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -70,7 +70,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || 0 == x.count()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -81,7 +81,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || 0 == x.size) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -96,7 +96,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (a.t == null || a.t.length == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -107,7 +107,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (java.io.File.separator == null || java.io.File.separator.length == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -121,7 +121,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -132,7 +132,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -143,7 +143,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -157,7 +157,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -168,7 +168,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -179,7 +179,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -193,7 +193,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -204,7 +204,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -215,7 +215,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -229,7 +229,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -240,7 +240,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -251,7 +251,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -265,7 +265,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -276,7 +276,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -287,7 +287,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.length == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
 
@@ -298,7 +298,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x == "") return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -312,7 +312,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -326,7 +326,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -340,7 +340,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -354,7 +354,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).hasSize(1)
             }
         }
@@ -371,7 +371,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.isEmpty()) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -382,7 +382,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
 
@@ -393,7 +393,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.size == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -407,7 +407,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                         if (x == null || x.count() == 0) return
                     }
                 """.trimIndent()
-                val findings = subject.compileAndLintWithContext(env, code)
+                val findings = subject.lintWithContext(env, code)
                 assertThat(findings).isEmpty()
             }
         }
@@ -419,7 +419,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     if (x == null || y.isEmpty()) return
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -430,7 +430,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     if (x != null && x.isEmpty()) return
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -441,7 +441,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     if (x == null || x.count() == 1) return
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -452,7 +452,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     if (x == null || x.isEmpty()) return
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -467,7 +467,7 @@ class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +21,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptyList()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("This '?: emptyList()' can be replaced with 'orEmpty()' call")
             assertThat(findings).hasStartSourceLocation(2, 13)
@@ -34,7 +34,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptySet()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -45,7 +45,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptyMap()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -56,7 +56,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptySequence()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -67,7 +67,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptyArray()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -78,7 +78,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: listOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -89,7 +89,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: setOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -100,7 +100,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: mapOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -111,7 +111,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: sequenceOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -122,7 +122,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: arrayOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -133,7 +133,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: ""
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -144,7 +144,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptyList()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -158,7 +158,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     c["key"] ?: emptyList()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -172,7 +172,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: emptyList()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -183,7 +183,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: listOf(1)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -197,7 +197,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val x = c ?: emptyList<Int>()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -208,7 +208,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: mutableListOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -219,7 +219,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val a = x ?: intArrayOf()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -235,7 +235,7 @@ class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
                     val z = (c["key"]) ?: emptyList<Int>()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -18,7 +18,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
                 require(i != null)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -29,7 +29,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
                 require(null != i)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -40,7 +40,7 @@ class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
                 require(i > 0)
             }
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -20,7 +20,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -34,7 +34,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(3, 9)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 9)
     }
 
     @Test
@@ -45,7 +45,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -56,7 +56,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -67,7 +67,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -79,7 +79,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -91,7 +91,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -106,7 +106,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -114,19 +114,19 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
         val code = """
             fun throwingFunction(): () -> Any = { throw IllegalArgumentException("message") }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not report an issue if the exception thrown unconditionally`() {
         val code = """fun doThrow(): Nothing = throw IllegalArgumentException("message")"""
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `does not report an issue if the exception thrown unconditionally in a function block`() {
         val code = """fun doThrow() { throw IllegalArgumentException("message") }"""
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -136,7 +136,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (throwable !is NumberFormatException) throw IllegalArgumentException(throwable)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -146,7 +146,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (throwable !is NumberFormatException) throw IllegalArgumentException("a", throwable)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -157,7 +157,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                 if (throwable !is NumberFormatException) throw IllegalArgumentException(s)
             }
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Nested
@@ -174,7 +174,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     else -> throw IllegalArgumentException("Not supported List type")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -190,7 +190,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     throw IllegalArgumentException("Test was too big")
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -204,7 +204,7 @@ class UseRequireSpec(val env: KotlinCoreEnvironment) {
                     return subclass
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'sumOf' instead of 'flatMap' and 'size'")
     }
@@ -32,7 +32,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'sumOf' instead of 'flatMap' and 'count'")
     }
@@ -45,7 +45,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'sumOf' instead of 'flatMap' and 'count'")
     }
@@ -58,7 +58,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
         assertThat(actual[0].message).isEqualTo("Use 'sumOf' instead of 'flatten' and 'size'")
     }
@@ -71,7 +71,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -84,7 +84,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -96,7 +96,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Bar(val bar: Set<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).hasSize(1)
     }
 
@@ -108,7 +108,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -120,7 +120,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -132,7 +132,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 
@@ -144,7 +144,7 @@ class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
             }
             class Foo(val foo: List<Int>)
         """.trimIndent()
-        val actual = subject.compileAndLintWithContext(env, code)
+        val actual = subject.lintWithContext(env, code)
         assertThat(actual).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -243,7 +242,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.lintWithContext(env, code)
+        val findings = subject.compileAndLintWithContext(env, code, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -257,7 +256,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.lintWithContext(env, code)
+        val findings = subject.compileAndLintWithContext(env, code, compile = false)
         assertThat(findings).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -14,7 +14,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when calling orEmpty on a list`() {
         val code = """val testList = listOf("string").orEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -22,7 +22,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when calling orEmpty on a list with a safe call`() {
         val code = """val testList = listOf("string")?.orEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -30,7 +30,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when calling orEmpty on a list in a chain`() {
         val code = """val testList = listOf("string").orEmpty().map { }"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -39,7 +39,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     fun `reports when calling orEmpty on a list with a platform type`() {
         // System.getenv().keys.toList() will be of type List<String!>.
         val code = """val testSequence = System.getenv().keys.toList().orEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -50,13 +50,13 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val testList: List<String>? = listOf("string")
             val nonNullableTestList = testList.orEmpty()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports when calling isNullOrBlank on a string with a safe call`() {
         val code = """val testString = ""?.isNullOrBlank()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace isNullOrBlank with isBlank")
     }
@@ -67,13 +67,13 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val testString: String? = ""
             val nonNullableTestString = testString.isNullOrBlank()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports when calling isNullOrEmpty on a string`() {
         val code = """val testString = "".isNullOrEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace isNullOrEmpty with isEmpty")
     }
@@ -81,7 +81,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `reports when calling isNullOrEmpty on a string with a safe call`() {
         val code = """val testString = ""?.isNullOrEmpty()"""
-        assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
 
     @Test
@@ -90,13 +90,13 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val testString: String? = ""
             val nonNullableTestString = testString.isNullOrEmpty()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports when calling orEmpty on a string`() {
         val code = """val testString = "".orEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -107,13 +107,13 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val testString: String? = ""
             val nonNullableTestString = testString.orEmpty()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
     fun `reports when calling orEmpty on a sequence`() {
         val code = """val testSequence = listOf(1).asSequence().orEmpty()"""
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -124,7 +124,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val testSequence: Sequence<Int>? = listOf(1).asSequence()
             val nonNullableTestSequence = testSequence.orEmpty()
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -135,7 +135,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val noList = "str".orEmpty()
             val list = listOf(1, 2, 3).orEmpty()
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Remove redundant call to orEmpty")
     }
@@ -145,7 +145,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val strings = listOfNotNull("string")
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
     }
@@ -155,7 +155,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val strings = listOfNotNull<String>()
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
     }
@@ -165,7 +165,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
         val code = """
             val strings = listOfNotNull("string", null)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -175,7 +175,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nullableArray = arrayOf("string", null)
             val strings = listOfNotNull(*nullableArray)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -185,7 +185,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull(*nonNullableArray)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
     }
@@ -197,7 +197,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull("string", *nonNullableArray, "foo", *nullableArray)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -207,7 +207,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val nonNullableArray = arrayOf("string", "bar")
             val strings = listOfNotNull("string", *nonNullableArray, null)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -218,7 +218,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             val otherNonNullableArray = arrayOf("foobar")
             val strings = listOfNotNull("string", *nonNullableArray, "foo", *otherNonNullableArray)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace listOfNotNull with listOf")
     }
@@ -230,7 +230,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             
             val strings = listOfNotNull("string", null)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -242,7 +242,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code, compile = false)
+        val findings = subject.lintWithContext(env, code, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -256,7 +256,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
             }
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code, compile = false)
+        val findings = subject.lintWithContext(env, code, compile = false)
         assertThat(findings).isEmpty()
     }
 
@@ -267,7 +267,7 @@ class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
                 list.isNullOrEmpty()
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).isEqualTo("Replace isNullOrEmpty with isEmpty")
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -3,8 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lint
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -23,7 +22,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 internal var b = 2
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -36,7 +35,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -49,7 +48,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -64,7 +63,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test
@@ -82,7 +81,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -100,7 +99,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     internal var b = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -115,7 +114,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     internal var b = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -129,7 +128,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -143,7 +142,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -153,7 +152,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     private var a = 1
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -168,7 +167,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a = 2
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -179,7 +178,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a += 2
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -190,7 +189,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     a++
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -201,7 +200,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     --a
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -214,7 +213,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -225,7 +224,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     val b = a + 2
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].message).isEqualTo("Variable 'a' could be val.")
@@ -239,7 +238,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     println(a)
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
 
             assertThat(findings).hasSize(1)
             assertThat(findings[0].message).isEqualTo("Variable 'a' could be val.")
@@ -256,7 +255,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val lint = subject.compileAndLintWithContext(env, code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint).hasSize(1)
             with(lint[0].entity) {
@@ -278,7 +277,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -291,7 +290,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -305,7 +304,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            with(subject.compileAndLintWithContext(env, code)[0]) {
+            with(subject.lintWithContext(env, code)[0]) {
                 assertThat(entity.ktElement.text).isEqualTo("var myVar = value")
             }
         }
@@ -322,7 +321,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -335,7 +334,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     wrapper.test = false
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -350,7 +349,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -368,7 +367,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                     o.optionEnabled = false
                 }
             """.trimIndent()
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Nested
@@ -386,7 +385,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         return o
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -406,7 +405,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         return o
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -423,7 +422,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         return o
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -444,7 +443,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         return o
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -459,7 +458,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -478,7 +477,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -491,7 +490,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         override var optionEnabled: Boolean = false
                     }
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
 
             @Test
@@ -506,7 +505,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                         }
                     } else null
                 """.trimIndent()
-                assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
     }
@@ -521,13 +520,13 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
 
         @Test
         fun `reports uninitialized lateinit vars by default`() {
-            assertThat(subject.compileAndLintWithContext(env, code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
         fun `does not report uninitialized lateinit vars if disabled in config`() {
             val subject = VarCouldBeVal(TestConfig("ignoreLateinitVar" to true))
-            assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -5,7 +5,6 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import io.gitlab.arturbosch.detekt.test.lint
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
@@ -65,7 +64,7 @@ class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
                 }
             """.trimIndent()
 
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
+            assertThat(subject.compileAndLintWithContext(env, code, compile = false)).isEmpty()
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.rules.style.movelambdaout
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -22,7 +22,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
             fun bar(a: Int = 0, f: (Int) -> Int) { }
             fun bar(a: Int, b: Int, f: (Int) -> Int) { }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code, compile = false)
+        val findings = subject.lintWithContext(env, code, compile = false)
         assertThat(findings).hasSize(1)
     }
 
@@ -33,7 +33,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
             class C1(s: String, f: (String) -> String) : I
             class C2 : I by C1("", { "" })
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -44,7 +44,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 p(1, { 2 })
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -59,7 +59,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 b(1)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -72,7 +72,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
 
             fun bar(p1: (Int) -> Int, p2: (Int) -> Int) {}
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -88,7 +88,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 test({ })
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -104,7 +104,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 test({ }, { }) // Don't flag it as IDE also doesn't flag it and trailing lambda might look more complicated in this case
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -117,7 +117,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
 
             fun bar(b: (Int) -> Int, option: Int = 0) {}
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -132,7 +132,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 b(a)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -150,7 +150,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 b(a)
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5).hasEndSourceLocation(2, 8)
     }
 
@@ -165,7 +165,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 return name4(name1) + name2 + name3
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -180,7 +180,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 return { }
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -195,7 +195,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 runSuspend({ println() })
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -210,7 +210,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 runSuspend({ println() })
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -223,7 +223,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 foo({ "a" })
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -235,7 +235,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
                 foo({})
             }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -4,7 +4,6 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
@@ -23,7 +22,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) 
             fun bar(a: Int = 0, f: (Int) -> Int) { }
             fun bar(a: Int, b: Int, f: (Int) -> Int) { }
         """.trimIndent()
-        val findings = subject.lintWithContext(env, code)
+        val findings = subject.compileAndLintWithContext(env, code, compile = false)
         assertThat(findings).hasSize(1)
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.FakeCompilerResources
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.ExplicitApiMode
@@ -22,7 +22,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
         val code = """
             fun foo(): Unit { }
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -31,7 +31,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
         val code = """
             fun foo() = String
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
 
@@ -52,7 +52,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
 
         @BeforeEach
         fun beforeEachTest() {
-            findings = subject.compileAndLintWithContext(env, code)
+            findings = subject.lintWithContext(env, code)
         }
 
         @Test
@@ -83,7 +83,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     override fun returnsUnit() = Unit
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -110,7 +110,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
 
         @BeforeEach
         fun beforeEachTest() {
-            findings = subject.compileAndLintWithContext(env, code)
+            findings = subject.lintWithContext(env, code)
         }
 
         @Test
@@ -140,7 +140,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     val i: (Int) -> Unit = { _ -> }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -154,7 +154,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     fun method(i: Int) = Unit
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -176,7 +176,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -197,7 +197,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -224,7 +224,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -249,7 +249,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -278,7 +278,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -304,7 +304,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -330,7 +330,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     }.foo()
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -341,7 +341,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                     String
                 }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
     }
@@ -353,7 +353,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun test(): Unit = throw UnsupportedOperationException()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -368,7 +368,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 
                 fun doFoo(): Unit = foo {}
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
 
@@ -383,7 +383,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 
                 fun doFoo(): Unit = foo<Nothing> {}
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
 
@@ -394,7 +394,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 
                 fun doFoo(): Unit = foo()
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code)
+            val findings = subject.lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -407,7 +407,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 code,
                 compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
@@ -420,7 +420,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 code,
                 compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
@@ -433,7 +433,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 code,
                 compilerResources = FakeCompilerResources(ExplicitApiMode.DISABLED)
@@ -446,7 +446,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit = println("")
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 code,
                 compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
@@ -459,7 +459,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit = println("")
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(
+            val findings = subject.lintWithContext(
                 env,
                 code,
                 compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
@@ -473,7 +473,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithPrivate =
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     code,
                     compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
@@ -484,7 +484,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 internal fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithInternal =
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     code2,
                     compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
@@ -498,7 +498,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithPrivate =
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     code,
                     compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
@@ -509,7 +509,7 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 internal fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithInternal =
-                subject.compileAndLintWithContext(
+                subject.lintWithContext(
                     env,
                     code2,
                     compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -407,7 +407,11 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.STRICT))
+            val findings = subject.compileAndLintWithContext(
+                env,
+                code,
+                compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
+            )
             assertThat(findings).hasSize(1)
         }
 
@@ -416,7 +420,11 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.WARNING))
+            val findings = subject.compileAndLintWithContext(
+                env,
+                code,
+                compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
+            )
             assertThat(findings).hasSize(1)
         }
 
@@ -425,7 +433,11 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit { }
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.DISABLED))
+            val findings = subject.compileAndLintWithContext(
+                env,
+                code,
+                compilerResources = FakeCompilerResources(ExplicitApiMode.DISABLED)
+            )
             assertThat(findings).hasSize(1)
         }
 
@@ -434,7 +446,11 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit = println("")
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.STRICT))
+            val findings = subject.compileAndLintWithContext(
+                env,
+                code,
+                compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
+            )
             assertThat(findings).isEmpty()
         }
 
@@ -443,7 +459,11 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
             val code = """
                 fun foo(): Unit = println("")
             """.trimIndent()
-            val findings = subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.WARNING))
+            val findings = subject.compileAndLintWithContext(
+                env,
+                code,
+                compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
+            )
             assertThat(findings).isEmpty()
         }
 
@@ -453,14 +473,22 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithPrivate =
-                subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.STRICT))
+                subject.compileAndLintWithContext(
+                    env,
+                    code,
+                    compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
+                )
             assertThat(findingsWithPrivate).hasSize(1)
 
             val code2 = """
                 internal fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithInternal =
-                subject.compileAndLintWithContext(env, code2, FakeCompilerResources(ExplicitApiMode.STRICT))
+                subject.compileAndLintWithContext(
+                    env,
+                    code2,
+                    compilerResources = FakeCompilerResources(ExplicitApiMode.STRICT)
+                )
             assertThat(findingsWithInternal).hasSize(1)
         }
 
@@ -470,14 +498,22 @@ class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
                 private fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithPrivate =
-                subject.compileAndLintWithContext(env, code, FakeCompilerResources(ExplicitApiMode.WARNING))
+                subject.compileAndLintWithContext(
+                    env,
+                    code,
+                    compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
+                )
             assertThat(findingsWithPrivate).hasSize(1)
 
             val code2 = """
                 internal fun foo(): Unit = println("")
             """.trimIndent()
             val findingsWithInternal =
-                subject.compileAndLintWithContext(env, code2, FakeCompilerResources(ExplicitApiMode.WARNING))
+                subject.compileAndLintWithContext(
+                    env,
+                    code2,
+                    compilerResources = FakeCompilerResources(ExplicitApiMode.WARNING)
+                )
             assertThat(findingsWithInternal).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -2,7 +2,7 @@ package io.gitlab.arturbosch.detekt.rules.style.optional
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
@@ -19,7 +19,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             val pair3 = Pair(Pair(1, 2), Pair(3, 4))
         """.trimIndent()
 
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(5)
         assertThat(findings[0].message).endsWith("`1 to 2`.")
     }
@@ -30,7 +30,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             val pair = createPair()
             fun createPair() = Pair(1, 2)
         """.trimIndent()
-        val findings = subject.compileAndLintWithContext(env, code)
+        val findings = subject.lintWithContext(env, code)
         assertThat(findings).hasSize(1)
         assertThat(findings[0].message).endsWith("`1 to 2`.")
     }
@@ -38,7 +38,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
     @Test
     fun `does not report if it is created using the to syntax`() {
         val code = "val pair = 1 to 2"
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -50,7 +50,7 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             
             data class Pair<T, Z>(val int1: T, val int2: Z)
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 
     @Test
@@ -59,6 +59,6 @@ class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
             val pair = createPair()
             fun createPair() = 1 to 2
         """.trimIndent()
-        assertThat(subject.compileAndLintWithContext(env, code)).isEmpty()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
 }

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -1,7 +1,7 @@
 public final class io/github/detekt/test/utils/CompileExtensionsKt {
 	public static final fun compileContentForTest (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static final fun compileContentForTest (Ljava/lang/String;Ljava/nio/file/Path;)Lorg/jetbrains/kotlin/psi/KtFile;
-	public static synthetic fun compileContentForTest$default (Ljava/lang/String;Ljava/nio/file/Path;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static synthetic fun compileContentForTest$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static final fun compileForTest (Ljava/nio/file/Path;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/CompileExtensions.kt
@@ -11,12 +11,12 @@ import kotlin.io.path.absolute
  */
 fun compileContentForTest(
     @Language("kotlin") content: String,
-    filename: String,
+    filename: String = "Test.kt",
 ): KtFile {
     require('/' !in filename && '\\' !in filename) {
         "filename must be a file name only and not contain any path elements"
     }
-    return compileContentForTest(content, path = Path("/$filename"))
+    return compileContentForTest(content, path = Path("/").absolute().resolve(filename))
 }
 
 /**
@@ -24,7 +24,7 @@ fun compileContentForTest(
  */
 fun compileContentForTest(
     @Language("kotlin") content: String,
-    path: Path = Path("/").absolute().resolve("Test.kt"),
+    path: Path,
 ): KtFile = KtTestCompiler.createKtFile(content, path)
 
 /**

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -41,8 +41,8 @@ public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
-	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
-	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
+	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -47,8 +47,6 @@ public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
-	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
-	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -41,12 +41,12 @@ public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
-	public static final fun compileAndLintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
-	public static synthetic fun compileAndLintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
+	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
+	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -24,11 +24,7 @@ fun Rule.lint(
     compile: Boolean = true,
 ): List<Finding> {
     require(this !is RequiresFullAnalysis) {
-        if (compile) {
-            "${this.ruleName} requires full analysis so you should use compileAndLintWithContext instead of lint"
-        } else {
-            "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
-        }
+        "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
     }
     if (compile && shouldCompileTestSnippets) {
         KotlinScriptEngine.compile(content)
@@ -37,7 +33,7 @@ fun Rule.lint(
     return visitFile(ktFile, compilerResources = compilerResources).filterSuppressed(this)
 }
 
-fun Rule.lintWithContext(
+fun <T> T.lintWithContext(
     environment: KotlinCoreEnvironment,
     @Language("kotlin") content: String,
     @Language("kotlin") vararg additionalContents: String,
@@ -46,10 +42,7 @@ fun Rule.lintWithContext(
         DataFlowValueFactoryImpl(environment.configuration.languageVersionSettings)
     ),
     compile: Boolean = true,
-): List<Finding> {
-    require(this is RequiresFullAnalysis) {
-        "${this.ruleName} doesn't require full analysis so you should use lint compileAndLintWithContext"
-    }
+): List<Finding> where T : Rule, T : RequiresFullAnalysis {
     if (compile && shouldCompileTestSnippets) {
         KotlinScriptEngine.compile(content)
     }
@@ -64,7 +57,7 @@ fun Rule.lintWithContext(
 
 fun Rule.lint(ktFile: KtFile, compilerResources: CompilerResources = FakeCompilerResources()): List<Finding> {
     require(this !is RequiresFullAnalysis) {
-        "${this::class.simpleName} needs full analysis to work, you should use `compileAndLintWithContext`."
+        "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
     }
     return visitFile(ktFile, compilerResources = compilerResources).filterSuppressed(this)
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -37,25 +37,6 @@ fun Rule.lint(
     return visitFile(ktFile, compilerResources = compilerResources).filterSuppressed(this)
 }
 
-@Deprecated(
-    "Use compileAndLintWithContext with compile = false",
-    replaceWith = ReplaceWith("compileAndLintWithContext(environment, content, *additionalContents, compilerResources = compilerResources, compile = false)")
-)
-fun Rule.lintWithContext(
-    environment: KotlinCoreEnvironment,
-    @Language("kotlin") content: String,
-    @Language("kotlin") vararg additionalContents: String,
-    compilerResources: CompilerResources = CompilerResources(
-        environment.configuration.languageVersionSettings,
-        DataFlowValueFactoryImpl(environment.configuration.languageVersionSettings)
-    ),
-): List<Finding> {
-    require(this is RequiresFullAnalysis) {
-        "${this.ruleName} doesn't require full analysis so you should use lint instead of lintWithContext"
-    }
-    return compileAndLintWithContext(environment, content, *additionalContents, compilerResources = compilerResources, compile = false)
-}
-
 fun Rule.compileAndLintWithContext(
     environment: KotlinCoreEnvironment,
     @Language("kotlin") content: String,

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -37,7 +37,7 @@ fun Rule.lint(
     return visitFile(ktFile, compilerResources = compilerResources).filterSuppressed(this)
 }
 
-fun Rule.compileAndLintWithContext(
+fun Rule.lintWithContext(
     environment: KotlinCoreEnvironment,
     @Language("kotlin") content: String,
     @Language("kotlin") vararg additionalContents: String,


### PR DESCRIPTION
This is the follow up that I promised at #7873

The idea is the same. Collapse `lintWithContext` and `compileAndLintWithContext` in a single function with a parameter `compile` that is defaulted to `true`. This way, if someone wants to not compile its snippets s/he needs to add a `compile = false`. That's easy to see on reviews and when you are reading the code. And it's more clear that it's a decision and not just a typo.