### PR TITLE
Use kotlin-scripting-compiler dependency for kotlin-main-kts

### DIFF
--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -7,7 +7,11 @@ dependencies {
     api(libs.kotlin.stdlib)
     api(libs.junit.jupiterApi)
     implementation(projects.detektParser)
-    implementation(libs.kotlin.mainKts)
+    implementation(libs.kotlin.mainKts) {
+        // Manually add the kotlin-scripting-compiler dependency instead to avoid future conflicts with Analysis API dependencies.
+        isTransitive = false
+    }
+    implementation(libs.kotlin.scriptingCompiler)
     implementation(libs.kotlinx.coroutinesCore)
 
     testImplementation(libs.assertj.core)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-emb
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-mainKts = { module = "org.jetbrains.kotlin:kotlin-main-kts", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-scriptingCompiler = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
The scripting-compiler-embeddable dependency used by kotlin-main-kts is not compatible with the dependencies required by the Analysis API. The non-embeddable kotlin-scripting-compiler lib works with the current kotlin-scripting version of test snippet compilation and will work with Analysis API as well so both can be used in parallel in future.

Required for #8027 

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
