### PR TITLE
Use the version url for link the rules' documentation

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptor.kt
@@ -8,6 +8,7 @@ import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
+import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
 import io.gitlab.arturbosch.detekt.core.util.isActiveOrDefault
 import java.net.URI
 
@@ -69,7 +70,7 @@ private fun RuleSet.getRules(
     }
 
 private fun generateDefaultUrl(ruleSetId: RuleSet.Id, ruleName: Rule.Name) =
-    URI("https://detekt.dev/docs/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}")
+    URI("https://detekt.dev/docs/${whichDetekt()}/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}")
 
 private val externalFirstPartyRuleSets = setOf(
     "formatting",

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptorKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptorKtTest.kt
@@ -393,7 +393,7 @@ private fun createRuleInstance(id: String, active: Boolean, url: String?, severi
         if (id.startsWith("AnotherRule")) {
             URI("https://example.org/")
         } else {
-            URI("https://detekt.dev/docs/rules/custom#${id.substringBefore("/").lowercase()}")
+            URI("https://detekt.dev/docs/1.6.0/rules/custom#${id.substringBefore("/").lowercase()}")
         }
     } else {
         url?.let(::URI)

--- a/detekt-core/src/test/resources/META-INF/MANIFEST.MF
+++ b/detekt-core/src/test/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,2 @@
+Manifest-Version: 1.0
+DetektVersion: 1.6.0


### PR DESCRIPTION
Now that we have #7970 we have links for each version of detekt. And with this the link that we provides points to the version that the user is using instead of the newest one.

This also allow us to revert #7686