### PR TITLE
Cleanup publishing logic between maven-publish and nexus-publish

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -43,4 +43,4 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
           ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-        run: ./gradlew publishAllToSonatypeSnapshot -Dsnapshot=true --stacktrace
+        run: ./gradlew publishToSonatype -Dsnapshot=true --stacktrace

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -5,24 +5,6 @@ plugins {
 }
 
 publishing {
-    repositories {
-        maven {
-            name = "mavenCentral"
-            url = uri("https://oss.sonatype.org/service/local/staging/deploy/maven2")
-            credentials {
-                username = "SONATYPE_USERNAME".byProperty
-                password = "SONATYPE_PASSWORD".byProperty
-            }
-        }
-        maven {
-            name = "sonatypeSnapshot"
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots")
-            credentials {
-                username = "SONATYPE_USERNAME".byProperty
-                password = "SONATYPE_PASSWORD".byProperty
-            }
-        }
-    }
     // We don't need to configure publishing for the Gradle plugin.
     if (project.name != "detekt-gradle-plugin") {
         publications.register<MavenPublication>(DETEKT_PUBLICATION) {

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -119,23 +119,3 @@ tasks.register("publishToMavenLocal") {
     }
     dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToMavenLocal"))
 }
-
-tasks.register("publishAllToSonatypeSnapshot") {
-    description = "Publish all the projects to Sonatype Snapshot Repository"
-    subprojects {
-        if (this.plugins.hasPlugin("publishing")) {
-            dependsOn(tasks.named("publishAllPublicationsToSonatypeSnapshotRepository"))
-        }
-    }
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishAllPublicationsToSonatypeSnapshotRepository"))
-}
-
-tasks.register("publishAllToMavenCentral") {
-    description = "Publish all the projects to Sonatype Staging Repository"
-    subprojects {
-        if (this.plugins.hasPlugin("publishing")) {
-            dependsOn(tasks.named("publishAllPublicationsToMavenCentralRepository"))
-        }
-    }
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishAllPublicationsToMavenCentralRepository"))
-}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,7 +2,7 @@
 set -e
 gradle publishToMavenLocal
 gradle build
-gradle publishAllToMavenCentral --max-workers 1
+gradle publishToSonatype closeSonatypeStagingRepository --max-workers 1
 gradle :detekt-gradle-plugin:publishPlugins
 gradle githubRelease
 gradle applyDocVersion


### PR DESCRIPTION
Fixes #8306

Turns out our repo was using a mixture of repositories configured with `maven-publish`, with still the old URLs, and repositories configured with `nexus-publish-plugin`.

Snapshots particularly were still using the `maven-publish` APIs.

I've migrated all the repository configuration to use just `nexus-publish-plugin` which should unblock snapshot publishing (currently failing with 401 as we're still attempting to publish to the old URL). 

See https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-central for more context on how this is configured