### PR TITLE
use gradle wrapper in contribution docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 - Read [this article](https://chris.beams.io/posts/git-commit/) before writing commit messages.
 - Before running any tests, run `./gradlew publishToMavenLocal` to ensure that all tests are using the locally built artifact (c.f. issue [#6708](https://github.com/detekt/detekt/issues/6708) and PR [#6415](https://github.com/detekt/detekt/pull/6415)). Otherwise, the tests will pull a possibly outdated version of detekt from Maven Central or Sonatype.
 - Use `./gradlew build -x dokkaGenerate` to build the source but exclude documentation JAR generation to save time.
-- Make sure that `./gradlew detekt detektMain detektTest` does not report any errors.
+- Make sure that `./gradlew detektMain detektTest` does not report any errors.
 - This repository follows the [Kotlin coding conventions](https://kotlinlang.org/docs/reference/coding-conventions.html),
   which are enforced by ktlint when running the `detekt` Gradle tasks on the project itself.
 - Make sure your IDE uses [ktlint](https://github.com/pinterest/ktlint) formatting rules as well


### PR DESCRIPTION
I ran into the issue that `dokkaHtml` is not a valid task anymore and found that there was a mix between `gradle` and `gradlew`.
