### PR TITLE
Fix MagicNumber rule to support suppression of negative constants in ranges (#8338)

### DIFF
--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -920,6 +920,12 @@ class MagicNumberSpec {
         }
     }
 
+    @Test
+    fun `does not report negative numbers in ranges when ranges are ignored`() {
+        val code = "val range = -15..-10"
+        assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).isEmpty()
+    }
+
     @Nested
     inner class `a number assigned to a local variable` {
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -879,9 +879,11 @@ class MagicNumberSpec {
         @Suppress("UnusedPrivateFunction")
         private fun cases() = listOf(
             "val range = 1..27",
+            "val range = -1..-27",
             "val range = (1..27)",
             "val range = 27 downTo 1",
             "val range = 1 until 27 step 1",
+            "val range = -1 until -27 step 1",
             "val inRange = 1 in 1..27",
             "val inRange = (1 in 27 downTo 0 step 1)",
             "val inRange = (1..27 step 1).last"
@@ -918,12 +920,6 @@ class MagicNumberSpec {
             val code = "val foo : Int = 1 + 27"
             assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
         }
-    }
-
-    @Test
-    fun `does not report negative numbers in ranges when ranges are ignored`() {
-        val code = "val range = -15..-10"
-        assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).isEmpty()
     }
 
     @Nested


### PR DESCRIPTION
Fix MagicNumber rule to support suppression of negative constants in ranges (#8338)

* Fix MagicNumber rule to correctly suppress negative values in ranges

- Enhance `isPartOfRange()` to detect negative constants wrapped in `KtPrefixExpression`
- Add support for cases like `-15..-10`, `-20 downTo -25`, etc.

Fixes #8338

* test: add test case for negative range expression