### PR TITLE
Add UnnecessaryTypeCasting rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -417,6 +417,8 @@ performance:
     active: false
   UnnecessaryTemporaryInstantiation:
     active: true
+  UnnecessaryTypeCasting:
+    active: false
 
 potential-bugs:
   active: true

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/PerformanceProvider.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/PerformanceProvider.kt
@@ -18,6 +18,7 @@ class PerformanceProvider : DefaultRuleSetProvider {
             ::ForEachOnRange,
             ::SpreadOperator,
             ::UnnecessaryTemporaryInstantiation,
+            ::UnnecessaryTypeCasting,
             ::ArrayPrimitive,
             ::CouldBeSequence,
             ::UnnecessaryPartOfBinaryExpression,

--- a/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCasting.kt
+++ b/detekt-rules-performance/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCasting.kt
@@ -1,0 +1,55 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtBinaryExpression
+import org.jetbrains.kotlin.psi.KtBinaryExpressionWithTypeRHS
+
+/**
+ * Reports cast of unnecessary type casting. Cases like this can be
+ * replaced with type checking for performance reasons.
+ *
+ * <noncompliant>
+ * fun foo() {
+ *  val objList: List<Any> = emptyList()
+ *  objList.any { it as? String != null }
+ * }
+ * </noncompliant>
+ *
+ * <compliant>
+ * fun foo() {
+ *  val objList: List<Any> = emptyList()
+ *  objList.any { it is String }
+ * }
+ * </compliant>
+ */
+class UnnecessaryTypeCasting(config: Config) :
+    Rule(
+        config,
+        "Unnecessary type casting is found. Consider using type checking."
+    ) {
+
+    @Suppress("ReturnCount")
+    override fun visitBinaryWithTypeRHSExpression(expression: KtBinaryExpressionWithTypeRHS) {
+        super.visitBinaryWithTypeRHSExpression(expression)
+
+        val operationReference = expression.operationReference
+        if (operationReference.getReferencedNameElementType() != KtTokens.AS_SAFE) return
+
+        val parent = expression.parent as? KtBinaryExpression ?: return
+        if (parent.operationReference.getReferencedNameElementType() != KtTokens.EXCLEQ) return
+
+        if (parent.right?.text != KtTokens.NULL_KEYWORD.value &&
+            parent.left?.text != KtTokens.NULL_KEYWORD.value
+        ) {
+            return
+        }
+
+        val message =
+            "Unnecessary type casting, which can cause perf issues. Use type checking instead."
+        report(Finding(Entity.from(operationReference), message))
+    }
+}

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
@@ -71,11 +71,9 @@ class UnnecessaryTypeCastingSpec {
     @Test
     fun `does not report type casting when stored in variable`() {
         val code = """
-            fun foo() {
-                val objList: List<Any> = emptyList()
-                val castResult = it as? String
-                objList.any { castResult != null }
-
+            fun foo(any: Any) {
+                val castResult = any as? String
+                print(castResult)
             }
         """.trimIndent()
 
@@ -87,7 +85,7 @@ class UnnecessaryTypeCastingSpec {
         val code = """
             fun foo() {
                 val objList: List<Any> = emptyList()
-                objList.any { it as String }
+                objList.any { it as String != null }
             }
         """.trimIndent()
 

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
@@ -1,0 +1,60 @@
+package io.gitlab.arturbosch.detekt.rules.performance
+
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.lint
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class UnnecessaryTypeCastingSpec {
+    private val subject = UnnecessaryTypeCasting(Config.empty)
+
+    @Test
+    fun `reports unnecessary type casting instead of type checking`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { it as? String != null }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report type checking`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { it is String }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report used type casting`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { it as? String != "foo" }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report type casting when stored in variable`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                val castResult = it as? String
+                objList.any { castResult != null }
+
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).isEmpty()
+    }
+}

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/UnnecessaryTypeCastingSpec.kt
@@ -21,6 +21,18 @@ class UnnecessaryTypeCastingSpec {
     }
 
     @Test
+    fun `reports unnecessary type casting with null checking on left side`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { null != it as? String }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).hasSize(1)
+    }
+
+    @Test
     fun `does not report type checking`() {
         val code = """
             fun foo() {
@@ -45,6 +57,18 @@ class UnnecessaryTypeCastingSpec {
     }
 
     @Test
+    fun `does not report used type casting with equal op`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { "foo" == it as? String }
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).isEmpty()
+    }
+
+    @Test
     fun `does not report type casting when stored in variable`() {
         val code = """
             fun foo() {
@@ -52,6 +76,18 @@ class UnnecessaryTypeCastingSpec {
                 val castResult = it as? String
                 objList.any { castResult != null }
 
+            }
+        """.trimIndent()
+
+        assertThat(subject.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report unsafe type casting`() {
+        val code = """
+            fun foo() {
+                val objList: List<Any> = emptyList()
+                objList.any { it as String }
             }
         """.trimIndent()
 


### PR DESCRIPTION
This PR adds a new Performance rule: `UnnecessaryTypeCasting`.
Context about this has been discussed in #7860.

## UnnecessaryTypeCasting
### Explanation
 * Checks Binary expressions where operation token is `as?`
 * Checks if the previous expression is a `BinaryExpression` with op token `!=` and one of the terms is `null`.

In this case (`variable as? String != null`), it reports a violation.

### Exceptions
Violation is not reported when cast result is stored in another variable, since it could be used later.

We don't detect if the variable is actually used in other parts of the code since it would complicate the rule, and possibly need type resolution. In case we want to pursue this use case as well, we could have 2 variants of the same rule with and without type resolution.

### Example
Non-compliant code:

```kotlin
variable as? String != null
```

Compliant code:
```kotlin
variable is String
```

Close #7860 
