### PR TITLE
Move tests where they belong

### DIFF
--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/ConfigAssert.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.generator.config
+package io.gitlab.arturbosch.detekt.core.config
 
 import io.github.classgraph.ClassGraph
 import io.gitlab.arturbosch.detekt.api.Config
@@ -6,7 +6,6 @@ import io.gitlab.arturbosch.detekt.api.Rule
 import io.gitlab.arturbosch.detekt.api.RuleName
 import io.gitlab.arturbosch.detekt.api.RuleSetProvider
 import io.gitlab.arturbosch.detekt.api.internal.DefaultRuleSetProvider
-import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.fail
 import java.lang.reflect.Modifier

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DetektYmlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/DetektYmlConfigSpec.kt
@@ -1,6 +1,5 @@
-package io.gitlab.arturbosch.detekt.generator.config
+package io.gitlab.arturbosch.detekt.core.config
 
-import io.gitlab.arturbosch.detekt.core.config.YamlConfig
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest

--- a/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorSpec.kt
+++ b/detekt-generator/src/test/kotlin/io/gitlab/arturbosch/detekt/generator/GeneratorSpec.kt
@@ -1,6 +1,5 @@
-package io.gitlab.arturbosch.detekt.generator.printer
+package io.gitlab.arturbosch.detekt.generator
 
-import io.gitlab.arturbosch.detekt.generator.main
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll

--- a/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/dsl/PluginsSpec.kt
+++ b/detekt-tooling/src/test/kotlin/io/github/detekt/tooling/dsl/PluginsSpec.kt
@@ -1,6 +1,5 @@
-package io.github.detekt.tooling.api
+package io.github.detekt.tooling.dsl
 
-import io.github.detekt.tooling.dsl.ExtensionsSpecBuilder
 import io.github.detekt.tooling.internal.PluginsHolder
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
I found this while I was moving detekt files to their new packages. This will remove noise on that PR too.