### PR TITLE
ForbiddenMethodCall: add forbidden method config options

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -219,6 +219,7 @@ style:
       - 'java.lang.Class.getResourceAsStream'
       - 'java.lang.ClassLoader.getResourceAsStream'
       - 'kotlin.system.measureTimeMillis'
+      - 'kotlin.lazy(() -> kotlin.Any)'
   ForbiddenVoid:
     active: true
     ignoreOverridden: true

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -646,6 +646,8 @@ style:
         value: 'java.math.BigDecimal.<init>(kotlin.String)'
       - reason: 'It is marked as obsolete. Use `kotlin.time.measureTime` instead.'
         value: 'kotlin.system.measureTimeMillis'
+      - reason: 'Must use `lazy(LazyThreadSafetyMode.PUBLICATION)` for performance and also compatibility with JVM virtual thread'
+        value: 'kotlin.lazy(() -> kotlin.Any)'
   ForbiddenNamedParam:
     active: false
     methods: []

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCall.kt
@@ -72,6 +72,8 @@ class ForbiddenMethodCall(config: Config) :
             "java.math.BigDecimal.<init>(kotlin.String)" to "using `BigDecimal(String)` can result in a " +
                 "`NumberFormatException`. Use `String.toBigDecimalOrNull()`",
             "kotlin.system.measureTimeMillis" to "It is marked as obsolete. Use `kotlin.time.measureTime` instead.",
+            "kotlin.lazy(() -> kotlin.Any)" to "Must use `lazy(LazyThreadSafetyMode.PUBLICATION)` for performance " +
+                "and also compatibility with JVM virtual thread"
         )
     ) { list ->
         list.map { ForbiddenMethod(fromFunctionSignature(it.value), it.reason) }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -684,6 +684,31 @@ class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
     }
 
     @Nested
+    inner class `configure LazyThreadSafetyMode #7823` {
+        @Test
+        fun `should detect forbidden lazy call`() {
+            val code = """
+                fun main() {
+                    val lazyValue = lazy { "Hello" } 
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `recommended lazy call`() {
+            val code = """
+                fun main() {
+                    val lazyValue = lazy(LazyThreadSafetyMode.PUBLICATION) { "Hello" } 
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(TestConfig()).lintWithContext(env, code)
+            assertThat(findings).hasSize(0)
+        }
+    }
+
+    @Nested
     inner class `Forbid constructors` {
         @Nested
         inner class NameOnly {


### PR DESCRIPTION
<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

I modified the code after looking at issue #7823.

I suggested how to configure `ForbiddenMethodCall` for function type parameters in the documentation and improves its enforcement by ensuring that `lazy {}` is replaced with `lazy(LazyThreadSafetyMode.PUBLICATION) {}`.

This PR only enforces lazy {} to use LazyThreadSafetyMode.PUBLICATION, not other modes.


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
