### PR TITLE
Don't fail when adding new aliases

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/config/validation/ConfigValidation.kt
@@ -28,6 +28,7 @@ internal val DEFAULT_PROPERTY_EXCLUDES = setOf(
     ".*>.*>active",
     ".*>.*>autoCorrect",
     ".*>severity",
+    ".*>.*>aliases",
     ".*>.*>severity",
     ".*>.*>ignoreAnnotated",
     ".*>.*>ignoreFunction",

--- a/detekt-core/src/test/resources/common_known_sections.yml
+++ b/detekt-core/src/test/resources/common_known_sections.yml
@@ -11,3 +11,7 @@ console-reports:
   active: true
   exclude:
     - 'FileBasedFindingsReport'
+
+potential-bugs:
+  UnusedUnaryOperator:
+    aliases: ['an-alias']


### PR DESCRIPTION
This issues was added with #7312. Well, in that issue we added the option to customize `aliases` but I forgot to allow that configuration in all the rules.

Fixes #7816