### PR TITLE
[ForbiddenMethodCall] Fix false positive with getters and setters

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -651,6 +651,25 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
             ).lintWithContext(env, code)
             assertThat(findings).hasSize(1)
         }
+
+        @Test
+        fun `should report property getter and setter call`() {
+            val code = """
+                import java.util.Calendar
+                
+                fun main() {
+                    val calendar = Calendar.getInstance()
+                    val day = calendar.firstDayOfWeek
+                    calendar.firstDayOfWeek = 1
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(
+                TestConfig(
+                    METHODS to listOf("java.util.Calendar.getFirstDayOfWeek", "java.util.Calendar.setFirstDayOfWeek"),
+                )
+            ).lintWithContext(env, code)
+            assertThat(findings).hasSize(2)
+        }
     }
 
     @Test


### PR DESCRIPTION
Fix #8282

If you report the getter and then you use the setter `ForbiddenMethodCall` was reporting it as an issue. In my test case without the fix I was getting 4 issues but there were only 2.