### PR TITLE
Remove use of ios() target shortcut in tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -283,7 +283,8 @@ class DetektMultiplatformSpec {
                         KMM_PLUGIN_BLOCK,
                         """
                             kotlin {
-                                ios()
+                                iosArm64()
+                                iosX64()
                             }
                         """.trimIndent(),
                         DETEKT_BLOCK,


### PR DESCRIPTION
Using this target is an error in Kotlin 2.2.0

