### PR TITLE
Configure CLI options file generation entirely in detekt-generator project

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.apache.tools.ant.filters.ReplaceTokens
-import java.io.ByteArrayOutputStream
 
 plugins {
     id("com.gradleup.shadow") version "8.3.6"
@@ -55,8 +54,6 @@ publishing {
     }
 }
 
-val generatedCliUsage: Configuration by configurations.consumable("generatedCliUsage")
-
 tasks {
     shadowJar {
         mergeServiceFiles()
@@ -100,25 +97,6 @@ tasks {
     check {
         dependsOn(runWithHelpFlag, runWithArgsFile)
     }
-
-    val cliUsage by registering(JavaExec::class) {
-        val cliUsagesOutput = layout.buildDirectory.file("output/cli-usage.md")
-        outputs.file(cliUsagesOutput)
-        classpath = files(shadowJar)
-        args = listOf("--help")
-        doFirst {
-            standardOutput = ByteArrayOutputStream()
-        }
-        doLast {
-            cliUsagesOutput.get().asFile.apply {
-                writeText("```\n")
-                appendBytes((standardOutput as ByteArrayOutputStream).toByteArray())
-                appendText("```\n")
-            }
-        }
-    }
-
-    artifacts.add(generatedCliUsage.name, cliUsage)
 }
 
 val shadowDist: Configuration by configurations.consumable("shadowDist")

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.ByteArrayOutputStream
+
 plugins {
     id("com.gradleup.shadow") version "8.3.6"
     id("module")
@@ -8,18 +10,16 @@ application {
     mainClass = "io.gitlab.arturbosch.detekt.generator.Main"
 }
 
-val generatedUsage by configurations.dependencyScope("generatedUsage")
-val generatedUsageOutput by configurations.resolvable("generatedUsageOutput") {
-    extendsFrom(generatedUsage)
+val detektCli by configurations.dependencyScope("detektCli")
+val detektCliClasspath by configurations.resolvable("detektCliClasspath") {
+    extendsFrom(detektCli)
 }
 
 dependencies {
     implementation(projects.detektParser)
     implementation(projects.detektApi)
     implementation(projects.detektPsiUtils)
-    generatedUsage(projects.detektCli) {
-        targetConfiguration = "generatedCliUsage"
-    }
+    detektCli(projects.detektCli)
     implementation(projects.detektUtils)
     implementation(libs.jcommander)
 
@@ -30,6 +30,25 @@ dependencies {
     testRuntimeOnly(projects.detektRules)
 }
 
+val generateCliOptions by tasks.registering(JavaExec::class) {
+    classpath = detektCliClasspath
+    mainClass = "io.gitlab.arturbosch.detekt.cli.Main"
+    args = listOf("--help")
+
+    val cliOptionsOutput = isolated.rootProject.projectDirectory.file("website/docs/gettingstarted/_cli-options.md")
+    outputs.file(cliOptionsOutput)
+    doFirst {
+        standardOutput = ByteArrayOutputStream()
+    }
+    doLast {
+        cliOptionsOutput.asFile.apply {
+            writeText("```\n")
+            appendBytes((standardOutput as ByteArrayOutputStream).toByteArray())
+            appendText("```\n")
+        }
+    }
+}
+
 val documentationDir = "$rootDir/website/docs/rules"
 val configDir = "$rootDir/detekt-core/src/main/resources"
 val defaultConfigFile = "$configDir/default-detekt-config.yml"
@@ -38,14 +57,9 @@ val formattingConfigFile = "$rootDir/detekt-formatting/src/main/resources/config
 val librariesConfigFile = "$rootDir/detekt-rules-libraries/src/main/resources/config/config.yml"
 val ruleauthorsConfigFile = "$rootDir/detekt-rules-ruleauthors/src/main/resources/config/config.yml"
 
-val copyDetektCliUsage by tasks.registering(Copy::class) {
-    from(generatedUsageOutput) { rename { "_cli-options.md" } }
-    destinationDir = rootDir.resolve("website/docs/gettingstarted")
-}
-
 tasks.register("generateWebsite") {
     dependsOn(
-        copyDetektCliUsage,
+        generateCliOptions,
         generateDocumentation,
         ":dokkaGenerate",
         gradle.includedBuild("detekt-gradle-plugin").task(":dokkaGenerate"),


### PR DESCRIPTION
Simplifies things a little bit and keeps the responsibility for generating CLI options file within the detekt-generator project where it belongs.