### PR TITLE
Show diagnostic errors on console when using Analysis API

### DIFF
--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/tooling/Lifecycle.kt
@@ -1,5 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.tooling
 
+import io.github.detekt.parser.DetektMessageCollector
 import io.github.detekt.parser.generateBindingContext
 import io.github.detekt.tooling.api.AnalysisMode
 import io.gitlab.arturbosch.detekt.api.Config
@@ -17,6 +18,12 @@ import io.gitlab.arturbosch.detekt.core.reporting.OutputFacade
 import io.gitlab.arturbosch.detekt.core.rules.createRuleProviders
 import io.gitlab.arturbosch.detekt.core.util.PerformanceMonitor.Phase
 import io.gitlab.arturbosch.detekt.core.util.getOrCreateMonitor
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
+import org.jetbrains.kotlin.analysis.api.diagnostics.KaSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocationWithRange
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.diagnostics.DiagnosticUtils.getLineAndColumnRangeInPsiFile
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
@@ -69,6 +76,33 @@ internal class DefaultLifecycle(
     override val bindingProvider: (files: List<KtFile>) -> BindingContext =
         {
             if (settings.spec.projectSpec.analysisMode == AnalysisMode.full) {
+                val collector = DetektMessageCollector(CompilerMessageSeverity.ERROR, settings::debug, settings::info)
+
+                it.forEach { file: KtFile ->
+                    analyze(file) {
+                        file.collectDiagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS).forEach { diagnostic ->
+                            val lineAndColumnRange =
+                                getLineAndColumnRangeInPsiFile(diagnostic.psi.containingFile, diagnostic.psi.textRange)
+
+                            val location = CompilerMessageLocationWithRange.create(
+                                diagnostic.psi.containingFile.virtualFile.path,
+                                lineAndColumnRange.start.line,
+                                lineAndColumnRange.start.column,
+                                lineAndColumnRange.end.line,
+                                lineAndColumnRange.end.column,
+                                lineAndColumnRange.start.lineContent
+                            )
+                            collector.report(
+                                diagnostic.severity.toCompilerMessageSeverity(),
+                                diagnostic.defaultMessage,
+                                location
+                            )
+                        }
+                    }
+                }
+
+                collector.printIssuesCountIfAny(k2Mode = true)
+
                 generateBindingContext(
                     settings.project,
                     settings.configuration,
@@ -85,3 +119,10 @@ internal class DefaultLifecycle(
     override val ruleSetsProvider: () -> List<RuleSetProvider> =
         { settings.createRuleProviders() },
 ) : Lifecycle
+
+private fun KaSeverity.toCompilerMessageSeverity(): CompilerMessageSeverity =
+    when (this) {
+        KaSeverity.ERROR -> CompilerMessageSeverity.ERROR
+        KaSeverity.WARNING -> CompilerMessageSeverity.WARNING
+        KaSeverity.INFO -> CompilerMessageSeverity.INFO
+    }

--- a/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/io/github/detekt/parser/BindingContextUtils.kt
@@ -70,7 +70,7 @@ fun generateBindingContext(
     return analyzer.analysisResult.bindingContext
 }
 
-internal class DetektMessageCollector(
+class DetektMessageCollector(
     private val minSeverity: CompilerMessageSeverity,
     private val debugPrinter: (() -> String) -> Unit,
     private val warningPrinter: (String) -> Unit,
@@ -84,10 +84,11 @@ internal class DetektMessageCollector(
         }
     }
 
-    fun printIssuesCountIfAny() {
+    fun printIssuesCountIfAny(k2Mode: Boolean = false) {
         if (messages > 0) {
             warningPrinter(
-                "There were $messages compiler errors found during analysis. This affects accuracy of reporting.\n" +
+                "There were $messages compiler errors found during ${if (!k2Mode) "legacy compiler " else ""}" +
+                    "analysis. This affects accuracy of reporting.\n" +
                     "Run detekt CLI with --debug or set `detekt { debug = true }` in Gradle to see the error messages."
             )
         }

--- a/detekt-parser/src/test/kotlin/io/github/detekt/parser/DetektMessageCollectorSpec.kt
+++ b/detekt-parser/src/test/kotlin/io/github/detekt/parser/DetektMessageCollectorSpec.kt
@@ -36,7 +36,7 @@ class DetektMessageCollectorSpec {
 
         @Test
         fun `adds up to the message count`() {
-            subject.printIssuesCountIfAny()
+            subject.printIssuesCountIfAny(k2Mode = true)
 
             assertThat(warningPrinter.messages).contains(
                 """
@@ -61,7 +61,7 @@ class DetektMessageCollectorSpec {
 
         @Test
         fun `adds up to the message count`() {
-            subject.printIssuesCountIfAny()
+            subject.printIssuesCountIfAny(k2Mode = true)
 
             assertThat(warningPrinter.messages).contains(
                 """


### PR DESCRIPTION
This will display any diagnostic errors reported by the Analysis API, in the same way as they are reported for the legacy compiler.

Many issues will be reported when detekt runs against itself after this PR - a follow up PR will setup the proper analysis environment and clear them.

Required for #8047