### PR TITLE
UnusedParameter: add ignored function/parameter annotation config options

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -797,6 +797,8 @@ style:
     active: true
     aliases: ['UNUSED_PARAMETER', 'unused']
     allowedNames: 'ignored|expected'
+    ignoreAnnotatedFunctions: []
+    ignoreAnnotatedParameters: []
   UnusedPrivateClass:
     active: true
     aliases: ['unused']

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameter.kt
@@ -9,6 +9,7 @@ import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.config
+import io.gitlab.arturbosch.detekt.rules.hasAnnotation
 import io.gitlab.arturbosch.detekt.rules.isAbstract
 import io.gitlab.arturbosch.detekt.rules.isActual
 import io.gitlab.arturbosch.detekt.rules.isExpect

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -1,9 +1,8 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
-import io.gitlab.arturbosch.detekt.test.TestConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -173,7 +173,7 @@ class UnusedParameterSpec {
         }
     }
 
-    @nested
+    @Nested
     inner class `ignored by config` {
         @Test
         fun `does not report parameters with allowed names`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -187,6 +187,18 @@ class UnusedParameterSpec {
         }
 
         @Test
+        fun `reports parameters with disallowed names`() {
+            val code = """
+                fun foo(ignored: Int, notIgnored: Int){}
+            """.trimIndent()
+
+            val lint = subject.lint(code)
+
+            assertThat(lint).hasSize(1)
+            assertThat(lint[0].message).isEqualTo("Function parameter `notIgnored` is unused.")
+        }
+
+        @Test
         fun `does not report functions with listed annotation`() {
             val code = """
                 annotation class IgnoredFunction


### PR DESCRIPTION
<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

I have a use case where I want Detekt to ignore unused parameters in functions annotated with my custom annotation, so I've added the option to the config. I also added a similar option for the parameters themselves.

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
