### PR TITLE
Make code more explicit - minor refactor

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/Analyzer.kt
@@ -48,9 +48,10 @@ internal class Analyzer(
     ): List<Issue> =
         ktFiles.flatMap { file ->
             processors.forEach { it.onProcess(file) }
-            val issues = runCatching { analyze(file, compilerResources) }
-                .onFailure { throwIllegalStateException(file, it) }
-                .getOrDefault(emptyList())
+            val issues = runCatching { analyze(file, compilerResources) }.fold(
+                onSuccess = { it },
+                onFailure = { throwIllegalStateException(file, it) }
+            )
             processors.forEach { it.onProcessComplete(file, issues) }
             issues
         }


### PR DESCRIPTION
This change doesn't change any behaviour. It only makes the code easier to read. We never were using the `default` value because if we had a failure we were raising an exception before that point.

Using `fold` the code is more clear. If it's success we return the value. If it's a failure we throw an exception. There are not default values.