### PR TITLE
Rename Rule to RuleName

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -238,7 +238,7 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	protected final fun getCompilerResources ()Lio/gitlab/arturbosch/detekt/api/CompilerResources;
 	public final fun getConfig ()Lio/gitlab/arturbosch/detekt/api/Config;
 	public final fun getDescription ()Ljava/lang/String;
-	public fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/Rule$Name;
+	public fun getRuleName ()Lio/gitlab/arturbosch/detekt/api/RuleName;
 	public final fun getUrl ()Ljava/net/URI;
 	protected fun postVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	protected fun preVisit (Lorg/jetbrains/kotlin/psi/KtFile;)V
@@ -247,14 +247,6 @@ public class io/gitlab/arturbosch/detekt/api/Rule : io/gitlab/arturbosch/detekt/
 	protected final fun setCompilerResources (Lio/gitlab/arturbosch/detekt/api/CompilerResources;)V
 	public fun visit (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public final fun visitFile (Lorg/jetbrains/kotlin/psi/KtFile;Lio/gitlab/arturbosch/detekt/api/CompilerResources;)Ljava/util/List;
-}
-
-public final class io/gitlab/arturbosch/detekt/api/Rule$Name {
-	public fun <init> (Ljava/lang/String;)V
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getValue ()Ljava/lang/String;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
@@ -266,6 +258,14 @@ public final class io/gitlab/arturbosch/detekt/api/RuleInstance {
 	public final fun getRuleSetId ()Lio/gitlab/arturbosch/detekt/api/RuleSet$Id;
 	public final fun getSeverity ()Lio/gitlab/arturbosch/detekt/api/Severity;
 	public final fun getUrl ()Ljava/net/URI;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/gitlab/arturbosch/detekt/api/RuleName {
+	public fun <init> (Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Rule.kt
@@ -28,7 +28,7 @@ open class Rule(
      *
      * By default, it is the name of the class name. Override to change it.
      */
-    open val ruleName: Name get() = Name(javaClass.simpleName)
+    open val ruleName: RuleName get() = RuleName(javaClass.simpleName)
 
     protected lateinit var compilerResources: CompilerResources
     private lateinit var _bindingContext: BindingContext
@@ -97,13 +97,13 @@ open class Rule(
     fun setBindingContext(bindingContext: BindingContext) {
         _bindingContext = bindingContext
     }
+}
 
-    @Poko
-    class Name(val value: String) {
-        init {
-            validateIdentifier(value)
-        }
-
-        override fun toString(): String = value
+@Poko
+class RuleName(val value: String) {
+    init {
+        validateIdentifier(value)
     }
+
+    override fun toString(): String = value
 }

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/RuleSet.kt
@@ -6,7 +6,7 @@ import io.gitlab.arturbosch.detekt.api.internal.validateIdentifier
 /**
  * A rule set is a collection of rules and must be defined within a rule set provider implementation.
  */
-class RuleSet(val id: Id, val rules: Map<Rule.Name, (Config) -> Rule>) {
+class RuleSet(val id: Id, val rules: Map<RuleName, (Config) -> Rule>) {
     companion object {
         operator fun invoke(id: Id, rules: List<(Config) -> Rule>): RuleSet =
             RuleSet(id, rules.associateBy { it(Config.empty).ruleName })

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptor.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/RuleDescriptor.kt
@@ -5,6 +5,7 @@ import io.gitlab.arturbosch.detekt.api.RequiresAnalysisApi
 import io.gitlab.arturbosch.detekt.api.RequiresFullAnalysis
 import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleInstance
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.Severity
@@ -70,7 +71,7 @@ private fun RuleSet.getRules(
         }
     }
 
-private fun generateDefaultUrl(ruleSetId: RuleSet.Id, ruleName: Rule.Name) =
+private fun generateDefaultUrl(ruleSetId: RuleSet.Id, ruleName: RuleName) =
     URI("https://detekt.dev/docs/${whichDetekt()}/rules/${ruleSetId.value.lowercase()}#${ruleName.value.lowercase()}")
 
 private val externalFirstPartyRuleSets = setOf(
@@ -98,5 +99,5 @@ private fun parseToSeverity(severity: String): Severity {
         ?: error("'$severity' is not a valid Severity. Allowed values are ${Severity.entries}")
 }
 
-internal fun extractRuleName(key: String): Rule.Name? =
-    runCatching { Rule.Name(key.substringBefore("/")) }.getOrNull()
+internal fun extractRuleName(key: String): RuleName? =
+    runCatching { RuleName(key.substringBefore("/")) }.getOrNull()

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProvider.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.rules
 
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 
@@ -12,7 +12,7 @@ internal class SingleRuleProvider private constructor(
     override fun instance() = ruleSet
 
     companion object {
-        operator fun invoke(ruleName: Rule.Name, wrapped: RuleSetProvider): SingleRuleProvider {
+        operator fun invoke(ruleName: RuleName, wrapped: RuleSetProvider): SingleRuleProvider {
             val ruleProvider = requireNotNull(wrapped.instance().rules[ruleName]) {
                 "There was not rule '$ruleName' in rule set '${wrapped.ruleSetId}'."
             }

--- a/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
+++ b/detekt-core/src/main/kotlin/io/gitlab/arturbosch/detekt/core/suppressors/Suppressions.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.suppressors
 
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.extractRuleName
 import org.jetbrains.kotlin.psi.KtAnnotated
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import kotlin.text.RegexOption.IGNORE_CASE
 
 internal fun isForbiddenSuppressById(id: String) = extractRuleName(id) == FORBIDDEN_SUPPRESS_NAME
-private val FORBIDDEN_SUPPRESS_NAME = Rule.Name("ForbiddenSuppress")
+private val FORBIDDEN_SUPPRESS_NAME = RuleName("ForbiddenSuppress")
 
 /**
  * Checks if this psi element is suppressed by @Suppress or @SuppressWarnings annotations.

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/RuleSetsSpec.kt
@@ -3,7 +3,7 @@ package io.gitlab.arturbosch.detekt.core.rules
 import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
 import io.github.detekt.tooling.api.spec.RulesSpec.RunPolicy.RestrictToSingleRule
-import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
@@ -58,7 +58,7 @@ class RuleSetsSpec {
         assertThat(providers.map { it.ruleSetId.value })
             .containsExactlyInAnyOrder("style")
         assertThat(providers.single().instance().rules)
-            .containsOnlyKeys(Rule.Name("MagicNumber"))
+            .containsOnlyKeys(RuleName("MagicNumber"))
     }
 
     @ParameterizedTest

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/rules/SingleRuleProviderSpec.kt
@@ -2,6 +2,7 @@ package io.gitlab.arturbosch.detekt.core.rules
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import org.assertj.core.api.Assertions.assertThat
@@ -14,7 +15,7 @@ class SingleRuleProviderSpec {
     @ParameterizedTest
     @ValueSource(strings = ["CustomRule1", "CustomRule2"])
     fun `constructs the expected RuleSetProvider`(ruleNameString: String) {
-        val ruleName = Rule.Name(ruleNameString)
+        val ruleName = RuleName(ruleNameString)
         val wrappedRuleSet = CustomRuleSetProvider()
         val subject = SingleRuleProvider(ruleName, wrappedRuleSet)
         assertThat(subject.ruleSetId.value).isEqualTo("custom")
@@ -26,7 +27,7 @@ class SingleRuleProviderSpec {
     @Test
     fun `throws when the rule name doesn't exist`() {
         assertThatThrownBy {
-            SingleRuleProvider(Rule.Name("ARule"), CustomRuleSetProvider())
+            SingleRuleProvider(RuleName("ARule"), CustomRuleSetProvider())
         }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessage("There was not rule 'ARule' in rule set 'custom'.")

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/config/ConfigAssert.kt
@@ -3,6 +3,7 @@ package io.gitlab.arturbosch.detekt.generator.config
 import io.github.classgraph.ClassGraph
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
 import io.gitlab.arturbosch.detekt.core.config.YamlConfig
@@ -54,7 +55,7 @@ class ConfigAssert(
         val clazz = rule::class.java
         assertThat(rule.ruleName)
             .withFailMessage { "rule $clazz declares the rule id ${rule.ruleName} instead of ${clazz.simpleName}" }
-            .isEqualTo(Rule.Name(clazz.simpleName))
+            .isEqualTo(RuleName(clazz.simpleName))
     }
 
     private fun getYmlRuleConfig() = config.subConfig(name) as? YamlConfig

--- a/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtElement
@@ -34,7 +35,6 @@ import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.source.getPsi
 import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
-import org.jetbrains.kotlin.name.Name as KotlinName
 
 /**
  * `suspend` functions should not be called inside `runCatching`'s lambda block, because `runCatching` catches all the
@@ -310,6 +310,6 @@ class SuspendFunSwallowedCancellation(config: Config) :
         // Based on code from Kotlin project:
         // https://github.com/JetBrains/kotlin/commit/87bbac9d43e15557a2ff0dc3254fd41a9d5639e1
         private val COROUTINE_CONTEXT_FQ_NAME =
-            COROUTINES_PACKAGE_FQ_NAME.child(KotlinName.identifier("coroutineContext"))
+            COROUTINES_PACKAGE_FQ_NAME.child(Name.identifier("coroutineContext"))
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/MapGetWithNotNullAssertionOperator.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtPostfixExpression
 
@@ -62,7 +63,7 @@ class MapGetWithNotNullAssertionOperator(config: Config) :
     private fun KtPostfixExpression.isMapGet(): Boolean {
         val postfixExpression = baseExpression ?: return false
 
-        val equalsCallableId = CallableId(StandardClassIds.Map, org.jetbrains.kotlin.name.Name.identifier("get"))
+        val equalsCallableId = CallableId(StandardClassIds.Map, Name.identifier("get"))
 
         analyze(postfixExpression) {
             return postfixExpression

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/NullableToStringCall.kt
@@ -11,6 +11,7 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.StandardClassIds.BASE_KOTLIN_PACKAGE
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
@@ -80,6 +81,6 @@ class NullableToStringCall(config: Config) :
     }
 
     companion object {
-        val toString = CallableId(BASE_KOTLIN_PACKAGE, org.jetbrains.kotlin.name.Name.identifier("toString"))
+        val toString = CallableId(BASE_KOTLIN_PACKAGE, Name.identifier("toString"))
     }
 }

--- a/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnnecessaryNotNullCheck.kt
@@ -9,6 +9,7 @@ import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.successfulFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.StandardClassIds.BASE_KOTLIN_PACKAGE
 import org.jetbrains.kotlin.psi.KtCallExpression
 
@@ -65,8 +66,8 @@ class UnnecessaryNotNullCheck(config: Config) :
 
     companion object {
         private val notNullCheckFunctionFqNames = listOf(
-            CallableId(BASE_KOTLIN_PACKAGE, org.jetbrains.kotlin.name.Name.identifier("requireNotNull")),
-            CallableId(BASE_KOTLIN_PACKAGE, org.jetbrains.kotlin.name.Name.identifier("checkNotNull")),
+            CallableId(BASE_KOTLIN_PACKAGE, Name.identifier("requireNotNull")),
+            CallableId(BASE_KOTLIN_PACKAGE, Name.identifier("checkNotNull")),
         )
     }
 }


### PR DESCRIPTION
Closes #8092

`Rule.Name` conflicted with `org.jetbrains.kotlin.name.Name`. This PR renames `Rule.Name` with `RuleName` to avoid that collision.