### PR TITLE
Migrate MapGetWithNotNullAssertionOperator to Analysis API

### DIFF
--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
+    compileOnly(projects.detektKotlinAnalysisApi)
     compileOnly(projects.detektPsiUtils)
     implementation(projects.detektTooling)
     testImplementation(projects.detektTest)

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -4,13 +4,15 @@ import io.gitlab.arturbosch.detekt.api.ActiveByDefault
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Entity
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
+import io.gitlab.arturbosch.detekt.api.RequiresAnalysisApi
 import io.gitlab.arturbosch.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtPostfixExpression
-import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
-import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 
 /**
  * Reports calls of the map access methods `map[]` or `map.get()` with a not-null assertion operator `!!`.
@@ -48,7 +50,7 @@ class MapGetWithNotNullAssertionOperator(config: Config) :
         "map.get() with not-null assertion operator (!!) can result in a NullPointerException. " +
             "Consider usage of map.getValue(), map.getOrDefault() or map.getOrElse() instead."
     ),
-    RequiresFullAnalysis {
+    RequiresAnalysisApi {
 
     override fun visitPostfixExpression(expression: KtPostfixExpression) {
         if (expression.operationToken == KtTokens.EXCLEXCL && expression.isMapGet()) {
@@ -57,10 +59,17 @@ class MapGetWithNotNullAssertionOperator(config: Config) :
         super.visitPostfixExpression(expression)
     }
 
-    private fun KtPostfixExpression.isMapGet(): Boolean =
-        this
-            .baseExpression
-            .getResolvedCall(bindingContext)
-            ?.resultingDescriptor
-            ?.fqNameSafe == FqName("kotlin.collections.Map.get")
+    private fun KtPostfixExpression.isMapGet(): Boolean {
+        val postfixExpression = baseExpression ?: return false
+
+        val equalsCallableId = CallableId(StandardClassIds.Map, org.jetbrains.kotlin.name.Name.identifier("get"))
+
+        analyze(postfixExpression) {
+            return postfixExpression
+                .resolveToCall()
+                ?.successfulFunctionCallOrNull()
+                ?.symbol
+                ?.callableId == equalsCallableId
+        }
+    }
 }


### PR DESCRIPTION
First rule migrated to Kotlin Analysis API 🥇 

Part of #8041 

Stacks on:
* #8037 
* #8153
* #8154 
* #8156 