### PR TITLE
Remove `CloseableWrapper`

### DIFF
--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -16,10 +16,10 @@ public final class io/github/detekt/test/utils/KotlinAnalysisApiEngine {
 	public static synthetic fun compile$default (Lio/github/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
-public final class io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper {
+public final class io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper : java/lang/AutoCloseable, org/junit/jupiter/api/extension/ExtensionContext$Store$CloseableResource {
 	public fun <init> (Lcom/intellij/openapi/project/Project;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/Disposable;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;)V
 	public synthetic fun <init> (Lcom/intellij/openapi/project/Project;Lorg/jetbrains/kotlin/config/CompilerConfiguration;Lcom/intellij/openapi/Disposable;Lio/github/detekt/test/utils/KotlinEnvironmentContainer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun dispose ()V
+	public fun close ()V
 	public final fun getEnv ()Lio/github/detekt/test/utils/KotlinEnvironmentContainer;
 }
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinCoreEnvironmentWrapper.kt
@@ -5,21 +5,24 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISession
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.junit.jupiter.api.extension.ExtensionContext
 import java.io.File
 
 class KotlinEnvironmentContainer(val project: Project, val configuration: CompilerConfiguration)
 
 /**
- * Make sure to always call [dispose] or use a [use] block when working with [StandaloneAnalysisAPISession]s.
+ * Make sure to always call [close] or use a [use] block when working with [StandaloneAnalysisAPISession]s.
  */
 class KotlinCoreEnvironmentWrapper(
     private val project: Project,
     private val configuration: CompilerConfiguration,
     private val disposable: Disposable,
     val env: KotlinEnvironmentContainer = KotlinEnvironmentContainer(project, configuration),
-) {
-
-    fun dispose() {
+) :
+    @Suppress("DEPRECATION")
+    ExtensionContext.Store.CloseableResource,
+    AutoCloseable {
+    override fun close() {
         Disposer.dispose(disposable)
     }
 }

--- a/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-utils/src/main/kotlin/io/gitlab/arturbosch/detekt/rules/KotlinEnvironmentTestSetup.kt
@@ -19,8 +19,8 @@ annotation class KotlinCoreEnvironmentTest(
 )
 
 internal class KotlinEnvironmentResolver : ParameterResolver {
-    private var ExtensionContext.wrapper: CloseableWrapper?
-        get() = getStore(NAMESPACE)[WRAPPER_KEY, CloseableWrapper::class.java]
+    private var ExtensionContext.wrapper: KotlinCoreEnvironmentWrapper?
+        get() = getStore(NAMESPACE)[WRAPPER_KEY, KotlinCoreEnvironmentWrapper::class.java]
         set(value) = getStore(NAMESPACE).put(WRAPPER_KEY, value)
 
     override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
@@ -28,15 +28,13 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
 
     override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Any {
         val closeableWrapper = extensionContext.wrapper
-            ?: CloseableWrapper(
-                createEnvironment(
-                    additionalRootPaths = checkNotNull(
-                        classpathFromClassloader(Thread.currentThread().contextClassLoader)
-                    ) { "We should always have a classpath" },
-                    additionalJavaSourceRootPaths = extensionContext.additionalJavaSourcePaths(),
-                )
+            ?: createEnvironment(
+                additionalRootPaths = checkNotNull(
+                    classpathFromClassloader(Thread.currentThread().contextClassLoader)
+                ) { "We should always have a classpath" },
+                additionalJavaSourceRootPaths = extensionContext.additionalJavaSourcePaths(),
             ).also { extensionContext.wrapper = it }
-        return closeableWrapper.wrapper.env
+        return closeableWrapper.env
     }
 
     companion object {
@@ -46,14 +44,6 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
             val annotation = requiredTestClass.annotations
                 .find { it is KotlinCoreEnvironmentTest } as? KotlinCoreEnvironmentTest ?: return emptyList()
             return annotation.additionalJavaSourcePaths.map { resourceAsPath(it).toFile() }
-        }
-    }
-
-    @Suppress("DEPRECATION")
-    private class CloseableWrapper(val wrapper: KotlinCoreEnvironmentWrapper) :
-        ExtensionContext.Store.CloseableResource, AutoCloseable {
-        override fun close() {
-            wrapper.dispose()
         }
     }
 }


### PR DESCRIPTION
`CloseableWrapper` was a wrapper of a wrapper.  Probably we don't even need any wrapper at all but we can at least remove this one.

It's a bit odd to add `ExtensionContext.Store.CloseableResource` to `KotlinCoreEnvironmentWrapper` but it is there just for retrocompatibility. We could remove it at any moment, we it only needs to implement `AutoCloseable`.

Related with https://github.com/detekt/detekt/pull/8176#discussion_r2135390031