### PR TITLE
Don't add runtime dependencies to plugin under test classpath in min version test

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -218,7 +218,7 @@ tasks {
     }
 
     register<PluginUnderTestMetadata>("gradleMinVersionPluginUnderTestMetadata") {
-        pluginClasspath.setFrom(sourceSets.main.get().runtimeClasspath, testKitGradleMinVersionRuntimeOnly)
+        pluginClasspath.setFrom(sourceSets.main.get().output, testKitGradleMinVersionRuntimeOnly)
         outputDirectory = layout.buildDirectory.dir(name)
     }
 


### PR DESCRIPTION
The DGP runtime dependencies shouldn't be on the plugin classpath at all, as they include things like the Gradle runtime environment. Only the plugin output, plus other plugins required for the plugin tests, should be on the plugin classpath.

This issue was uncovered while testing Gradle 9 milestone builds.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
