### PR TITLE
Switched to use ktlint version ref for the ruleset

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ coroutines = "1.10.1"
 jacoco = "0.8.12"
 junit = "5.12.0"
 kotlin = "2.1.10"
-ktlint = "1.3.1"
 slf4j = "2.0.16"
 
 jvm-target = "1.8"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ coroutines = "1.10.1"
 jacoco = "0.8.12"
 junit = "5.12.0"
 kotlin = "2.1.10"
+ktlint = "1.5.0"
 slf4j = "2.0.16"
 
 jvm-target = "1.8"
@@ -35,7 +36,7 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.re
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotlinx-html = { module = "org.jetbrains.kotlinx:kotlinx-html-jvm", version = "0.12.0" }
-ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version = "1.5.0"  }
+ktlint-rulesetStandard = { module = "com.pinterest.ktlint:ktlint-ruleset-standard", version.ref = "ktlint"  }
 poko-annotations = { module = "dev.drewhamilton.poko:poko-annotations", version = "0.18.2" }
 sarif4k = { module = "io.github.detekt.sarif4k:sarif4k", version = "0.6.0" }
 semver4j = { module = "org.semver4j:semver4j", version = "5.6.0" }


### PR DESCRIPTION
The Gradle version ref for ktlint was pointing to **1.3.1**, while the `ktlint-ruleset-standard` library was pointing to **1.5.0**. So I propose updating the version ref and using it for the ruleset.