### PR TITLE
Use standard binary Gradle wrapper distribution for detekt-sample-extensions

### DIFF
--- a/detekt-sample-extensions/gradle/wrapper/gradle-wrapper.properties
+++ b/detekt-sample-extensions/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
See #7955