### PR TITLE
Update Analysis API repository location

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -79,6 +79,6 @@ dependencyResolutionManagement {
     repositories {
         mavenCentral()
         // Remove when this is closed: https://youtrack.jetbrains.com/issue/KT-56203/AA-Publish-analysis-api-standalone-and-dependencies-to-Maven-Central
-        maven("https://redirector.kotlinlang.org/maven/kotlin-ide-plugin-dependencies")
+        maven("https://redirector.kotlinlang.org/maven/intellij-dependencies")
     }
 }


### PR DESCRIPTION
Update Analysis API repository location as it seems to have changed. I've [raised an issue](https://youtrack.jetbrains.com/issue/KT-78662/Analysis-API-2.2.0-artifacts-not-published) on the Kotlin issue tracker to confirm but this seems to be the new location and should unblock the Kotlin 2.2.0 update.

The repository is also using the new redirector from JetBrains. From a PR on google/ksp:

> At JetBrains, we are moving our Maven repositories to a new
> hosting URL. Instead of using a direct link to the repositories,
> we’ve created a redirector that points to the current artifact
> location. This way, we won’t need to update the URL in projects
> using our Maven repositories in the future.

https://github.com/google/ksp/pull/2419

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
