### PR TITLE
Use StandaloneAnalysisAPISession to setup analysis environment

### DIFF
--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -64,6 +64,8 @@ val unzipKotlinCompiler by tasks.registering(Copy::class) {
 }
 
 val testPluginKotlinc by tasks.registering(Task::class) {
+    enabled = false
+
     val outputDir = layout.buildDirectory.dir("tmp/kotlinc")
     val sourceFile = file("src/test/resources/hello.kt")
 

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -3,15 +3,19 @@ package io.gitlab.arturbosch.detekt.core.settings
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
+import com.intellij.pom.PomModel
+import io.github.detekt.parser.DetektPomModel
 import io.github.detekt.parser.createCompilerConfiguration
-import io.github.detekt.parser.createKotlinCoreEnvironment
 import io.github.detekt.tooling.api.spec.CompilerSpec
 import io.github.detekt.tooling.api.spec.LoggingSpec
 import io.github.detekt.tooling.api.spec.ProjectSpec
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
+import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
+import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
+import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
 import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.friendPaths
 import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
+import org.jetbrains.kotlin.resolve.CodeAnalyzerInitializer
 import java.io.Closeable
 import java.io.File
 import java.io.OutputStream
@@ -24,32 +28,13 @@ interface EnvironmentAware {
 }
 
 internal class EnvironmentFacade(
-    private val projectSpec: ProjectSpec,
-    private val compilerSpec: CompilerSpec,
+    projectSpec: ProjectSpec,
+    compilerSpec: CompilerSpec,
     loggingSpec: LoggingSpec,
 ) : AutoCloseable, Closeable, EnvironmentAware {
 
     private val printStream = if (loggingSpec.debug) loggingSpec.errorChannel.asPrintStream() else NullPrintStream
-    private val environment: KotlinCoreEnvironment by lazy {
-        val env = createKotlinCoreEnvironment(
-            configuration,
-            disposable,
-            printStream,
-        )
-
-        val moduleVisibilityManager = ModuleVisibilityManager.SERVICE.getInstance(env.project)
-        configuration.getList(JVMConfigurationKeys.FRIEND_PATHS).forEach(moduleVisibilityManager::addFriendPath)
-
-        env
-    }
-
-    override val disposable: Disposable = Disposer.newDisposable()
-
-    override val project: Project by lazy {
-        environment.project
-    }
-
-    override val configuration: CompilerConfiguration by lazy {
+    override val configuration: CompilerConfiguration =
         createCompilerConfiguration(
             projectSpec.inputPaths.toList(),
             compilerSpec.classpathEntries(),
@@ -60,6 +45,25 @@ internal class EnvironmentFacade(
             compilerSpec.freeCompilerArgs,
             printStream,
         )
+
+    override val disposable: Disposable = Disposer.newDisposable()
+
+    private val analysisSession = buildStandaloneAnalysisAPISession(disposable) {
+        // Required for autocorrect support
+        registerProjectService(PomModel::class.java, DetektPomModel)
+
+        // Required by K1 compiler setup
+        registerProjectService(CodeAnalyzerInitializer::class.java, CliTraceHolder(project))
+        registerProjectService(ModuleVisibilityManager::class.java, CliModuleVisibilityManagerImpl(true))
+        val moduleVisibilityManager = ModuleVisibilityManager.SERVICE.getInstance(project)
+        configuration.friendPaths.forEach(moduleVisibilityManager::addFriendPath)
+
+        @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
+        buildKtModuleProviderByCompilerConfiguration(configuration)
+    }
+
+    override val project: Project by lazy {
+        analysisSession.project
     }
 
     override fun close() {

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/settings/EnvironmentAware.kt
@@ -12,6 +12,7 @@ import io.github.detekt.tooling.api.spec.ProjectSpec
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.cli.common.CliModuleVisibilityManagerImpl
 import org.jetbrains.kotlin.cli.jvm.compiler.CliTraceHolder
+import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.friendPaths
 import org.jetbrains.kotlin.load.kotlin.ModuleVisibilityManager
@@ -57,6 +58,8 @@ internal class EnvironmentFacade(
         registerProjectService(ModuleVisibilityManager::class.java, CliModuleVisibilityManagerImpl(true))
         val moduleVisibilityManager = ModuleVisibilityManager.SERVICE.getInstance(project)
         configuration.friendPaths.forEach(moduleVisibilityManager::addFriendPath)
+
+        configuration.putIfAbsent(CommonConfigurationKeys.MODULE_NAME, "<no module name provided>")
 
         @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
         buildKtModuleProviderByCompilerConfiguration(configuration)

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/KotlinEnvironmentUtils.kt
@@ -1,9 +1,5 @@
 package io.github.detekt.parser
 
-import com.intellij.mock.MockProject
-import com.intellij.openapi.Disposable
-import com.intellij.openapi.util.Disposer
-import com.intellij.pom.PomModel
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArguments
@@ -11,8 +7,6 @@ import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.common.setupLanguageVersionSettings
-import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
 import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
@@ -24,38 +18,6 @@ import org.jetbrains.kotlin.config.JVMConfigurationKeys
 import java.io.File
 import java.io.PrintStream
 import java.nio.file.Path
-
-/**
- * Creates an environment instance which can be used to compile source code to KtFile's.
- * This environment also allows to modify the resulting AST files.
- */
-fun createKotlinCoreEnvironment(
-    configuration: CompilerConfiguration = CompilerConfiguration(),
-    disposable: Disposable = Disposer.newDisposable(),
-    printStream: PrintStream,
-): KotlinCoreEnvironment {
-    configuration.put(
-        CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
-        PrintingMessageCollector(printStream, MessageRenderer.PLAIN_FULL_PATHS, false)
-    )
-    configuration.put(CommonConfigurationKeys.MODULE_NAME, "detekt")
-
-    val environment = KotlinCoreEnvironment.createForProduction(
-        disposable,
-        configuration,
-        EnvironmentConfigFiles.JVM_CONFIG_FILES
-    )
-
-    val projectCandidate = environment.project
-
-    val project = requireNotNull(projectCandidate as? MockProject) {
-        "MockProject type expected, actual - ${projectCandidate.javaClass.simpleName}"
-    }
-
-    project.registerService(PomModel::class.java, DetektPomModel)
-
-    return environment
-}
 
 /**
  * Creates a compiler configuration for the kotlin compiler with all known sources and classpath jars.

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ kotlin.daemon.useFallbackStrategy=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-org.gradle.jvmargs=-Xmx1g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
Last part of #8059 

Note the increased memory requirement for the build. This is due to https://youtrack.jetbrains.com/issue/KT-71706. There is a workaround available. I've created an issue to track and will fix in a separate PR:
* #8113

**Breaking change:** This is the PR that breaks detekt-compiler-plugin - 1.23.8 will be the final working version.