### PR TITLE
Initialize Gradle configurations lazily

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val extraDepsToPackage: Configuration by configurations.creating
+val extraDepsToPackage by configurations.registering
 
 dependencies {
     compileOnly(projects.detektApi)
@@ -47,6 +47,6 @@ tasks.jar {
         configurations.runtimeClasspath.get()
             .filter { dependency -> depsToPackage.any { it in dependency.toString() } }
             .map { if (it.isDirectory) it else zipTree(it) },
-        extraDepsToPackage.map { zipTree(it) },
+        extraDepsToPackage.get().map { zipTree(it) },
     )
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -118,9 +118,9 @@ kotlin {
     }
 }
 
-val testKitRuntimeOnly: Configuration by configurations.creating
-val testKitJava17RuntimeOnly: Configuration by configurations.creating
-val testKitGradleMinVersionRuntimeOnly: Configuration by configurations.creating
+val testKitRuntimeOnly by configurations.registering
+val testKitJava17RuntimeOnly by configurations.registering
+val testKitGradleMinVersionRuntimeOnly by configurations.registering
 
 dependencies {
     compileOnly(libs.android.gradleApi)

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -55,7 +55,7 @@ class DetektBasePlugin : Plugin<Project> {
             extension.config.setFrom(project.files(defaultConfigFile))
         }
 
-        project.configurations.create(CONFIGURATION_DETEKT_PLUGINS) { configuration ->
+        project.configurations.register(CONFIGURATION_DETEKT_PLUGINS) { configuration ->
             configuration.isVisible = false
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT_PLUGINS libraries to be used for this project."

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -88,7 +88,7 @@ class DetektPlugin : Plugin<Project> {
     }
 
     private fun configurePluginDependencies(project: Project, extension: DetektExtension) {
-        project.configurations.create(CONFIGURATION_DETEKT) { configuration ->
+        project.configurations.register(CONFIGURATION_DETEKT) { configuration ->
             configuration.isVisible = false
             configuration.isTransitive = true
             configuration.description = "The $CONFIGURATION_DETEKT dependencies to be used for this project."


### PR DESCRIPTION
Takes advantage of new capabilities in Gradle 8.14.

https://docs.gradle.org/8.14/release-notes.html#configurations-are-initialized-lazily

> This change can lead to reduced configuration time and lower memory usage in some builds.