### PR TITLE
Fail when JUnit identifies test discovery issues

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -31,6 +31,7 @@ jacoco.toolVersion = versionCatalog.findVersion("jacoco").get().requiredVersion
 tasks.withType<Test>().configureEach {
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
     systemProperty("junit.jupiter.testinstance.lifecycle.default", "per_class")
+    systemProperty("junit.platform.discovery.issue.severity.critical", "INFO")
     val compileTestSnippets = providers.gradleProperty("compile-test-snippets").orNull.toBoolean()
     systemProperty("compile-test-snippets", compileTestSnippets)
     val compileTestSnippetsAa = providers.gradleProperty("compile-test-snippets-aa").orNull.toBoolean()

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/util/ConfigExtensionsSpec.kt
@@ -7,7 +7,6 @@ import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class IsActiveOrDefaultSpec {
@@ -31,7 +30,6 @@ class IsActiveOrDefaultSpec {
     }
 }
 
-@Nested
 class ShouldAnalyzeFileSpec {
 
     private val basePath = resourceAsPath("cases")

--- a/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -14,6 +14,7 @@ class ReturnFromFinallySpec(val env: KotlinEnvironmentContainer) {
 
     val subject = ReturnFromFinally(Config.empty)
 
+    @Nested
     inner class `a finally block with a return statement` {
         val code = """
             fun x() {


### PR DESCRIPTION
https://junit.org/junit5/docs/5.13.1/user-guide/#running-tests-discovery-issues

> To surface all discovery issues in your project, it is recommended to set the `junit.platform.discovery.issue.severity.critical` configuration parameter to `INFO`.
