### PR TITLE
Replace APIs drop down with single link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -130,19 +130,9 @@ const config = {
             position: "left",
           },
           {
+            to: "https://detekt.dev/kdoc/",
             label: "APIs",
-            type: "dropdown",
             position: "left",
-            items: [
-              {
-                href: "https://detekt.dev/kdoc/",
-                label: "Core APIs",
-              },
-              {
-                href: "https://detekt.dev/kdoc/detekt-gradle-plugin/",
-                label: "Gradle Plugin APIs",
-              },
-            ],
           },
           {
             to: "/marketplace",


### PR DESCRIPTION
Now DGP API is documented alongside the other modules we can use a single link for API documentation.