### PR TITLE
Avoid compile=false on UnnecessaryInnerClassSpec

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryInnerClassSpec.kt
@@ -192,7 +192,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinEnvironmentContainer) {
                         inner class B {
                             val fizz = "BUZZ"
                             fun printFoo() {
-                                if (fizz == "BUZZ" && foo) {
+                                if (fizz == "BUZZ" && foo == "BAR") {
                                     println("FOO")
                                 }
                             }
@@ -200,7 +200,7 @@ class UnnecessaryInnerClassSpec(val env: KotlinEnvironmentContainer) {
                     }
                 """.trimIndent()
 
-                assertThat(subject.lintWithContext(env, code, compile = false)).isEmpty()
+                assertThat(subject.lintWithContext(env, code)).isEmpty()
             }
         }
 


### PR DESCRIPTION
When this code was created it used only `lintWithContext` instead of the old `compileAndLintWithContext`. Then, at some point I did a pass and changed all the `lintWithContext` for `compileAndLintWithContext` and keep the ones that compiled with `compileAndLintWithContext`. And because this one had a real compilation problem I kept it with `lintWithContext`. In that moment I was changing a lot of tests so I didn't have the time to check each one.

Now I see that this `compile=false` could be avoided just fixing the code. That's what I'm doing now. Make the code compile and remove `compile=false`. This doesn't change what this test is testing.