### PR TITLE
Bump DGP API version to 1.7

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -108,7 +108,7 @@ kotlin {
         allWarningsAsErrors = false
         // The apiVersion Gradle property cannot be used here, so set api version using free compiler args.
         // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
-        freeCompilerArgs.addAll("-api-version", "1.4")
+        freeCompilerArgs.addAll("-api-version", "1.7")
     }
 
     // Some functional tests reference internal functions in the Gradle plugin. This should become unnecessary as further


### PR DESCRIPTION
DGP supports Gradle 7.6.3 and up. 7.6.3 embeds Kotlin compiler 1.7.10 so DGP can use API version 1.7.

https://docs.gradle.org/7.6.3/userguide/compatibility.html#kotlin