### PR TITLE
Fix `RulesWhichCantBeCorrectedSpec`

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
@@ -1,7 +1,5 @@
 package io.gitlab.arturbosch.detekt.formatting
 
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.formatting.wrappers.EnumEntryNameCase
 import io.gitlab.arturbosch.detekt.formatting.wrappers.Filename
 import io.gitlab.arturbosch.detekt.formatting.wrappers.ImportOrdering
@@ -9,23 +7,26 @@ import io.gitlab.arturbosch.detekt.formatting.wrappers.Indentation
 import io.gitlab.arturbosch.detekt.formatting.wrappers.MaximumLineLength
 import io.gitlab.arturbosch.detekt.formatting.wrappers.NoWildcardImports
 import io.gitlab.arturbosch.detekt.formatting.wrappers.PackageName
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import org.junit.jupiter.api.Test
 
 class RulesWhichCantBeCorrectedSpec {
 
+    private val autoCorrectConfig = TestConfig("autoCorrect" to true)
+
     @Test
     fun `Filename findings can't be corrected`() {
-        assertThat(Filename(Config.empty).lint("class NotTheFilename"))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(Filename(autoCorrectConfig).lint("class NotTheFilename"))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
     fun `PackageName findings can't be corrected`() {
-        assertThat(PackageName(Config.empty).lint("package under_score"))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(PackageName(autoCorrectConfig).lint("package under_score"))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
@@ -35,32 +36,32 @@ class RulesWhichCantBeCorrectedSpec {
             /*comment in between*/
             import java.io.*
         """.trimIndent()
-        assertThat(ImportOrdering(Config.empty).lint(code))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(ImportOrdering(autoCorrectConfig).lint(code))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
     fun `NoWildcardImports can't be corrected`() {
-        assertThat(NoWildcardImports(Config.empty).lint("import java.io.*"))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(NoWildcardImports(autoCorrectConfig).lint("import java.io.*"))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
     fun `MaximumLineLength can't be corrected`() {
         val code =
             "class MaximumLeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeth"
-        assertThat(MaximumLineLength(Config.empty).lint(code))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(MaximumLineLength(autoCorrectConfig).lint(code))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
     fun `EnumEntryNameCase can't be corrected`() {
-        assertThat(EnumEntryNameCase(Config.empty).lint("enum class Enum { violation_triggering_name }"))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(EnumEntryNameCase(autoCorrectConfig).lint("enum class Enum { violation_triggering_name }"))
+            .singleElement()
+            .noSuppress()
     }
 
     @Test
@@ -73,8 +74,8 @@ class RulesWhichCantBeCorrectedSpec {
                 $multilineQuote.trimIndent()
         """.trimIndent()
 
-        assertThat(Indentation(Config.empty).lint(code))
-            .isNotEmpty
-            .hasExactlyElementsOfTypes(CodeSmell::class.java)
+        assertThat(Indentation(autoCorrectConfig).lint(code))
+            .singleElement()
+            .noSuppress()
     }
 }

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/RulesWhichCantBeCorrectedSpec.kt
@@ -30,15 +30,13 @@ class RulesWhichCantBeCorrectedSpec {
 
     @Test
     fun `ImportOrdering has a case with comments which is not correctable`() {
-        assertThat(
-            ImportOrdering(Config.empty).lint(
-                """
-                    import xyz.wrong_order
-                    /*comment in between*/
-                    import java.io.*
-                """.trimIndent()
-            )
-        ).isNotEmpty
+        val code = """
+            import xyz.wrong_order
+            /*comment in between*/
+            import java.io.*
+        """.trimIndent()
+        assertThat(ImportOrdering(Config.empty).lint(code))
+            .isNotEmpty
             .hasExactlyElementsOfTypes(CodeSmell::class.java)
     }
 
@@ -51,13 +49,10 @@ class RulesWhichCantBeCorrectedSpec {
 
     @Test
     fun `MaximumLineLength can't be corrected`() {
-        assertThat(
-            MaximumLineLength(Config.empty).lint(
-                """
-                    class MaximumLeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeth
-                """.trimIndent()
-            )
-        ).isNotEmpty
+        val code =
+            "class MaximumLeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeth"
+        assertThat(MaximumLineLength(Config.empty).lint(code))
+            .isNotEmpty
             .hasExactlyElementsOfTypes(CodeSmell::class.java)
     }
 
@@ -70,7 +65,7 @@ class RulesWhichCantBeCorrectedSpec {
 
     @Test
     fun `Indentation finding inside string templates can't be corrected`() {
-        val multilineQuote = "${'"'}${'"'}${'"'}"
+        val multilineQuote = "\"\"\""
         val code = """
             val foo = $multilineQuote
                   line1

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -8,6 +8,7 @@ public final class io/gitlab/arturbosch/detekt/test/FindingAssert : org/assertj/
 	public final fun getActual ()Lio/gitlab/arturbosch/detekt/api/Finding;
 	public final fun hasMessage (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/test/FindingAssert;
 	public final fun hasSourceLocation (II)Lio/gitlab/arturbosch/detekt/test/FindingAssert;
+	public final fun noSuppress ()Lio/gitlab/arturbosch/detekt/test/FindingAssert;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/FindingExtensionsKt {

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/FindingsAssertions.kt
@@ -126,4 +126,12 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
             failWithMessage("Expected message <$expectedMessage> but actual message was <${actual?.message}>")
         }
     }
+
+    fun noSuppress() = apply {
+        if (actual == null) {
+            failWithMessage("Expect no null")
+        } else if (actual.suppressReasons.isNotEmpty()) {
+            failWithMessage("Expect no suppressions but ${actual.suppressReasons} was found")
+        }
+    }
 }


### PR DESCRIPTION
While doing #7870 I realized that at some point I make this tests useless. They were testing nothing. This PR brings back their original intention.