### PR TITLE
Report ignored return values of functions that return a lambda (#7967)

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -473,6 +473,7 @@ potential-bugs:
       - 'CanIgnoreReturnValue'
       - '*.CanIgnoreReturnValue'
     returnValueTypes:
+      - 'kotlin.Function*'
       - 'kotlin.sequences.Sequence'
       - 'kotlinx.coroutines.flow.*Flow'
       - 'java.util.stream.*Stream'

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValue.kt
@@ -84,6 +84,7 @@ class IgnoredReturnValue(config: Config) :
     @Configuration("List of return types that should not be ignored")
     private val returnValueTypes: List<Regex> by config(
         listOf(
+            "kotlin.Function*",
             "kotlin.sequences.Sequence",
             "kotlinx.coroutines.flow.*Flow",
             "java.util.stream.*Stream",

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1144,6 +1144,60 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }
+
+        @Test
+        fun `reports when result of function returning lambda is ignored`() {
+            val code = """
+                fun returnsALambda(): () -> Int = {
+                    42
+                }
+                
+                fun foo() : Int {
+                    returnsALambda()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasSourceLocation(6, 5)
+                .hasMessage("The call returnsALambda is returning a value that is ignored.")
+        }
+
+        @Test
+        fun `reports when result of function returning lambda with arguments is ignored`() {
+            val code = """
+                fun returnsALambda(): (Boolean, String) -> Int = { _, _ ->
+                    42
+                }
+                
+                fun foo() : Int {
+                    returnsALambda()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasSourceLocation(6, 5)
+                .hasMessage("The call returnsALambda is returning a value that is ignored.")
+        }
+
+        @Test
+        fun `doesn't report when result of function returning lambda is ignored`() {
+            val code = """
+                fun returnsALambda(): () -> Int = {
+                    42
+                }
+                
+                fun foo() : Int {
+                    returnsALambda().invoke()
+                    return 42
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
Apply #7967 again after #7984 reverted it