### PR TITLE
Don't generate compatibility bridges and DefaultImpls classes for default implementations in interfaces

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -71,6 +71,7 @@ kotlin {
     compilerOptions {
         progressiveMode = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
+        freeCompilerArgs.add("-Xjvm-default=all")
     }
 }
 

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -30,7 +30,7 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/Config {
 	public abstract fun getParentPath ()Ljava/lang/String;
 	public abstract fun subConfig (Ljava/lang/String;)Lio/gitlab/arturbosch/detekt/api/Config;
 	public abstract fun subConfigKeys ()Ljava/util/Set;
-	public abstract fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
+	public fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun valueOrNull (Ljava/lang/String;)Ljava/lang/Object;
 }
 
@@ -43,10 +43,6 @@ public final class io/gitlab/arturbosch/detekt/api/Config$Companion {
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
 	public final fun getEmpty ()Lio/gitlab/arturbosch/detekt/api/Config;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Config$DefaultImpls {
-	public static fun valueOrDefault (Lio/gitlab/arturbosch/detekt/api/Config;Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Config$InvalidConfigurationError : java/lang/RuntimeException {
@@ -68,22 +64,12 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/ConfigValidator 
 	public abstract fun validate (Lio/gitlab/arturbosch/detekt/api/Config;)Ljava/util/Collection;
 }
 
-public final class io/gitlab/arturbosch/detekt/api/ConfigValidator$DefaultImpls {
-	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConfigValidator;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-}
-
 public abstract interface annotation class io/gitlab/arturbosch/detekt/api/Configuration : java/lang/annotation/Annotation {
 	public abstract fun description ()Ljava/lang/String;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/ConsoleReport : io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun render (Lio/gitlab/arturbosch/detekt/api/Detektion;)Ljava/lang/String;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/ConsoleReport$DefaultImpls {
-	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ConsoleReport;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
 public class io/gitlab/arturbosch/detekt/api/DetektVisitor : org/jetbrains/kotlin/psi/KtTreeVisitorVoid {
@@ -118,29 +104,15 @@ public final class io/gitlab/arturbosch/detekt/api/Entity$Companion {
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/Extension {
 	public abstract fun getId ()Ljava/lang/String;
-	public abstract fun getPriority ()I
-	public abstract fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Extension$DefaultImpls {
-	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/Extension;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/Extension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
+	public fun getPriority ()I
+	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/FileProcessListener : io/gitlab/arturbosch/detekt/api/Extension {
-	public abstract fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public abstract fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;)V
-	public abstract fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
-	public abstract fun onStart (Ljava/util/List;)V
-}
-
-public final class io/gitlab/arturbosch/detekt/api/FileProcessListener$DefaultImpls {
-	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-	public static fun onFinish (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public static fun onProcess (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;)V
-	public static fun onProcessComplete (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
-	public static fun onStart (Lio/gitlab/arturbosch/detekt/api/FileProcessListener;Ljava/util/List;)V
+	public fun onFinish (Ljava/util/List;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+	public fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;)V
+	public fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
+	public fun onStart (Ljava/util/List;)V
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Finding {
@@ -211,11 +183,7 @@ public final class io/gitlab/arturbosch/detekt/api/Location$Companion {
 public abstract interface class io/gitlab/arturbosch/detekt/api/Notification {
 	public abstract fun getLevel ()Lio/gitlab/arturbosch/detekt/api/Notification$Level;
 	public abstract fun getMessage ()Ljava/lang/String;
-	public abstract fun isError ()Z
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Notification$DefaultImpls {
-	public static fun isError (Lio/gitlab/arturbosch/detekt/api/Notification;)Z
+	public fun isError ()Z
 }
 
 public final class io/gitlab/arturbosch/detekt/api/Notification$Level : java/lang/Enum {
@@ -230,8 +198,6 @@ public final class io/gitlab/arturbosch/detekt/api/Notification$Level : java/lan
 public abstract class io/gitlab/arturbosch/detekt/api/OutputReport : io/gitlab/arturbosch/detekt/api/Extension {
 	public fun <init> ()V
 	public abstract fun getEnding ()Ljava/lang/String;
-	public fun getPriority ()I
-	public fun init (Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
 	public abstract fun render (Lio/gitlab/arturbosch/detekt/api/Detektion;)Ljava/lang/String;
 	public final fun write (Ljava/nio/file/Path;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
 }
@@ -253,17 +219,9 @@ public abstract interface class io/gitlab/arturbosch/detekt/api/PropertiesAware 
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/ReportingExtension : io/gitlab/arturbosch/detekt/api/Extension {
-	public abstract fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public abstract fun onRawResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public abstract fun transformIssues (Ljava/util/List;)Ljava/util/List;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/ReportingExtension$DefaultImpls {
-	public static fun getPriority (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;)I
-	public static fun init (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/SetupContext;)V
-	public static fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public static fun onRawResult (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Lio/gitlab/arturbosch/detekt/api/Detektion;)V
-	public static fun transformIssues (Lio/gitlab/arturbosch/detekt/api/ReportingExtension;Ljava/util/List;)Ljava/util/List;
+	public fun onFinalResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+	public fun onRawResult (Lio/gitlab/arturbosch/detekt/api/Detektion;)V
+	public fun transformIssues (Ljava/util/List;)Ljava/util/List;
 }
 
 public abstract interface class io/gitlab/arturbosch/detekt/api/RequiresFullAnalysis {

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -65,16 +65,12 @@ public abstract class io/github/detekt/tooling/api/DetektError : java/lang/Runti
 public abstract interface class io/github/detekt/tooling/api/DetektProvider {
 	public static final field Companion Lio/github/detekt/tooling/api/DetektProvider$Companion;
 	public abstract fun get (Lio/github/detekt/tooling/api/spec/ProcessingSpec;)Lio/github/detekt/tooling/api/Detekt;
-	public abstract fun getPriority ()I
+	public fun getPriority ()I
 }
 
 public final class io/github/detekt/tooling/api/DetektProvider$Companion {
 	public final fun load (Ljava/lang/ClassLoader;)Lio/github/detekt/tooling/api/DetektProvider;
 	public static synthetic fun load$default (Lio/github/detekt/tooling/api/DetektProvider$Companion;Ljava/lang/ClassLoader;ILjava/lang/Object;)Lio/github/detekt/tooling/api/DetektProvider;
-}
-
-public final class io/github/detekt/tooling/api/DetektProvider$DefaultImpls {
-	public static fun getPriority (Lio/github/detekt/tooling/api/DetektProvider;)I
 }
 
 public final class io/github/detekt/tooling/api/InvalidConfig : io/github/detekt/tooling/api/DetektError {


### PR DESCRIPTION
There is new default behaviour in Kotlin 2.2.0. For details refer to:
* https://kotlinlang.org/docs/whatsnew-eap.html#changes-to-default-method-generation-for-interface-functions
* https://youtrack.jetbrains.com/issue/KT-71768/Enable-Xjvm-defaultall-compatibility-by-default-to-generate-JVM-default-interface-methods
* https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/

Switching to `all` (or with the new flag introduced in 2.2.0, `-jvm-default=no-compatibility`) is a better option for detekt v2 release. We don't need binary compatibility (since lots of API changes are being introduced) and it reduces the number of generated methods & classes.