### PR TITLE
Limit Renovate to checking specific repositories for Gradle dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,6 +13,14 @@
   ],
   "packageRules": [
     {
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://repo.maven.apache.org/maven2",
+        "https://plugins.gradle.org/m2/",
+        "https://dl.google.com/android/maven2/"
+      ],
+    },
+    {
       "groupName": "Dokka",
       "matchPackageNames": [
         "org.jetbrains.dokka:**"


### PR DESCRIPTION
Renovate currently auto-detects 4 repos, the three explicitly listed here as well as https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-ide-plugin-dependencies

Checking the jetbrains.space repo seems to be adding a lot of time to the Renovate job which is causing it to time out and fail. This should fix that while not having any impact on any dependency updates that detekt cares about.

This means Renovate won't check for updates to *-for-ide packages anymore, but those should be synced with Kotlin updates anyway, so this won't be an issue.

Should fix #8052, and avoid creating unhelpful PRs like #8035.