### PR TITLE
Use Kotlin language version 1.8 in DGP

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -108,6 +108,7 @@ kotlin {
         allWarningsAsErrors = false
         // The apiVersion Gradle property cannot be used here, so set api version using free compiler args.
         // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
+        freeCompilerArgs.addAll("-language-version", "1.8")
         freeCompilerArgs.addAll("-api-version", "1.7")
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/invoke/CliArgument.kt
@@ -42,7 +42,7 @@ internal sealed class CliArgument {
     abstract fun toArgument(): List<String>
 }
 
-internal data object CreateBaselineArgument : CliArgument() {
+internal object CreateBaselineArgument : CliArgument() {
     override fun toArgument() = listOf(CREATE_BASELINE_PARAMETER)
 }
 


### PR DESCRIPTION
We support Gradle 7.6.3 which embeds Kotlin 1.7.10. Kotlin is forwards compatible +1 major version, so it will be compatible with language version 1.8.

DGP is currently built with Kotlin 2.0.21 and no explicit language version, so it is defaulting to language version 2.0 which has no compatibility guarantees for Kotlin 1.7.

This was not previously identified as Gradle 7.6.3 does not support the skipMetadataVersionCheck property which was introduced in Gradle 8.5.