### PR TITLE
Make CloseableWrapper implement AutoCloseable

### DIFF
--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -51,7 +51,7 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
 
     @Suppress("DEPRECATION")
     private class CloseableWrapper(val wrapper: KotlinCoreEnvironmentWrapper) :
-        ExtensionContext.Store.CloseableResource {
+        ExtensionContext.Store.CloseableResource, AutoCloseable {
         override fun close() {
             wrapper.dispose()
         }


### PR DESCRIPTION
Fixes the following JUnit warning:

```
WARNING: Type implements CloseableResource but not AutoCloseable: io.gitlab.arturbosch.detekt.rules.KotlinEnvironmentResolver$CloseableWrapper
```