### PR TITLE
Allow creation of BindingContext in tests without KotlinCoreEnvironment

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -266,6 +266,9 @@ public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImp
 	public static fun transformIssues (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/List;)Ljava/util/List;
 }
 
+public abstract interface class io/gitlab/arturbosch/detekt/api/RequiresAnalysisApi {
+}
+
 public abstract interface class io/gitlab/arturbosch/detekt/api/RequiresFullAnalysis {
 }
 

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -19,6 +19,10 @@ detekt {
     config.from("config/detekt.yml")
 }
 
+tasks.detektTest {
+    debug = true
+}
+
 val javaComponent = components["java"] as AdhocComponentWithVariants
 listOf(configurations.testFixturesApiElements, configurations.testFixturesRuntimeElements).forEach { config ->
     config.configure {

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Location.kt
@@ -38,7 +38,7 @@ class Location(
                 sourceLocation,
                 endSourceLocation,
                 textLocation,
-                Path((element.containingFile as KtFile).virtualFilePath)
+                Path(element.containingFile.viewProvider.virtualFile.path)
             )
         }
 

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RequiresAnalysisApi.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RequiresAnalysisApi.kt
@@ -1,0 +1,8 @@
+package io.gitlab.arturbosch.detekt.api
+
+/**
+ * Interface to let the core know that this [Rule] uses the Analysis API
+ *
+ * The core will only run your [Rule] if it is running in FullAnalysis mode.
+ */
+interface RequiresAnalysisApi

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(projects.detektApi)
     api(projects.detektParser)
     api(projects.detektTooling)
+    implementation(projects.detektKotlinAnalysisApi)
     implementation(libs.snakeyaml.engine)
     implementation(libs.kotlin.reflect)
     implementation(projects.detektMetrics)

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -69,7 +69,13 @@ internal class DefaultLifecycle(
     override val bindingProvider: (files: List<KtFile>) -> BindingContext =
         {
             if (settings.spec.projectSpec.analysisMode == AnalysisMode.full) {
-                generateBindingContext(settings.environment, it, settings::debug, settings::info)
+                generateBindingContext(
+                    settings.environment.project,
+                    settings.environment.configuration,
+                    it,
+                    settings::debug,
+                    settings::info
+                )
             } else {
                 BindingContext.EMPTY
             }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.psi.KtFile
 typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
 
 val inputPathsToKtFiles: ParsingStrategy = { settings ->
-    val compiler = KtCompiler(settings.environment)
+    val compiler = KtCompiler(settings.environment.project)
     settings.spec.projectSpec.inputPaths.map { path ->
         compiler.compile(path)
     }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -7,6 +7,6 @@ import org.jetbrains.kotlin.psi.KtFile
 typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
 
 val inputPathsToKtFiles: ParsingStrategy = { settings ->
-    val compiler = KtCompiler(settings.spec.projectSpec.inputPaths)
-    compiler.analysisSession.modulesWithFiles.entries.single().value.map { it as KtFile }
+    val compiler = KtCompiler(settings.spec.projectSpec.inputPaths, settings.environment.configuration)
+    compiler.files
 }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/ParsingStrategy.kt
@@ -7,8 +7,6 @@ import org.jetbrains.kotlin.psi.KtFile
 typealias ParsingStrategy = (settings: ProcessingSettings) -> List<KtFile>
 
 val inputPathsToKtFiles: ParsingStrategy = { settings ->
-    val compiler = KtCompiler(settings.environment.project)
-    settings.spec.projectSpec.inputPaths.map { path ->
-        compiler.compile(path)
-    }
+    val compiler = KtCompiler(settings.spec.projectSpec.inputPaths)
+    compiler.analysisSession.modulesWithFiles.entries.single().value.map { it as KtFile }
 }

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.KtParameter
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
 @KotlinCoreEnvironmentTest
-class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
+class AnnotationSuppressorSpec(private val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class AnnotationSuppressorFactory {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -317,7 +317,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
             )
 
             val bindings = listOf(
-                env.createBindingContext(listOf(root, *composableFiles)),
+                createBindingContext(listOf(root, *composableFiles), env.configuration, env.project),
                 BindingContext.EMPTY,
             )
 
@@ -414,7 +414,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.createBindingContext(listOf(root, *composableFiles)),
+                createBindingContext(listOf(root, *composableFiles), env.configuration, env.project),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -435,7 +435,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.createBindingContext(listOf(root, *composableFiles)),
+                createBindingContext(listOf(root, *composableFiles), env.configuration, env.project),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -458,7 +458,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
 
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                env.createBindingContext(listOf(root, *composableFiles)),
+                createBindingContext(listOf(root, *composableFiles), env.configuration, env.project),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -501,7 +501,7 @@ class AnnotationSuppressorSpec(private val env: KotlinCoreEnvironment) {
         fun `suppress if it has parameters with type solving`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Preview")),
-                env.createBindingContext(listOf(root, *composableFiles)),
+                createBindingContext(listOf(root, *composableFiles), env.configuration, env.project),
             )!!
 
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 
 dependencies {
     api(libs.kotlin.compiler)
+    implementation(projects.detektKotlinAnalysisApi)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
@@ -1,19 +1,26 @@
 package io.github.detekt.parser
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.impl.jar.CoreJarFileSystem
+import com.intellij.openapi.vfs.local.CoreLocalFileSystem
+import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
 import org.jetbrains.kotlin.cli.common.messages.AnalyzerWithCompilerReport
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.cli.common.messages.PlainTextMessageRenderer
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
+import org.jetbrains.kotlin.cli.jvm.index.JavaRoot
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
 fun generateBindingContext(
-    environment: KotlinCoreEnvironment,
+    project: Project,
+    configuration: CompilerConfiguration,
     files: List<KtFile>,
     debugPrinter: (() -> String) -> Unit,
     warningPrinter: (String) -> Unit,
@@ -26,16 +33,35 @@ fun generateBindingContext(
 
     val analyzer = AnalyzerWithCompilerReport(
         messageCollector,
-        environment.configuration.languageVersionSettings,
+        configuration.languageVersionSettings,
         false,
     )
+
+    val vfsFs = CoreJarFileSystem()
+    val coreLocalFilesystem = CoreLocalFileSystem()
+
+    val jarJavaRoots = configuration.jvmClasspathRoots
+        .filter { it.extension == "jar" }
+        .mapNotNull { vfsFs.findFileByPath("${it.absolutePath}!/") }
+        .map { JavaRoot(it, JavaRoot.RootType.BINARY) }
+
+    val dirJavaRoots = configuration.jvmClasspathRoots
+        .filter { it.extension != "jar" }
+        .mapNotNull { coreLocalFilesystem.findFileByPath("${it.absolutePath}") }
+        .map { JavaRoot(it, JavaRoot.RootType.BINARY) }
+
+    val packagePartProvider = StandaloneProjectFactory.createPackagePartsProvider(
+        jarJavaRoots + dirJavaRoots,
+        configuration.languageVersionSettings
+    )
+
     analyzer.analyzeAndReport(files) {
         TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
-            environment.project,
+            project,
             files,
-            NoScopeRecordCliBindingTrace(environment.project),
-            environment.configuration,
-            environment::createPackagePartProvider
+            NoScopeRecordCliBindingTrace(project),
+            configuration,
+            packagePartProvider
         )
     }
 

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -7,52 +7,101 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.api.diagnostics.getDefaultMessageWithFactoryName
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
 import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
+import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JvmTarget
+import org.jetbrains.kotlin.config.friendPaths
+import org.jetbrains.kotlin.config.jdkHome
+import org.jetbrains.kotlin.config.jvmTarget
+import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.Path
 import kotlin.io.path.isRegularFile
 
 open class KtCompiler(
     protected val paths: Collection<Path> = emptySet(),
+    private val compilerConfiguration: CompilerConfiguration = CompilerConfiguration(),
 ) {
-    val analysisSession = buildStandaloneAnalysisAPISession {
-        @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
-        buildKtModuleProviderByCompilerConfiguration(CompilerConfiguration())
-
-        buildKtModuleProvider {
-            val targetPlatform = JvmPlatforms.defaultJvmPlatform
-            platform = targetPlatform
-
-            addModule(
-                buildKtSourceModule {
-                    addSourceRoots(paths)
-                    platform = targetPlatform
-                    moduleName = "source"
-                }
-            )
-        }
-
+    val analysisSession = buildStandaloneAnalysisAPISession(unitTestMode = true) {
         registerProjectService(PomModel::class.java, DetektPomModel)
         registerProjectService(ModuleVisibilityManager::class.java, CliModuleVisibilityManagerImpl(true))
+
+        buildKtModuleProvider {
+            val targetPlatform =
+                JvmPlatforms.jvmPlatformByTargetVersion(compilerConfiguration.jvmTarget ?: JvmTarget.DEFAULT)
+            platform = targetPlatform
+
+            val jdk = compilerConfiguration.jdkHome?.let { jdkHome ->
+                buildKtSdkModule {
+                    addBinaryRootsFromJdkHome(jdkHome.toPath(), isJre = false)
+                    platform = targetPlatform
+                    libraryName = "jdk"
+                }
+            }
+
+            val friendDependencyModules = compilerConfiguration.friendPaths.filter { it.contains("classes") }.map { friendPath ->
+                buildKtLibraryModule {
+                    platform = targetPlatform
+                    addBinaryRoot(Path(friendPath))
+                    libraryName = UUID.randomUUID().toString()
+                }
+            }
+
+            val regularDependencyModules = compilerConfiguration.jvmClasspathRoots.map { regularDependencyFile ->
+                buildKtLibraryModule {
+                    platform = targetPlatform
+                    addBinaryRoot(regularDependencyFile.toPath())
+                    libraryName = UUID.randomUUID().toString()
+                }
+            }
+
+            val sourceModule = buildKtSourceModule {
+//                addSourceRoots(compilerConfiguration.kotlinSourceRoots.map { Path(it.path) })
+                addSourceRoots(paths)
+                platform = targetPlatform
+                moduleName = "source"
+
+                jdk?.let { addRegularDependency(it) }
+                friendDependencyModules.forEach { addFriendDependency(it) }
+                regularDependencyModules.forEach { addRegularDependency(it) }
+
+                languageVersionSettings = compilerConfiguration.languageVersionSettings
+            }
+
+            addModule(sourceModule)
+        }
     }
 
     protected val project = analysisSession.project
+    val files = analysisSession.modulesWithFiles.flatMap { it.value }.map { it as KtFile }
 
     init {
-        val files = analysisSession.modulesWithFiles.entries.single().value.map { it as KtFile }
-
-        files.forEach { ktFile ->
+        files.filter { it.virtualFilePath.contains("SignaturesSpec.kt") }.forEach { ktFile ->
             analyze(ktFile) {
                 val diagnostics = ktFile
                     .collectDiagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS)
 
-                println(diagnostics.joinToString("\n") {
-                    "${ktFile.viewProvider.virtualFile.toNioPath()}:${it.getDefaultMessageWithFactoryName()}"
-                })
+                if (diagnostics.isNotEmpty()) {
+                    print(diagnostics.joinToString("\n", postfix = "\n") {
+                        buildString {
+                            append(ktFile.viewProvider.virtualFile.toNioPath())
+                            append(":")
+                            append(PsiDiagnosticUtils.atLocation(it.psi))
+                            append(":")
+                            append(it.getDefaultMessageWithFactoryName())
+                        }
+//                        "${ktFile.viewProvider.virtualFile.toNioPath()}:${it.getDefaultMessageWithFactoryName()}"
+                    })
+                }
             }
         }
     }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -1,5 +1,6 @@
 package io.github.detekt.parser
 
+import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.psi.util.PsiUtilCore
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtFile
@@ -13,7 +14,10 @@ open class KtCompiler(
     fun compile(path: Path): KtFile {
         require(path.isRegularFile()) { "Given path '$path' should be a regular file!" }
 
-        val virtualFile = requireNotNull(environment.findLocalFile(path.toString()))
+        val virtualFile = requireNotNull(VirtualFileManager.getInstance().findFileByNioPath(path)) {
+            "$path cannot be retrieved as a VirtualFile"
+        }
+
         return requireNotNull(PsiUtilCore.getPsiFile(environment.project, virtualFile) as? KtFile) {
             "$path is not a Kotlin file"
         }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -5,7 +5,9 @@ import com.intellij.openapi.vfs.VirtualFileManager
 import com.intellij.pom.PomModel
 import com.intellij.psi.util.PsiUtilCore
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
@@ -32,4 +34,5 @@ private fun createDefaultProject(): Project = buildStandaloneAnalysisAPISession 
     buildKtModuleProviderByCompilerConfiguration(CompilerConfiguration())
 
     registerProjectService(PomModel::class.java, DetektPomModel)
+    registerProjectService(ModuleVisibilityManager::class.java, CliModuleVisibilityManagerImpl(true))
 }.project

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KtCompiler.kt
@@ -1,14 +1,21 @@
 package io.github.detekt.parser
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.vfs.VirtualFileManager
+import com.intellij.pom.PomModel
 import com.intellij.psi.util.PsiUtilCore
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
+import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreApplicationEnvironmentMode
+import org.jetbrains.kotlin.cli.jvm.compiler.setupIdeaStandaloneExecution
+import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.isRegularFile
 
 open class KtCompiler(
-    protected val environment: KotlinCoreEnvironment = createKotlinCoreEnvironment(printStream = System.err),
+    protected val project: Project = createDefaultProject(),
 ) {
 
     fun compile(path: Path): KtFile {
@@ -18,8 +25,22 @@ open class KtCompiler(
             "$path cannot be retrieved as a VirtualFile"
         }
 
-        return requireNotNull(PsiUtilCore.getPsiFile(environment.project, virtualFile) as? KtFile) {
+        return requireNotNull(PsiUtilCore.getPsiFile(project, virtualFile) as? KtFile) {
             "$path is not a Kotlin file"
         }
     }
+}
+
+private fun createDefaultProject(): Project {
+    setupIdeaStandaloneExecution()
+
+    val project = StandaloneProjectFactory.createProjectEnvironment(
+        Disposer.newDisposable(),
+        KotlinCoreApplicationEnvironmentMode.fromUnitTestModeFlag(false)
+    ).project
+
+    project.registerService(PomModel::class.java, DetektPomModel)
+    project.registerService(ModuleVisibilityManager::class.java, CliModuleVisibilityManagerImpl(true))
+
+    return project
 }

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.psi
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFunction
@@ -16,7 +16,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 
 @KotlinCoreEnvironmentTest
-class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
+class AnnotationExcluderSpec(private val env: KotlinEnvironmentContainer) {
     private val annotationsKtFile = compileContentForTest(
         """
             package dagger

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/AnnotationExcluderSpec.kt
@@ -44,7 +44,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases - Type Solving`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation)
-        val binding = env.createBindingContext(listOf(file, annotationsKtFile))
+        val binding = createBindingContext(listOf(file, annotationsKtFile), env.configuration, env.project)
         val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), binding)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
@@ -94,7 +94,7 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
             @Test
             fun `correct without type solving`() {
                 val (file, ktAnnotation) = createKtFile("@Deprecated")
-                val binding = env.createBindingContext(listOf(file, annotationsKtFile))
+                val binding = createBindingContext(listOf(file, annotationsKtFile), env.configuration, env.project)
                 val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -132,7 +132,11 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
             @Test
             @Disabled("This should be doable but it's not imlemented yet")
             fun `correct with type solving`() {
-                val binding = env.createBindingContext(listOf(file, helloWorldAnnotationsKtFile))
+                val binding = createBindingContext(
+                    listOf(file, helloWorldAnnotationsKtFile),
+                    env.configuration,
+                    env.project
+                )
                 val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -173,7 +177,11 @@ class AnnotationExcluderSpec(private val env: KotlinCoreEnvironment) {
 
             @Test
             fun `correct with type solving`() {
-                val binding = env.createBindingContext(listOf(file, helloWorldAnnotationsKtFile))
+                val binding = createBindingContext(
+                    listOf(file, helloWorldAnnotationsKtFile),
+                    env.configuration,
+                    env.project
+                )
                 val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), binding)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.psi
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.createBindingContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.findFunctionByName
@@ -18,7 +18,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 @KotlinCoreEnvironmentTest
-class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
+class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
 
     @TestFactory
     @Suppress("LongMethod")
@@ -345,7 +345,7 @@ private class TestCase(
 )
 
 private fun buildKtFunction(
-    environment: KotlinCoreEnvironment,
+    environment: KotlinEnvironmentContainer,
     code: String,
     includePackage: Boolean = true,
 ): Pair<KtNamedFunction, BindingContext> {

--- a/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/io/github/detekt/psi/FunctionMatcherSpec.kt
@@ -328,7 +328,7 @@ class FunctionMatcherSpec(private val env: KotlinCoreEnvironment) {
                     }
                 """.trimIndent()
             )
-            val bindingContext = env.createBindingContext(listOf(ktFile))
+            val bindingContext = createBindingContext(listOf(ktFile), env.configuration, env.project)
             val function = ktFile.findChildByClass(KtClass::class.java)!!
                 .findFunctionByName("bar") as KtNamedFunction
 
@@ -355,6 +355,6 @@ private fun buildKtFunction(
             $code
         """.trimIndent()
     )
-    val bindingContext = environment.createBindingContext(listOf(ktFile))
+    val bindingContext = createBindingContext(listOf(ktFile), environment.configuration, environment.project)
     return ktFile.findChildByClass(KtNamedFunction::class.java)!! to bindingContext
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LongParameterListSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class LongParameterListSpec(private val env: KotlinCoreEnvironment) {
+class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
     private val defaultMaximumParameters = 2
     private val defaultConfig = TestConfig(
         "allowedFunctionParameters" to defaultMaximumParameters,

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NamedArgumentsSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NamedArgumentsSpec(val env: KotlinCoreEnvironment) {
+class NamedArgumentsSpec(val env: KotlinEnvironmentContainer) {
     private val defaultAllowedArguments = 2
     private val defaultConfig = TestConfig("allowedArguments" to defaultAllowedArguments)
     val subject = NamedArguments(defaultConfig)

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NestedScopeFunctionsSpec(private val env: KotlinCoreEnvironment) {
+class NestedScopeFunctionsSpec(private val env: KotlinEnvironmentContainer) {
 
     private val defaultConfig = TestConfig(
         "allowedDepth" to 1,

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/ReplaceSafeCallChainWithRunSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.complexity
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ReplaceSafeCallChainWithRunSpec(val env: KotlinCoreEnvironment) {
+class ReplaceSafeCallChainWithRunSpec(val env: KotlinEnvironmentContainer) {
 
     val subject = ReplaceSafeCallChainWithRun(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
@@ -7,13 +8,12 @@ import io.gitlab.arturbosch.detekt.test.createBindingContext
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import io.gitlab.arturbosch.detekt.test.location
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvironment) {
+class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinEnvironmentContainer) {
 
     private val subject = CoroutineLaunchedInTestWithoutRunTest(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -345,7 +345,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinCoreEnvir
         """.trimIndent()
 
         val ktFile = compileContentForTest(code)
-        val bindingContext = env.createBindingContext(listOf(ktFile))
+        val bindingContext = createBindingContext(listOf(ktFile), env.configuration, env.project)
 
         val namedFunctions = ktFile
             .collectDescendantsOfType<KtNamedFunction>()

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/InjectDispatcherSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class InjectDispatcherSpec(val env: KotlinCoreEnvironment) {
+class InjectDispatcherSpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `InjectDispatcher with default config` {

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class RedundantSuspendModifierSpec(val env: KotlinCoreEnvironment) {
+class RedundantSuspendModifierSpec(val env: KotlinEnvironmentContainer) {
 
     private val subject = RedundantSuspendModifier(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SleepInsteadOfDelaySpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @Suppress("BlockingMethodInNonBlockingContext", "RedundantSuspendModifier")
 @KotlinCoreEnvironmentTest
-class SleepInsteadOfDelaySpec(private val env: KotlinCoreEnvironment) {
+class SleepInsteadOfDelaySpec(private val env: KotlinEnvironmentContainer) {
 
     private val subject = SleepInsteadOfDelay(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunInFinallySectionSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class SuspendFunInFinallySectionSpec(private val env: KotlinCoreEnvironment) {
+class SuspendFunInFinallySectionSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = SuspendFunInFinallySection(Config.empty)
 
     @Test

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellationSpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.SourceLocation
@@ -7,13 +8,12 @@ import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import io.gitlab.arturbosch.detekt.test.assertThat as assertThatFindings
 
 @KotlinCoreEnvironmentTest
-class SuspendFunSwallowedCancellationSpec(private val env: KotlinCoreEnvironment) {
+class SuspendFunSwallowedCancellationSpec(private val env: KotlinEnvironmentContainer) {
 
     private val subject = SuspendFunSwallowedCancellation(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithCoroutineScopeReceiverSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinCoreEnvironment) {
+class SuspendFunWithCoroutineScopeReceiverSpec(private val env: KotlinEnvironmentContainer) {
 
     private val subject = SuspendFunWithCoroutineScopeReceiver(Config.empty)
 

--- a/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunWithFlowReturnTypeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.coroutines
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinCoreEnvironment) {
+class SuspendFunWithFlowReturnTypeSpec(private val env: KotlinEnvironmentContainer) {
 
     private val subject = SuspendFunWithFlowReturnType(Config.empty)
 

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
+    compileOnly(projects.detektKotlinAnalysisApi)
     compileOnly(projects.detektPsiUtils)
     implementation(projects.detektTooling)
     testImplementation(projects.detektTest)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -4,13 +4,15 @@ import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
+import io.gitlab.arturbosch.detekt.api.RequiresAnalysisApi
 import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtPostfixExpression
-import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 /**
  * Reports calls of the map access methods `map[]` or `map.get()` with a not-null assertion operator `!!`.
@@ -48,7 +50,7 @@ class MapGetWithNotNullAssertionOperator(config: Config) :
         "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
             "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead."
     ),
-    RequiresFullAnalysis {
+    RequiresAnalysisApi {
 
     override fun visitPostfixExpression(expression: KtPostfixExpression) {
         if (expression.operationToken == KtTokens.EXCLEXCL && expression.isMapGet()) {
@@ -57,10 +59,17 @@ class MapGetWithNotNullAssertionOperator(config: Config) :
         super.visitPostfixExpression(expression)
     }
 
-    private fun KtPostfixExpression.isMapGet(): Boolean =
-        this
-            .baseExpression
-            .getResolvedCall(bindingContext)
-            ?.resultingDescriptor
-            ?.fqNameSafe == FqName("kotlin.collections.Map.get")
+    private fun KtPostfixExpression.isMapGet(): Boolean {
+        val postfixExpression = baseExpression ?: return false
+
+        val equalsCallableId = CallableId(StandardClassIds.Map, org.jetbrains.kotlin.name.Name.identifier("get"))
+
+        analyze(postfixExpression) {
+            return postfixExpression
+                .resolveToCall()
+                ?.successfulFunctionCallOrNull()
+                ?.symbol
+                ?.callableId == equalsCallableId
+        }
+    }
 }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEqualitySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/AvoidReferentialEqualitySpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class AvoidReferentialEqualitySpec(private val env: KotlinCoreEnvironment) {
+class AvoidReferentialEqualitySpec(private val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `ReferentialEquality with defaults` {

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CastNullableToNonNullableTypeSpec(private val env: KotlinCoreEnvironment) {
+class CastNullableToNonNullableTypeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = CastNullableToNonNullableType(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CastToNullableTypeSpec(private val env: KotlinCoreEnvironment) {
+class CastToNullableTypeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = CastToNullableType(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CharArrayToStringCallSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CharArrayToStringCallSpec(private val env: KotlinCoreEnvironment) {
+class CharArrayToStringCallSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = CharArrayToStringCall(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DeprecationSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class DeprecationSpec(private val env: KotlinCoreEnvironment) {
+class DeprecationSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = Deprecation(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DontDowncastCollectionTypesSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class DontDowncastCollectionTypesSpec(private val env: KotlinCoreEnvironment) {
+class DontDowncastCollectionTypesSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = DontDowncastCollectionTypes(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val MUTABLE_TYPES = "mutableTypes"
 
 @KotlinCoreEnvironmentTest
-class DoubleMutabilityForCollectionSpec(private val env: KotlinCoreEnvironment) {
+class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = DoubleMutabilityForCollection(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinCoreEnvironment) {
+class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = ElseCaseInsteadOfExhaustiveWhen(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ExitOutsideMainSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ExitOutsideMainSpec(private val env: KotlinCoreEnvironment) {
+class ExitOutsideMainSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = ExitOutsideMain(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/HasPlatformTypeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class HasPlatformTypeSpec(private val env: KotlinCoreEnvironment) {
+class HasPlatformTypeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = HasPlatformType(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -13,7 +13,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class `default config with non-annotated return values`(private val env: KotlinCoreEnvironment) {
+    inner class `default config with non-annotated return values`(private val env: KotlinEnvironmentContainer) {
         private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
@@ -198,7 +198,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class `default config with annotated return values`(private val env: KotlinCoreEnvironment) {
+    inner class `default config with annotated return values`(private val env: KotlinEnvironmentContainer) {
         private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
@@ -826,7 +826,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class `custom annotation config`(private val env: KotlinCoreEnvironment) {
+    inner class `custom annotation config`(private val env: KotlinEnvironmentContainer) {
         val subject = IgnoredReturnValue(
             TestConfig("returnValueAnnotations" to listOf("*.CustomReturn"))
         )
@@ -889,7 +889,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class `restrict to config`(private val env: KotlinCoreEnvironment) {
+    inner class `restrict to config`(private val env: KotlinEnvironmentContainer) {
         val subject = IgnoredReturnValue(TestConfig("restrictToConfig" to false))
 
         @Test
@@ -1081,7 +1081,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class `return value types default config`(private val env: KotlinCoreEnvironment) {
+    inner class `return value types default config`(private val env: KotlinEnvironmentContainer) {
         private val subject = IgnoredReturnValue(Config.empty)
 
         @Test
@@ -1202,7 +1202,7 @@ class IgnoredReturnValueSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
-    inner class `Java sources`(val env: KotlinCoreEnvironment) {
+    inner class `Java sources`(val env: KotlinEnvironmentContainer) {
         private val subject = IgnoredReturnValue(Config.empty)
 
         @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitDefaultLocaleSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ImplicitDefaultLocaleSpec(private val env: KotlinCoreEnvironment) {
+class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = ImplicitDefaultLocale(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/ImplicitUnitReturnTypeSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ImplicitUnitReturnTypeSpec(private val env: KotlinCoreEnvironment) {
+class ImplicitUnitReturnTypeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = ImplicitUnitReturnType(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperatorSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinCoreEnvironment) {
+class MapGetWithNotNullAssertionOperatorSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = MapGetWithNotNullAssertionOperator(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingSuperCallSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class MissingSuperCallSpec(private val env: KotlinCoreEnvironment) {
+class MissingSuperCallSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = MissingSuperCall(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MissingUseCallSpec.kt
@@ -2,17 +2,17 @@
 
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 @KotlinCoreEnvironmentTest
-class MissingUseCallSpec(private val env: KotlinCoreEnvironment) {
+class MissingUseCallSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = MissingUseCall()
 
     @ParameterizedTest

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullCheckOnMutablePropertySpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NullCheckOnMutablePropertySpec(private val env: KotlinCoreEnvironment) {
+class NullCheckOnMutablePropertySpec(private val env: KotlinEnvironmentContainer) {
     private val subject = NullCheckOnMutableProperty(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCallSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NullableToStringCallSpec(private val env: KotlinCoreEnvironment) {
+class NullableToStringCallSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = NullableToStringCall(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/PropertyUsedBeforeDeclarationSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class PropertyUsedBeforeDeclarationSpec(private val env: KotlinCoreEnvironment) {
+class PropertyUsedBeforeDeclarationSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = PropertyUsedBeforeDeclaration(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnamedParameterUseSpec(private val env: KotlinCoreEnvironment) {
+class UnnamedParameterUseSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnnamedParameterUse(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheckSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryNotNullCheckSpec(private val env: KotlinCoreEnvironment) {
+class UnnecessaryNotNullCheckSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnnecessaryNotNullCheck(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullOperatorSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryNotNullOperatorSpec(private val env: KotlinCoreEnvironment) {
+class UnnecessaryNotNullOperatorSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnnecessaryNotNullOperator(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessarySafeCallSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessarySafeCallSpec(private val env: KotlinCoreEnvironment) {
+class UnnecessarySafeCallSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnnecessarySafeCall(Config.empty)
 
     @Nested

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnreachableCatchBlockSpec(private val env: KotlinCoreEnvironment) {
+class UnreachableCatchBlockSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnreachableCatchBlock(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCodeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnreachableCodeSpec(private val env: KotlinCoreEnvironment) {
+class UnreachableCodeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnreachableCode(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCallOnNullableTypeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnsafeCallOnNullableTypeSpec(private val env: KotlinCoreEnvironment) {
+class UnsafeCallOnNullableTypeSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnsafeCallOnNullableType(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnsafeCastSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnsafeCastSpec(private val env: KotlinCoreEnvironment) {
+class UnsafeCastSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnsafeCast(Config.empty)
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.bugs
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnusedUnaryOperatorSpec(private val env: KotlinCoreEnvironment) {
+class UnusedUnaryOperatorSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = UnusedUnaryOperator(Config.empty)
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ErrorUsageWithThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ErrorUsageWithThrowableSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ErrorUsageWithThrowableSpec(private val env: KotlinCoreEnvironment) {
+class ErrorUsageWithThrowableSpec(private val env: KotlinEnvironmentContainer) {
     val subject = ErrorUsageWithThrowable(Config.empty)
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/InstanceOfCheckForExceptionSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class InstanceOfCheckForExceptionSpec(private val env: KotlinCoreEnvironment) {
+class InstanceOfCheckForExceptionSpec(private val env: KotlinEnvironmentContainer) {
     val subject = InstanceOfCheckForException(Config.empty)
 
     @Test

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ObjectExtendsThrowableSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ObjectExtendsThrowableSpec(val env: KotlinCoreEnvironment) {
+class ObjectExtendsThrowableSpec(val env: KotlinEnvironmentContainer) {
 
     val subject = ObjectExtendsThrowable(Config.empty)
 

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.exceptions
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ReturnFromFinallySpec(val env: KotlinCoreEnvironment) {
+class ReturnFromFinallySpec(val env: KotlinEnvironmentContainer) {
 
     val subject = ReturnFromFinally(Config.empty)
 

--- a/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
+++ b/detekt-rules-libraries/src/test/kotlin/io/gitlab/arturbosch/detekt/libraries/LibraryCodeMustSpecifyReturnTypeSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.libraries
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 @KotlinCoreEnvironmentTest
-class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinCoreEnvironment) {
+class LibraryCodeMustSpecifyReturnTypeSpec(val env: KotlinEnvironmentContainer) {
     @Nested
     inner class `positive cases` {
         val subject = LibraryCodeMustSpecifyReturnType(Config.empty)

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/BooleanPropertyNamingSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class BooleanPropertyNamingSpec(val env: KotlinCoreEnvironment) {
+class BooleanPropertyNamingSpec(val env: KotlinEnvironmentContainer) {
     val subject = BooleanPropertyNaming(Config.empty)
 
     @Nested

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 
 @KotlinCoreEnvironmentTest
-class MemberNameEqualsClassNameSpec(val env: KotlinCoreEnvironment) {
+class MemberNameEqualsClassNameSpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `some classes with methods which don't have the same name` {

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NoNameShadowingSpec(val env: KotlinCoreEnvironment) {
+class NoNameShadowingSpec(val env: KotlinEnvironmentContainer) {
     val subject = NoNameShadowing(Config.empty)
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.naming
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinCoreEnvironment) {
+class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
     val subject = NonBooleanPropertyPrefixedWithIs(Config.empty)
 
     @Nested

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class ArrayPrimitiveSpec(val env: KotlinCoreEnvironment) {
+class ArrayPrimitiveSpec(val env: KotlinEnvironmentContainer) {
 
     val subject = ArrayPrimitive(Config.empty)
 

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/CouldBeSequenceSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CouldBeSequenceSpec(val env: KotlinCoreEnvironment) {
+class CouldBeSequenceSpec(val env: KotlinEnvironmentContainer) {
     private val subject = CouldBeSequence(TestConfig("allowedOperations" to 2))
 
     @Test

--- a/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/performance/SpreadOperatorSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.performance
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class SpreadOperatorSpec(val env: KotlinCoreEnvironment) {
+class SpreadOperatorSpec(val env: KotlinEnvironmentContainer) {
 
     private val subject = SpreadOperator(Config.empty)
 

--- a/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImport.kt
+++ b/detekt-rules-style/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImport.kt
@@ -163,6 +163,9 @@ class UnusedImport(config: Config) :
                 bindingContext[BindingContext.SHORT_REFERENCE_TO_COMPANION_OBJECT, this]
                     ?: bindingContext[BindingContext.REFERENCE_TARGET, this]
             return descriptor?.getImportableDescriptor()?.fqNameOrNull()
+//            analyze(this) {
+//                return this@fqNameOrNull.expressionType?.expandedSymbol?.classId?.asSingleFqName()
+//            }
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val EXCLUDE_ANNOTATED_CLASSES = "excludeAnnotatedClasses"
 
 @KotlinCoreEnvironmentTest
-class AbstractClassCanBeConcreteClassSpec(val env: KotlinCoreEnvironment) {
+class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
     val subject = AbstractClassCanBeConcreteClass(TestConfig(EXCLUDE_ANNOTATED_CLASSES to listOf("Deprecated")))
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class AbstractClassCanBeInterfaceSpec(val env: KotlinCoreEnvironment) {
+class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
     val subject = AbstractClassCanBeInterface(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class CanBeNonNullableSpec(val env: KotlinCoreEnvironment) {
+class CanBeNonNullableSpec(val env: KotlinEnvironmentContainer) {
     val subject = CanBeNonNullable(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpressionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeExpressionSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class DoubleNegativeExpressionSpec(private val env: KotlinCoreEnvironment) {
+class DoubleNegativeExpressionSpec(private val env: KotlinEnvironmentContainer) {
     private val subject = DoubleNegativeExpression(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -14,7 +14,7 @@ class ExplicitCollectionElementAccessMethodSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class WithDefaultSources(val env: KotlinCoreEnvironment) {
+    inner class WithDefaultSources(val env: KotlinEnvironmentContainer) {
         @Nested
         inner class `Kotlin map` {
 
@@ -574,7 +574,7 @@ class ExplicitCollectionElementAccessMethodSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
-    inner class WithAdditionalJavaSources(val env: KotlinCoreEnvironment) {
+    inner class WithAdditionalJavaSources(val env: KotlinEnvironmentContainer) {
         @Test
         fun `does not report setters defined in java which are unlikely to be collection accessors`() {
             val code = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 private const val ANNOTATIONS = "annotations"
 
 @KotlinCoreEnvironmentTest
-class ForbiddenAnnotationSpec(val env: KotlinCoreEnvironment) {
+class ForbiddenAnnotationSpec(val env: KotlinEnvironmentContainer) {
 
     @Test
     fun `should report SuppressWarnings usages by default`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val METHODS = "methods"
 
 @KotlinCoreEnvironmentTest
-class ForbiddenMethodCallSpec(val env: KotlinCoreEnvironment) {
+class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
 
     @Test
     fun `should report kotlin print usages by default`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val METHODS = "methods"
 
 @KotlinCoreEnvironmentTest
-class ForbiddenNamedParamSpec(val env: KotlinCoreEnvironment) {
+class ForbiddenNamedParamSpec(val env: KotlinEnvironmentContainer) {
     @Test
     fun `should report nothing when methods are blank`() {
         val code = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -13,7 +13,7 @@ private const val IGNORE_OVERRIDDEN = "ignoreOverridden"
 private const val IGNORE_USAGE_IN_GENERICS = "ignoreUsageInGenerics"
 
 @KotlinCoreEnvironmentTest
-class ForbiddenVoidSpec(val env: KotlinCoreEnvironment) {
+class ForbiddenVoidSpec(val env: KotlinEnvironmentContainer) {
     val subject = ForbiddenVoid(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxChainedCallsOnSameLineSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class MaxChainedCallsOnSameLineSpec(private val env: KotlinCoreEnvironment) {
+class MaxChainedCallsOnSameLineSpec(private val env: KotlinEnvironmentContainer) {
     private val rule = MaxChainedCallsOnSameLine(TestConfig("maxChainedCalls" to 3))
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineLambdaItParameterSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class MultilineLambdaItParameterSpec(val env: KotlinCoreEnvironment) {
+class MultilineLambdaItParameterSpec(val env: KotlinEnvironmentContainer) {
     val subject = MultilineLambdaItParameter(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NullableBooleanCheckSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 @KotlinCoreEnvironmentTest
-class NullableBooleanCheckSpec(val env: KotlinCoreEnvironment) {
+class NullableBooleanCheckSpec(val env: KotlinEnvironmentContainer) {
     val subject = NullableBooleanCheck(Config.empty)
 
     /**

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ObjectLiteralToLambdaSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -14,7 +14,7 @@ class ObjectLiteralToLambdaSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest
-    inner class WithDefaultSources(val env: KotlinCoreEnvironment) {
+    inner class WithDefaultSources(val env: KotlinEnvironmentContainer) {
 
         @Nested
         inner class `report convertible expression` {
@@ -514,7 +514,7 @@ class ObjectLiteralToLambdaSpec {
 
     @Nested
     @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
-    inner class WithAdditionalJavaSources(val env: KotlinCoreEnvironment) {
+    inner class WithAdditionalJavaSources(val env: KotlinEnvironmentContainer) {
 
         @Test
         fun `has other default methods`() {

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantExplicitTypeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class RedundantExplicitTypeSpec(val env: KotlinCoreEnvironment) {
+class RedundantExplicitTypeSpec(val env: KotlinEnvironmentContainer) {
     val subject = RedundantExplicitType(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class RedundantHigherOrderMapUsageSpec(val env: KotlinCoreEnvironment) {
+class RedundantHigherOrderMapUsageSpec(val env: KotlinEnvironmentContainer) {
     val subject = RedundantHigherOrderMapUsage(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryAnySpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryAnySpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryAnySpec(val env: KotlinEnvironmentContainer) {
     val subject = UnnecessaryAny(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryApplySpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryApplySpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryApplySpec(val env: KotlinEnvironmentContainer) {
 
     val subject = UnnecessaryApply(Config.empty)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryFilterSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryFilterSpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryFilterSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnnecessaryFilter(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryInnerClassSpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryInnerClassSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnnecessaryInnerClass(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnnecessaryLetSpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryLetSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnnecessaryLet(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryReversedSpec(
-    val env: KotlinCoreEnvironment,
+    val env: KotlinEnvironmentContainer,
 ) {
     val subject = UnnecessaryReversed(Config.empty)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedImportSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 private const val ADDITIONAL_OPERATOR_SET = "additionalOperatorSet"
 
 @KotlinCoreEnvironmentTest
 class UnusedImportSpec(
-    val env: KotlinCoreEnvironment,
+    val env: KotlinEnvironmentContainer,
 ) {
     val subject = UnusedImport(Config.empty)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UnusedPrivateFunctionSpec(val env: KotlinCoreEnvironment) {
+class UnusedPrivateFunctionSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnusedPrivateFunction(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
@@ -8,7 +9,6 @@ import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.regex.PatternSyntaxException
@@ -16,7 +16,7 @@ import java.util.regex.PatternSyntaxException
 private const val ALLOWED_NAMES_PATTERN = "allowedNames"
 
 @KotlinCoreEnvironmentTest
-class UnusedPrivatePropertySpec(val env: KotlinCoreEnvironment) {
+class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
     val subject = UnusedPrivateProperty(Config.empty)
 
     val regexTestingCode = """

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedVariableSpec.kt
@@ -1,17 +1,17 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SourceLocation
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
 @Suppress("unused")
-class UnusedVariableSpec(val env: KotlinCoreEnvironment) {
+class UnusedVariableSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnusedVariable(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseAnyOrNoneInsteadOfFindSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinCoreEnvironment) {
+class UseAnyOrNoneInsteadOfFindSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseAnyOrNoneInsteadOfFind(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckNotNullSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseCheckNotNullSpec(val env: KotlinCoreEnvironment) {
+class UseCheckNotNullSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseCheckNotNull(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseCheckOrErrorSpec(val env: KotlinCoreEnvironment) {
+class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseCheckOrError(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -1,18 +1,18 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 private const val ALLOW_VARS = "allowVars"
 
 @KotlinCoreEnvironmentTest
-class UseDataClassSpec(val env: KotlinCoreEnvironment) {
+class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseDataClass(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseEmptyCounterpartSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseEmptyCounterpartSpec(val env: KotlinCoreEnvironment) {
+class UseEmptyCounterpartSpec(val env: KotlinEnvironmentContainer) {
     val rule = UseEmptyCounterpart(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseIfEmptyOrIfBlankSpec(val env: KotlinCoreEnvironment) {
+class UseIfEmptyOrIfBlankSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseIfEmptyOrIfBlank(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseIsNullOrEmptySpec(val env: KotlinCoreEnvironment) {
+class UseIsNullOrEmptySpec(val env: KotlinEnvironmentContainer) {
     val subject = UseIsNullOrEmpty(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseOrEmptySpec(val env: KotlinCoreEnvironment) {
+class UseOrEmptySpec(val env: KotlinEnvironmentContainer) {
     val subject = UseOrEmpty(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireNotNullSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseRequireNotNullSpec(val env: KotlinCoreEnvironment) {
+class UseRequireNotNullSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseRequireNotNull(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseRequireSpec(val env: KotlinCoreEnvironment) {
+class UseRequireSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseRequire(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseSumOfInsteadOfFlatMapSizeSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinCoreEnvironment) {
+class UseSumOfInsteadOfFlatMapSizeSpec(val env: KotlinEnvironmentContainer) {
     val subject = UseSumOfInsteadOfFlatMapSize(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UselessCallOnNotNullSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class UselessCallOnNotNullSpec(val env: KotlinCoreEnvironment) {
+class UselessCallOnNotNullSpec(val env: KotlinEnvironmentContainer) {
     val subject = UselessCallOnNotNull(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/VarCouldBeValSpec.kt
@@ -1,16 +1,16 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class VarCouldBeValSpec(val env: KotlinCoreEnvironment) {
+class VarCouldBeValSpec(val env: KotlinEnvironmentContainer) {
     val subject = VarCouldBeVal(Config.empty)
 
     @Nested

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -1,15 +1,15 @@
 package io.gitlab.arturbosch.detekt.rules.style.movelambdaout
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 // Source https://github.com/JetBrains/intellij-community/tree/master/plugins/kotlin/idea/tests/testData/inspectionsLocal/moveLambdaOutsideParentheses
 @KotlinCoreEnvironmentTest
-class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinCoreEnvironment) {
+class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinEnvironmentContainer) {
     private val subject = UnnecessaryBracesAroundTrailingLambda(Config.empty)
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -1,19 +1,19 @@
 package io.gitlab.arturbosch.detekt.rules.style.optional
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.FakeCompilerResources
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.ExplicitApiMode
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class OptionalUnitSpec(val env: KotlinCoreEnvironment) {
+class OptionalUnitSpec(val env: KotlinEnvironmentContainer) {
 
     val subject = OptionalUnit(Config.empty)
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/optional/PreferToOverPairSyntaxSpec.kt
@@ -1,14 +1,14 @@
 package io.gitlab.arturbosch.detekt.rules.style.optional
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.rules.KotlinCoreEnvironmentTest
 import io.gitlab.arturbosch.detekt.test.lintWithContext
 import org.assertj.core.api.Assertions.assertThat
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
-class PreferToOverPairSyntaxSpec(val env: KotlinCoreEnvironment) {
+class PreferToOverPairSyntaxSpec(val env: KotlinEnvironmentContainer) {
     val subject = PreferToOverPairSyntax(Config.empty)
 
     @Test

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -11,14 +11,23 @@ public final class io/github/detekt/test/utils/FileExtensionKt {
 }
 
 public final class io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper {
-	public fun <init> (Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Lcom/intellij/openapi/Disposable;)V
+	public fun <init> (Lcom/intellij/openapi/project/Project;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/Disposable;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;)V
+	public synthetic fun <init> (Lcom/intellij/openapi/project/Project;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/Disposable;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun dispose ()V
-	public final fun getEnv ()Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;
+	public final fun getConfiguration ()Lorg/jetbrains/kotlin/config/CompilerConfiguration;
+	public final fun getEnv ()Lio/github/detekt/test/utils/KotlinEnvironmentContainer;
+	public final fun getProject ()Lcom/intellij/openapi/project/Project;
 }
 
 public final class io/github/detekt/test/utils/KotlinCoreEnvironmentWrapperKt {
 	public static final fun createEnvironment (Ljava/util/List;Ljava/util/List;)Lio/github/detekt/test/utils/KotlinCoreEnvironmentWrapper;
 	public static synthetic fun createEnvironment$default (Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/github/detekt/test/utils/KotlinCoreEnvironmentWrapper;
+}
+
+public final class io/github/detekt/test/utils/KotlinEnvironmentContainer {
+	public fun <init> (Lcom/intellij/openapi/project/Project;Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
+	public final fun getConfiguration ()Lorg/jetbrains/kotlin/config/CompilerConfiguration;
+	public final fun getProject ()Lcom/intellij/openapi/project/Project;
 }
 
 public final class io/github/detekt/test/utils/KotlinScriptEngine {

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api(libs.kotlin.stdlib)
     api(libs.junit.jupiterApi)
+    implementation(projects.detektKotlinAnalysisApi)
     implementation(projects.detektParser)
     implementation(libs.kotlin.mainKts) {
         isTransitive = false

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -3,7 +3,6 @@ package io.github.detekt.test.utils
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.io.File
 
@@ -13,9 +12,10 @@ class KotlinEnvironmentContainer(val project: Project, val configuration: Compil
  * Make sure to always call [dispose] or use a [use] block when working with [KotlinCoreEnvironment]s.
  */
 class KotlinCoreEnvironmentWrapper(
-    private var environment: KotlinCoreEnvironment,
+    val project: Project,
+    val configuration: CompilerConfiguration,
     private val disposable: Disposable,
-    val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(environment.project, environment.configuration)
+    val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(project, configuration)
 ) {
 
     fun dispose() {

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -1,24 +1,25 @@
 package io.github.detekt.test.utils
 
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.io.File
+
+class KotlinEnvironmentContainer(val project: Project, val configuration: CompilerConfiguration)
 
 /**
  * Make sure to always call [dispose] or use a [use] block when working with [KotlinCoreEnvironment]s.
  */
 class KotlinCoreEnvironmentWrapper(
-    private var environment: KotlinCoreEnvironment?,
+    private var environment: KotlinCoreEnvironment,
     private val disposable: Disposable,
+    val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(environment.project, environment.configuration)
 ) {
-
-    val env: KotlinCoreEnvironment
-        get() = checkNotNull(environment) { "Environment already disposed." }
 
     fun dispose() {
         Disposer.dispose(disposable)
-        environment = null
     }
 }
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -15,7 +15,7 @@ class KotlinCoreEnvironmentWrapper(
     val project: Project,
     val configuration: CompilerConfiguration,
     private val disposable: Disposable,
-    val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(project, configuration)
+    val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(project, configuration),
 ) {
 
     fun dispose() {

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -1,13 +1,14 @@
 package io.github.detekt.test.utils
 
+import com.intellij.mock.MockProject
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtilRt
 import io.github.detekt.parser.KtCompiler
 import kotlinx.coroutines.CoroutineScope
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoot
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
@@ -17,6 +18,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtPsiFactory
+import org.jetbrains.kotlin.resolve.CodeAnalyzerInitializer
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.name
@@ -52,13 +54,17 @@ internal object KtTestCompiler : KtCompiler() {
         }
 
         val parentDisposable = Disposer.newDisposable()
-        val kotlinCoreEnvironment =
-            KotlinCoreEnvironment.createForTests(
-                parentDisposable,
-                configuration,
-                EnvironmentConfigFiles.JVM_CONFIG_FILES
-            )
-        return KotlinCoreEnvironmentWrapper(kotlinCoreEnvironment.project, kotlinCoreEnvironment.configuration, parentDisposable)
+
+        val analysisSession = buildStandaloneAnalysisAPISession(parentDisposable) {
+            @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
+            buildKtModuleProviderByCompilerConfiguration(configuration)
+        }
+
+        // Required to set up BindingContext with TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration
+        val traceHolder = CliTraceHolder(analysisSession.project)
+        (analysisSession.project as MockProject).registerService(CodeAnalyzerInitializer::class.java, traceHolder)
+
+        return KotlinCoreEnvironmentWrapper(analysisSession.project, configuration, parentDisposable)
     }
 
     fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -28,7 +28,7 @@ import kotlin.io.path.name
  */
 internal object KtTestCompiler : KtCompiler() {
 
-    private val psiFileFactory = KtPsiFactory(environment.project, markGenerated = false)
+    private val psiFileFactory = KtPsiFactory(project, markGenerated = false)
 
     /**
      * Not sure why but this function only works from this context.

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -1,6 +1,5 @@
 package io.github.detekt.test.utils
 
-import com.intellij.mock.MockProject
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.util.text.StringUtilRt
 import io.github.detekt.parser.KtCompiler
@@ -58,11 +57,10 @@ internal object KtTestCompiler : KtCompiler() {
         val analysisSession = buildStandaloneAnalysisAPISession(parentDisposable) {
             @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
             buildKtModuleProviderByCompilerConfiguration(configuration)
-        }
 
-        // Required to set up BindingContext with TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration
-        val traceHolder = CliTraceHolder(analysisSession.project)
-        (analysisSession.project as MockProject).registerService(CodeAnalyzerInitializer::class.java, traceHolder)
+            // Required to set up BindingContext with TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration
+            registerProjectService(CodeAnalyzerInitializer::class.java, CliTraceHolder(project))
+        }
 
         return KotlinCoreEnvironmentWrapper(analysisSession.project, configuration, parentDisposable)
     }

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -58,7 +58,7 @@ internal object KtTestCompiler : KtCompiler() {
                 configuration,
                 EnvironmentConfigFiles.JVM_CONFIG_FILES
             )
-        return KotlinCoreEnvironmentWrapper(kotlinCoreEnvironment, parentDisposable)
+        return KotlinCoreEnvironmentWrapper(kotlinCoreEnvironment.project, kotlinCoreEnvironment.configuration, parentDisposable)
     }
 
     fun createKtFile(@Language("kotlin") content: String, path: Path): KtFile =

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.rules
 
 import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.createEnvironment
 import io.github.detekt.test.utils.resourceAsPath
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
@@ -24,7 +24,7 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
         set(value) = getStore(NAMESPACE).put(WRAPPER_KEY, value)
 
     override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
-        parameterContext.parameter.type == KotlinCoreEnvironment::class.java
+        parameterContext.parameter.type == KotlinEnvironmentContainer::class.java
 
     override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
         val closeableWrapper = extensionContext.wrapper

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -34,7 +34,6 @@ public final class io/gitlab/arturbosch/detekt/test/FindingsAssertionsKt {
 
 public final class io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensionsKt {
 	public static final fun createBindingContext (Ljava/util/List;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/kotlin/resolve/BindingContext;
-	public static final fun createBindingContext (Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/util/List;)Lorg/jetbrains/kotlin/resolve/BindingContext;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/ResourcesKt {
@@ -47,8 +46,8 @@ public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
 	public static final fun lint (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
-	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
-	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
+	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
+	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -33,6 +33,7 @@ public final class io/gitlab/arturbosch/detekt/test/FindingsAssertionsKt {
 }
 
 public final class io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensionsKt {
+	public static final fun createBindingContext (Ljava/util/List;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/kotlin/resolve/BindingContext;
 	public static final fun createBindingContext (Lorg/jetbrains/kotlin/cli/jvm/compiler/KotlinCoreEnvironment;Ljava/util/List;)Lorg/jetbrains/kotlin/resolve/BindingContext;
 }
 

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -32,6 +32,11 @@ public final class io/gitlab/arturbosch/detekt/test/FindingsAssertionsKt {
 	public static final fun assertThat (Ljava/util/List;)Lio/gitlab/arturbosch/detekt/test/FindingsAssert;
 }
 
+public final class io/gitlab/arturbosch/detekt/test/KotlinAnalysisApiEngine {
+	public static final field INSTANCE Lio/gitlab/arturbosch/detekt/test/KotlinAnalysisApiEngine;
+	public final fun compile (Ljava/lang/String;[Ljava/lang/String;)Lorg/jetbrains/kotlin/psi/KtFile;
+}
+
 public final class io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensionsKt {
 	public static final fun createBindingContext (Ljava/util/List;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/kotlin/resolve/BindingContext;
 }
@@ -47,7 +52,9 @@ public final class io/gitlab/arturbosch/detekt/test/RuleExtensionsKt {
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun lint$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;Z)Ljava/util/List;
+	public static final fun lintWithContext (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;Lio/gitlab/arturbosch/detekt/api/CompilerResources;ZILjava/lang/Object;)Ljava/util/List;
+	public static synthetic fun lintWithContext$default (Lio/gitlab/arturbosch/detekt/api/Rule;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;[Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 }
 
 public final class io/gitlab/arturbosch/detekt/test/TestConfig : io/gitlab/arturbosch/detekt/api/Config {

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 dependencies {
     api(projects.detektApi)
     api(projects.detektTestUtils)
+    implementation(projects.detektKotlinAnalysisApi)
     implementation(projects.detektUtils)
     implementation(libs.kotlin.reflect)
     compileOnly(libs.assertj.core)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
@@ -1,16 +1,40 @@
 package io.gitlab.arturbosch.detekt.test
 
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.vfs.impl.jar.CoreJarFileSystem
+import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
+import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
+import org.jetbrains.kotlin.cli.jvm.index.JavaRoot
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
-fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingContext =
-    TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
-        this.project,
+fun createBindingContext(files: List<KtFile>, configuration: CompilerConfiguration, project: Project): BindingContext {
+    val vfsFs = CoreJarFileSystem()
+
+    val classpathRoots = configuration.jvmClasspathRoots
+        .filter { it.extension == "jar" }
+        .mapNotNull { vfsFs.findFileByPath("${it.absolutePath}!/") }
+        .map { JavaRoot(it, JavaRoot.RootType.BINARY) }
+
+    val packagePartProvider = StandaloneProjectFactory.createPackagePartsProvider(
+        classpathRoots,
+        configuration.languageVersionSettings
+    )
+
+    return TopDownAnalyzerFacadeForJVM.analyzeFilesWithJavaIntegration(
+        project,
         files,
-        NoScopeRecordCliBindingTrace(this.project),
-        this.configuration,
-        this::createPackagePartProvider
+        NoScopeRecordCliBindingTrace(project),
+        configuration,
+        packagePartProvider
     ).bindingContext
+}
+
+@Deprecated("Use createBindingContext function directly")
+fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingContext =
+    createBindingContext(files, configuration, project)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/KotlinCoreEnvironmentExtensions.kt
@@ -3,7 +3,6 @@ package io.gitlab.arturbosch.detekt.test
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.vfs.impl.jar.CoreJarFileSystem
 import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.compiler.NoScopeRecordCliBindingTrace
 import org.jetbrains.kotlin.cli.jvm.compiler.TopDownAnalyzerFacadeForJVM
 import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
@@ -34,7 +33,3 @@ fun createBindingContext(files: List<KtFile>, configuration: CompilerConfigurati
         packagePartProvider
     ).bindingContext
 }
-
-@Deprecated("Use createBindingContext function directly")
-fun KotlinCoreEnvironment.createBindingContext(files: List<KtFile>): BindingContext =
-    createBindingContext(files, configuration, project)

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -6,14 +6,28 @@ import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.CompilerResources
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.RequiresAnalysisApi
 import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.suppressors.isSuppressedBy
+import kotlinx.coroutines.CoroutineScope
 import org.intellij.lang.annotations.Language
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaModule
+import org.jetbrains.kotlin.analysis.api.projectStructure.contextModule
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
+import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
 import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
+import java.io.File
+import java.nio.file.Path
+import kotlin.io.path.Path
 
 private val shouldCompileTestSnippets: Boolean =
     System.getProperty("compile-test-snippets", "false")!!.toBoolean()
@@ -61,6 +75,22 @@ fun <T> T.lintWithContext(
     return visitFile(ktFile, compilerResources).filterSuppressed(this)
 }
 
+fun <T> T.lintWithContext(
+    environment: KotlinEnvironmentContainer,
+    @Language("kotlin") content: String,
+    @Language("kotlin") vararg additionalContents: String,
+    compile: Boolean = true,
+): List<Finding> where T : Rule, T : RequiresAnalysisApi {
+    val ktFile = KotlinAnalysisApiEngine.compile(content, additionalContents)
+
+    val compilerResources = CompilerResources(
+        environment.configuration.languageVersionSettings,
+        DataFlowValueFactoryImpl(environment.configuration.languageVersionSettings)
+    )
+
+    return visitFile(ktFile, compilerResources).filterSuppressed(this)
+}
+
 fun Rule.lint(ktFile: KtFile, compilerResources: CompilerResources = FakeCompilerResources()): List<Finding> {
     require(this !is RequiresFullAnalysis) {
         "${this.ruleName} requires full analysis so you should use lintWithContext instead of lint"
@@ -74,3 +104,69 @@ private fun List<Finding>.filterSuppressed(rule: Rule): List<Finding> =
     }
 
 private val Rule.aliases: Set<String> get() = config.valueOrDefault(Config.ALIASES_KEY, emptyList<String>()).toSet()
+
+object KotlinAnalysisApiEngine {
+    private lateinit var sourceModule: KaModule
+
+    private val session = buildStandaloneAnalysisAPISession(unitTestMode = false) {
+        buildKtModuleProvider {
+            val targetPlatform = JvmPlatforms.defaultJvmPlatform
+            platform = targetPlatform
+
+            val jdk = addModule(
+                buildKtSdkModule {
+                    addBinaryRootsFromJdkHome(Path(System.getProperty("java.home")), true)
+                    platform = targetPlatform
+                    libraryName = "sdk"
+                }
+            )
+
+            val stdlib = addModule(
+                buildKtLibraryModule {
+                    addBinaryRoot(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath())
+                    platform = targetPlatform
+                    libraryName = "stdlib"
+                }
+            )
+
+            val coroutinesCore = addModule(
+                buildKtLibraryModule {
+                    addBinaryRoot(kotlinxCoroutinesCorePath())
+                    platform = targetPlatform
+                    libraryName = "coroutines-core"
+                }
+            )
+
+            sourceModule = addModule(
+                buildKtSourceModule {
+                    addRegularDependency(jdk)
+                    addRegularDependency(stdlib)
+                    addRegularDependency(coroutinesCore)
+                    platform = targetPlatform
+                    moduleName = "source"
+                }
+            )
+        }
+    }
+
+    private val factory = KtPsiFactory(session.project, markGenerated = true)
+
+    /**
+     * Compiles a given code string using Kotlin's Analysis API.
+     *
+     * @throws IllegalStateException if the given code snippet does not compile
+     */
+    @OptIn(KaExperimentalApi::class)
+    fun compile(@Language("kotlin") code: String, additionalContents: Array<out String>): KtFile {
+        additionalContents.forEach {
+            factory.createFile(it).contextModule = sourceModule
+        }
+
+        return factory.createFile(code).apply {
+            contextModule = sourceModule
+        }
+    }
+
+    private fun kotlinxCoroutinesCorePath(): Path =
+        File(CoroutineScope::class.java.protectionDomain.codeSource.location.path).toPath()
+}

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -50,7 +50,13 @@ fun <T> T.lintWithContext(
     val additionalKtFiles = additionalContents.mapIndexed { index, additionalContent ->
         compileContentForTest(additionalContent, "AdditionalTest$index.kt")
     }
-    setBindingContext(environment.createBindingContext(listOf(ktFile) + additionalKtFiles))
+    setBindingContext(
+        createBindingContext(
+            listOf(ktFile) + additionalKtFiles,
+            environment.configuration,
+            environment.project
+        )
+    )
 
     return visitFile(ktFile, compilerResources).filterSuppressed(this)
 }

--- a/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/io/gitlab/arturbosch/detekt/test/RuleExtensions.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.test
 
+import io.github.detekt.test.utils.KotlinEnvironmentContainer
 import io.github.detekt.test.utils.KotlinScriptEngine
 import io.github.detekt.test.utils.compileContentForTest
 import io.gitlab.arturbosch.detekt.api.CompilerResources
@@ -10,7 +11,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.suppressors.isSuppressedBy
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.calls.smartcasts.DataFlowValueFactoryImpl
@@ -34,7 +34,7 @@ fun Rule.lint(
 }
 
 fun <T> T.lintWithContext(
-    environment: KotlinCoreEnvironment,
+    environment: KotlinEnvironmentContainer,
     @Language("kotlin") content: String,
     @Language("kotlin") vararg additionalContents: String,
     compilerResources: CompilerResources = CompilerResources(


### PR DESCRIPTION
Part of #8059 
