### PR TITLE
Setup AA session in production mode

### DIFF
--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinAnalysisApiEngine.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KotlinAnalysisApiEngine.kt
@@ -46,7 +46,7 @@ object KotlinAnalysisApiEngine {
         val disposable = Disposer.newDisposable()
 
         @OptIn(KaImplementationDetail::class, KaPlatformInterface::class)
-        val session = buildStandaloneAnalysisAPISession(disposable, unitTestMode = true) {
+        val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
                 platform = targetPlatform
 

--- a/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
+++ b/detekt-test-utils/src/main/kotlin/io/github/detekt/test/utils/KtTestCompiler.kt
@@ -53,7 +53,7 @@ internal object KtTestCompiler : KtCompiler() {
         }
 
         val parentDisposable = Disposer.newDisposable()
-        val analysisSession = buildStandaloneAnalysisAPISession(parentDisposable, unitTestMode = true) {
+        val analysisSession = buildStandaloneAnalysisAPISession(parentDisposable) {
             @Suppress("DEPRECATION") // Required until fully transitioned to setting up Kotlin Analysis API session
             buildKtModuleProviderByCompilerConfiguration(configuration)
 


### PR DESCRIPTION
detekt does not unit test Analysis API so enabling unit testing mode is not correct. This configuration also caused issues when upgrading to Kotlin 2.2.0.

Also see https://github.com/detekt/detekt/pull/8098#issuecomment-3066717563

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
