### PR TITLE
Remove failOnSeverity from 1.x docs

### DIFF
--- a/website/versioned_docs/version-1.23.8/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-1.23.8/gettingstarted/gradle.mdx
@@ -224,12 +224,6 @@ detekt {
     // If set to `true` the build does not fail when there are any issues.
     // Defaults to `false`.
     ignoreFailures = false
-
-    // The build fails when there is at least one issue with this severity (or above).
-    // If set ot `Never`, the task will not fail regardless of the number of issues and their severities.
-    // If `ignoreFailures` is set to `true`, the value of this property is ignored.
-    // Defaults to `Error`
-    failOnSeverity = io.gitlab.arturbosch.detekt.extensions.FailOnSeverity.Error
     
     // Android: Don't create tasks for the specified build types (e.g. "release")
     ignoredBuildTypes = ["release"]
@@ -285,12 +279,6 @@ detekt {
     // If set to `true` the build does not fail when there are any issues.
     // Defaults to `false`.
     ignoreFailures = false
-
-    // The build fails when there is at least one issue with this severity (or above).
-    // If set ot `Never`, the task will not fail regardless of the number of issues and their severities.
-    // If `ignoreFailures` is set to `true`, the value of this property is ignored.
-    // Defaults to `Error`
-    failOnSeverity = io.gitlab.arturbosch.detekt.extensions.FailOnSeverity.Error
 
     // Android: Don't create tasks for the specified build types (e.g. "release")
     ignoredBuildTypes = listOf("release")

--- a/website/versioned_docs/version-1.23.8/introduction/configurations.mdx
+++ b/website/versioned_docs/version-1.23.8/introduction/configurations.mdx
@@ -121,9 +121,7 @@ everyone can benefit from it.
 
 ## Build failure
 
-_detekt_ will fail your build if there is at least one issue with a severity of error. You can lower that threshold
-or completely disable build failures by using the `failOnSeverity` setting. Details can be found in the
-[gradle](/docs/gettingstarted/gradle) and the [cli](/docs/gettingstarted/cli) sections.
+_detekt_ will fail your build if there is at least one issue with a severity of error.
 
 ## Console Reports
 


### PR DESCRIPTION
`failOnSeverity` has been introduced in #6417 and should not be included in the 1.23.8 docs

Fixes https://github.com/detekt/detekt/issues/8103