### PR TITLE
Update build now Java 17 is min required version

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ If you want to use a SNAPSHOT version, you can find more info on [this documenta
 
 #### Requirements
 
+##### Executing detekt
+
 Gradle 6.8.3+ is the minimum requirement. However, the recommended versions together with the other tools recommended versions are:
 
 | Detekt Version | Gradle   | Kotlin   | AGP     | Java Target Level | JDK Max Version |
@@ -113,6 +115,10 @@ Gradle 6.8.3+ is the minimum requirement. However, the recommended versions toge
 | `1.23.8`       | `8.12.1` | `2.0.21` | `8.8.1` | `1.8`             | `21`            |
 
 The list of [recommended versions for previous detekt version is listed here](https://detekt.dev/compatibility.html).
+
+##### Building detekt
+
+Java 17 is required to build detekt.
 
 ### Adding more rule sets
 

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 
 kotlin {
     @Suppress("MagicNumber")
-    jvmToolchain(8)
+    jvmToolchain(17)
 
     compilerOptions {
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -119,7 +119,6 @@ kotlin {
 }
 
 val testKitRuntimeOnly by configurations.registering
-val testKitJava17RuntimeOnly by configurations.registering
 val testKitGradleMinVersionRuntimeOnly by configurations.registering
 
 dependencies {
@@ -131,13 +130,13 @@ dependencies {
     compileOnly(libs.jetbrains.annotations)
 
     testKitRuntimeOnly(libs.kotlin.gradle.plugin)
+    testKitRuntimeOnly(libs.android.gradle.plugin)
     testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle.plugin) {
         attributes {
             // Set this value to the minimum Gradle version tested in testKitGradleMinVersionRuntimeOnly source set
             attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, objects.named("7.6.3"))
         }
     }
-    testKitJava17RuntimeOnly(libs.android.gradle.plugin)
 
     // We use this published version of the detekt-formatting to self analyse this project.
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:1.23.8")
@@ -207,10 +206,6 @@ tasks {
     // Manually inject dependency to gradle-testkit since the default injected plugin classpath is from `main.runtime`.
     pluginUnderTestMetadata {
         pluginClasspath.from(testKitRuntimeOnly)
-
-        if (named<Test>("functionalTest").get().javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
-            pluginClasspath.from(testKitJava17RuntimeOnly)
-        }
     }
 
     validatePlugins {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -5,8 +5,6 @@ import io.gitlab.arturbosch.detekt.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledForJreRange
-import org.junit.jupiter.api.condition.JRE
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
@@ -43,7 +41,6 @@ class DetektBasePluginSpec {
     }
 
     @Test
-    @EnabledForJreRange(min = JRE.JAVA_17, disabledReason = "Android Gradle Plugin 8.0+ requires JDK 17 or newer")
     fun `generates source set tasks for Android project`() {
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(
@@ -86,7 +83,6 @@ class DetektBasePluginSpec {
     }
 
     @Nested
-    @EnabledForJreRange(min = JRE.JAVA_17, disabledReason = "Android Gradle Plugin 8.0+ requires JDK 17 or newer")
     inner class `generates source set tasks for KMP project` {
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -8,11 +8,8 @@ import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.EnabledIf
-import org.junit.jupiter.api.condition.JRE
 
-@EnabledForJreRange(min = JRE.JAVA_17, disabledReason = "Android Gradle Plugin 8.0+ requires JDK 17 or newer")
 @EnabledIf("io.gitlab.arturbosch.detekt.DetektAndroidSpecKt#isAndroidSdkInstalled")
 class DetektAndroidSpec {
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -8,10 +8,8 @@ import org.gradle.testkit.runner.BuildResult
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.EnabledIf
 import org.junit.jupiter.api.condition.EnabledOnOs
-import org.junit.jupiter.api.condition.JRE.JAVA_17
 import org.junit.jupiter.api.condition.OS.MAC
 import java.util.concurrent.TimeUnit
 
@@ -135,7 +133,6 @@ class DetektMultiplatformSpec {
     }
 
     @Nested
-    @EnabledForJreRange(min = JAVA_17, disabledReason = "Android Gradle Plugin 8.0+ requires JDK 17 or newer")
     @EnabledIf("io.gitlab.arturbosch.detekt.DetektAndroidSpecKt#isAndroidSdkInstalled")
     inner class `multiplatform projects - Android target` {
         val gradleRunner =

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -8,9 +8,7 @@ import io.gitlab.arturbosch.detekt.testkit.reIndent
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledForJreRange
 import org.junit.jupiter.api.condition.EnabledIf
-import org.junit.jupiter.api.condition.JRE.JAVA_17
 
 class ReportMergeSpec {
 
@@ -87,7 +85,6 @@ class ReportMergeSpec {
 
     @Suppress("LongMethod")
     @Test
-    @EnabledForJreRange(min = JAVA_17, disabledReason = "Android Gradle Plugin 8.0+ requires JDK 17 or newer")
     @EnabledIf("io.gitlab.arturbosch.detekt.DetektAndroidSpecKt#isAndroidSdkInstalled")
     fun `for android detekt`() {
         val builder = DslTestBuilder.kotlin()


### PR DESCRIPTION
Java 17 is the minimum tested version for detekt since https://github.com/detekt/detekt/pull/8073.

A few other things can/should be updated to reflect this. Can also make explicit that Java 17 is the minimum required version to build detekt. This will be true when this project updates to Gradle 9.