### PR TITLE
Bump DGP compiler version to 2.1.21

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -99,7 +99,7 @@ testing {
 
 kotlin {
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
-    compilerVersion = "2.0.21"
+    compilerVersion = "2.1.21"
 
     compilerOptions {
         suppressWarnings = true


### PR DESCRIPTION
This is the most recent compiler that still supports API version 1.7