### PR TITLE
Remove unnecessary full qualified names

### DIFF
--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ActiveByDefault.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/ActiveByDefault.kt
@@ -1,8 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
- * Annotated [io.gitlab.arturbosch.detekt.api.Rule] or [io.gitlab.arturbosch.detekt.api.RuleSetProvider]
- * is active by default.
+ * Annotated [Rule] or [RuleSetProvider] is active by default.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.SOURCE)

--- a/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Configuration.kt
+++ b/detekt-api/src/main/kotlin/io/gitlab/arturbosch/detekt/api/Configuration.kt
@@ -1,8 +1,7 @@
 package io.gitlab.arturbosch.detekt.api
 
 /**
- * Annotate the target to specify a configuration for [io.gitlab.arturbosch.detekt.api.Rule] or
- * [io.gitlab.arturbosch.detekt.api.RuleSetProvider].
+ * Annotate the target to specify a configuration for [Rule] or [RuleSetProvider].
  */
 @Target(AnnotationTarget.PROPERTY)
 @Retention(AnnotationRetention.RUNTIME)


### PR DESCRIPTION
No need to use full qualified names when you are in the same pacakge. This also generate noise when moving detekt to its new package.