### PR TITLE
Add workaround for KT-71706

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -213,12 +213,16 @@ style:
   ForbiddenMethodCall:
     active: true
     methods:
-      - 'kotlin.io.print'
-      - 'kotlin.io.println'
-      - 'java.net.URL.openStream'
-      - 'java.lang.Class.getResourceAsStream'
-      - 'java.lang.ClassLoader.getResourceAsStream'
-      - 'kotlin.system.measureTimeMillis'
+      - value: 'kotlin.io.print'
+      - value: 'kotlin.io.println'
+      - value: 'java.net.URL.openStream'
+      - value: 'java.lang.Class.getResourceAsStream'
+      - value: 'java.lang.ClassLoader.getResourceAsStream'
+      - value: 'kotlin.system.measureTimeMillis'
+      - value: 'org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule'
+        reason: 'Not performant due to KT-71706. Use buildKspLibraryModule instead.'
+      - value: 'org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule'
+        reason: 'Not performant due to KT-71706. Use buildKspSdkModule instead.'
   ForbiddenVoid:
     active: true
     ignoreOverridden: true

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -1,6 +1,9 @@
 // This package can be retired once this is closed: https://youtrack.jetbrains.com/issue/KT-56203/AA-Publish-analysis-api-standalone-and-dependencies-to-Maven-Central
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
+    kotlin("jvm")
     id("packaging")
     id("com.gradleup.shadow") version "8.3.6"
 }
@@ -21,6 +24,11 @@ dependencies {
             attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.EXTERNAL))
         }
     }
+    compileOnly(libs.kotlin.compiler)
+}
+
+kotlin {
+    compilerOptions.jvmTarget = JvmTarget.JVM_1_8
 }
 
 java {

--- a/detekt-kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
+++ b/detekt-kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2023 Google LLC
+ * Copyright 2010-2023 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:Suppress("INVISIBLE_REFERENCE", "INVISIBLE_MEMBER")
+package com.google.devtools.ksp.standalone
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.search.GlobalSearchScope
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
+import org.jetbrains.kotlin.analysis.api.KaImplementationDetail
+import org.jetbrains.kotlin.analysis.api.impl.base.util.LibraryUtils
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibraryModule
+import org.jetbrains.kotlin.analysis.api.projectStructure.KaLibrarySourceModule
+import org.jetbrains.kotlin.analysis.api.standalone.base.projectStructure.StandaloneProjectFactory
+import org.jetbrains.kotlin.analysis.project.structure.builder.KtBinaryModuleBuilder
+import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleBuilderDsl
+import org.jetbrains.kotlin.analysis.project.structure.builder.KtModuleProviderBuilder
+import org.jetbrains.kotlin.analysis.project.structure.impl.KaLibraryModuleImpl
+import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreProjectEnvironment
+import java.nio.file.Path
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+
+@KtModuleBuilderDsl
+open class KspLibraryModuleBuilder(
+    private val kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment
+) : KtBinaryModuleBuilder() {
+    public lateinit var libraryName: String
+    public var librarySources: KaLibrarySourceModule? = null
+
+    override fun build(): KaLibraryModule = build(isSdk = false)
+
+    @OptIn(KaExperimentalApi::class)
+    fun build(isSdk: Boolean): KaLibraryModule {
+        val binaryRoots = getBinaryRoots()
+        val binaryVirtualFiles = getBinaryVirtualFiles()
+        val contentScope = LibraryRootsSearchScope(
+            StandaloneProjectFactory.getVirtualFilesForLibraryRoots(binaryRoots, kotlinCoreProjectEnvironment) +
+                binaryVirtualFiles
+        )
+        return KaLibraryModuleImpl(
+            directRegularDependencies,
+            directDependsOnDependencies,
+            directFriendDependencies,
+            contentScope,
+            platform,
+            kotlinCoreProjectEnvironment.project,
+            binaryRoots,
+            binaryVirtualFiles,
+            libraryName,
+            librarySources,
+            isSdk
+        )
+    }
+}
+
+@OptIn(ExperimentalContracts::class)
+inline fun KtModuleProviderBuilder.buildKspLibraryModule(init: KspLibraryModuleBuilder.() -> Unit): KaLibraryModule {
+    contract {
+        callsInPlace(init, InvocationKind.EXACTLY_ONCE)
+    }
+    return KspLibraryModuleBuilder(kotlinCoreProjectEnvironment).apply(init).build()
+}
+
+internal class SimpleTrie(paths: List<String>) {
+    class TrieNode {
+        var isTerminal: Boolean = false
+    }
+
+    val root = TrieNode()
+
+    private val m = mutableMapOf<Pair<TrieNode, String>, TrieNode>().apply {
+        paths.forEach { path ->
+            var p = root
+            for (d in path.trim('/').split('/')) {
+                p = getOrPut(Pair(p, d)) { TrieNode() }
+            }
+            p.isTerminal = true
+        }
+    }
+
+    fun contains(s: String): Boolean {
+        var p = root
+        for (d in s.trim('/').split('/')) {
+            p = m.get(Pair(p, d))?.also {
+                if (it.isTerminal)
+                    return true
+            } ?: return false
+        }
+        return false
+    }
+}
+
+internal class LibraryRootsSearchScope(roots: List<VirtualFile>) : GlobalSearchScope() {
+    val trie: SimpleTrie = SimpleTrie(roots.map { it.path })
+
+    override fun contains(file: VirtualFile): Boolean {
+        return trie.contains(file.path)
+    }
+
+    override fun isSearchInModuleContent(aModule: Module): Boolean = false
+
+    override fun isSearchInLibraries(): Boolean = true
+}
+
+@KtModuleBuilderDsl
+public class KspSdkModuleBuilder(
+    kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment
+) : KspLibraryModuleBuilder(kotlinCoreProjectEnvironment) {
+    @OptIn(KaImplementationDetail::class)
+    public fun addBinaryRootsFromJdkHome(jdkHome: Path, isJre: Boolean) {
+        val jdkRoots = LibraryUtils.findClassesFromJdkHome(jdkHome, isJre)
+        addBinaryRoots(jdkRoots)
+    }
+
+    override fun build(): KaLibraryModule = build(isSdk = true)
+}
+
+@OptIn(ExperimentalContracts::class)
+public inline fun KtModuleProviderBuilder.buildKspSdkModule(init: KspSdkModuleBuilder.() -> Unit): KaLibraryModule {
+    contract {
+        callsInPlace(init, InvocationKind.EXACTLY_ONCE)
+    }
+    return KspSdkModuleBuilder(kotlinCoreProjectEnvironment).apply(init).build()
+}

--- a/detekt-kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
+++ b/detekt-kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
@@ -37,6 +37,9 @@ import kotlin.contracts.ExperimentalContracts
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
+/* Copied from https://github.com/google/ksp/blob/5b2fd3c79b60f99ca643f362e564659176d900ac/kotlin-analysis-api/src/main/kotlin/com/google/devtools/ksp/standalone/KspLibraryModuleBuilder.kt
+ * Required as a workaround for KT-71706.
+ */
 @KtModuleBuilderDsl
 open class KspLibraryModuleBuilder(
     private val kotlinCoreProjectEnvironment: KotlinCoreProjectEnvironment


### PR DESCRIPTION
Will avoid #8113 from occurring when using module builders to configure the Standalone Analysis API session.

Closes #8113. But note that until usage of deprecated `buildKtModuleProviderByCompilerConfiguration` has been removed and replaced with `buildKtModuleProvider`, and the project structure is set up with this workaround, the issue will persist. This PR will ensure the workaround is used when that happens.