### PR TITLE
Add `helpUri` on SARIF report

### DIFF
--- a/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
+++ b/detekt-report-sarif/src/main/kotlin/io/github/detekt/report/sarif/RuleDescriptors.kt
@@ -9,6 +9,7 @@ internal fun RuleInstance.toDescriptor() = ReportingDescriptor(
     id = "detekt.$ruleSetId.$id",
     name = id,
     shortDescription = MultiformatMessageString(text = description),
+    helpURI = url?.toString(),
     defaultConfiguration = ReportingConfiguration(
         enabled = active,
         level = severity.toResultLevel(),

--- a/detekt-report-sarif/src/test/resources/vanilla.sarif.json
+++ b/detekt-report-sarif/src/test/resources/vanilla.sarif.json
@@ -96,6 +96,7 @@
                 "enabled": true,
                 "level": "error"
               },
+              "helpUri": "http://example.org/TestSmellA",
               "id": "detekt.RuleSet1.TestSmellA",
               "name": "TestSmellA",
               "shortDescription": {
@@ -107,6 +108,7 @@
                 "enabled": true,
                 "level": "warning"
               },
+              "helpUri": "http://example.org/TestSmellB",
               "id": "detekt.RuleSet2.TestSmellB",
               "name": "TestSmellB",
               "shortDescription": {
@@ -118,6 +120,7 @@
                 "enabled": false,
                 "level": "note"
               },
+              "helpUri": "http://example.org/TestSmellC",
               "id": "detekt.RuleSet2.TestSmellC",
               "name": "TestSmellC",
               "shortDescription": {


### PR DESCRIPTION
This reverts #7686 (it's not a `git revert`)

Now we have versioned urls (#7973 and #7970) and we also allow to customize it for third parties (#7717). So it have sense to display this on our SARIF report.