### PR TITLE
Update instrunctions on where to fetch the latest snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ tasks.withType<DetektCreateBaselineTask>().configureEach {
 }
 ```
 
-See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt) for snapshots.
+See [maven central](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli) for releases and [sonatype](https://central.sonatype.com/repository/maven-snapshots/) for snapshots.
 
 If you want to use a SNAPSHOT version, you can find more info on [this documentation page](https://detekt.dev/snapshots.html).
 

--- a/website/docs/introduction/snapshots.md
+++ b/website/docs/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.21.0/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.21.0/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.22.0/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.22.0/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) Github Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.0/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.0/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.1/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.1/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.3/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.3/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.4/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.4/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.5/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.5/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.6/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.6/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.7/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.7/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }

--- a/website/versioned_docs/version-1.23.8/introduction/snapshots.md
+++ b/website/versioned_docs/version-1.23.8/introduction/snapshots.md
@@ -10,7 +10,7 @@ This page explains how you can use our **latest snapshots** to test upcoming unr
 
 ## Where to download snapshots
 
-You can find the latest snapshot on [sonatype](https://oss.sonatype.org/#view-repositories;snapshots~browsestorage~io/gitlab/arturbosch/detekt). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
+You can find the latest snapshot on [sonatype](https://central.sonatype.com/repository/maven-snapshots/). A new snapshot is published after every merge to `main` from the [Deploy Snapshot](https://github.com/detekt/detekt/actions?query=workflow%3A%22Deploy+Snapshot%22) GitHub Action workflow. 
 
 ## Gradle setup with Buildscript
 
@@ -20,7 +20,7 @@ If you're using Gradle with the `buildscript` block, you should update your top 
 buildscript {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
   dependencies {
@@ -33,7 +33,7 @@ apply plugin: "io.gitlab.arturbosch.detekt"
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -53,7 +53,7 @@ plugins {
 allprojects {
   repositories {
     maven {
-      url "https://oss.sonatype.org/content/repositories/snapshots/"
+      url "https://central.sonatype.com/repository/maven-snapshots/"
     }
   }
 }
@@ -73,7 +73,7 @@ pluginManagement {
     repositories {
         // Your other repos here.
         maven {
-            url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }


### PR DESCRIPTION
The URL to fetch the latest snapshot has changed, and users would still grab the old detekt snapshot from end of June if still using the old URL.

This updates the doc to fix it.