### PR TITLE
Only test with Java 17+ on CI

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        jdk: [ 8, 11, 17, 21 ]
+        jdk: [ 17, 21 ]
         include:
           - os: windows-latest
             jdk: 21


### PR DESCRIPTION
Closes #8072

If this is approved, the [repo config](https://github.com/detekt/detekt/settings/branch_protection_rules/2818248) needs to be updated to remove these from the _Status checks that are required_ before this is merged:
* gradle (ubuntu-latest, 8)
* gradle (ubuntu-latest, 11)