### PR TITLE
Move detekt-api/src/testFixtures to `dev.detekt.api.test`

### DIFF
--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.test
+package dev.detekt.api.testfixtures
 
 import com.intellij.openapi.util.Key
 import com.intellij.openapi.util.UserDataHolderBase

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.test
+package dev.detekt.api.testfixtures
 
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.RuleInstance

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestSetupContext.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestSetupContext.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.test
+package dev.detekt.api.testfixtures
 
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.SetupContext

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.test.utils.createTempDirectoryForTest
 import io.github.detekt.test.utils.resourceAsPath
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/baseline/DefaultBaselineKtTest.kt
@@ -1,6 +1,6 @@
 package io.gitlab.arturbosch.detekt.core.baseline
 
-import io.gitlab.arturbosch.detekt.test.createIssue
+import dev.detekt.api.testfixtures.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePoliciesKtTest.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/config/FailurePoliciesKtTest.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.core.config
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.createIssue
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.spec.RulesSpec
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/OutputFacadeSpec.kt
@@ -1,5 +1,9 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.report.html.HtmlOutputReport
 import io.github.detekt.report.md.MdOutputReport
 import io.github.detekt.report.xml.XmlOutputReport
@@ -9,10 +13,6 @@ import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.core.DetektResult
 import io.gitlab.arturbosch.detekt.core.createNullLoggingSpec
 import io.gitlab.arturbosch.detekt.core.tooling.withSettings
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/SuppressedIssueAssert.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/SuppressedIssueAssert.kt
@@ -1,9 +1,9 @@
 package io.gitlab.arturbosch.detekt.core.reporting
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createIssue
 import io.gitlab.arturbosch.detekt.api.ConsoleReport
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 
 internal object SuppressedIssueAssert {

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -1,5 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.metrics.CognitiveComplexity
 import io.github.detekt.metrics.processors.commentLinesKey
 import io.github.detekt.metrics.processors.complexityKey
@@ -8,8 +10,6 @@ import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.core.DetektResult
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.gitlab.arturbosch.detekt.core.reporting.SuppressedIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -1,12 +1,12 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.gitlab.arturbosch.detekt.core.reporting.SuppressedIssueAssert
 import io.gitlab.arturbosch.detekt.core.reporting.decolorized
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -1,11 +1,11 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.gitlab.arturbosch.detekt.core.reporting.SuppressedIssueAssert
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/NotificationReportSpec.kt
@@ -1,8 +1,8 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.TestDetektion
 import io.gitlab.arturbosch.detekt.core.NL
 import io.gitlab.arturbosch.detekt.core.util.SimpleNotification
-import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
+++ b/detekt-core/src/test/kotlin/io/gitlab/arturbosch/detekt/core/reporting/console/ProjectStatisticsReportSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.core.reporting.console
 
+import dev.detekt.api.testfixtures.TestDetektion
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
-import io.gitlab.arturbosch.detekt.test.TestDetektion
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 

--- a/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/io/github/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -1,13 +1,13 @@
 package io.github.detekt.metrics
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.createIssue
 import io.github.detekt.metrics.processors.commentLinesKey
 import io.github.detekt.metrics.processors.complexityKey
 import io.github.detekt.metrics.processors.linesKey
 import io.github.detekt.metrics.processors.logicalLinesKey
 import io.github.detekt.metrics.processors.sourceLinesKey
 import io.gitlab.arturbosch.detekt.api.Detektion
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.createIssue
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested

--- a/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/io/github/detekt/report/html/HtmlOutputReportSpec.kt
@@ -1,5 +1,11 @@
 package io.github.detekt.report.html
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.metrics.CognitiveComplexity
 import io.github.detekt.metrics.processors.commentLinesKey
 import io.github.detekt.metrics.processors.complexityKey
@@ -12,12 +18,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.nio.file.Path

--- a/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/io/github/detekt/report/md/MdOutputReportSpec.kt
@@ -1,5 +1,11 @@
 package io.github.detekt.report.md
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.metrics.CognitiveComplexity
 import io.github.detekt.metrics.processors.commentLinesKey
 import io.github.detekt.metrics.processors.complexityKey
@@ -10,12 +16,6 @@ import io.gitlab.arturbosch.detekt.api.Detektion
 import io.gitlab.arturbosch.detekt.api.Issue
 import io.gitlab.arturbosch.detekt.api.ProjectMetric
 import io.gitlab.arturbosch.detekt.api.internal.whichDetekt
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path

--- a/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/io/github/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -1,15 +1,15 @@
 package io.github.detekt.report.sarif
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createRuleInstance
 import io.github.detekt.test.utils.readResourceContent
 import io.gitlab.arturbosch.detekt.api.RuleInstance
 import io.gitlab.arturbosch.detekt.api.RuleSet
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
-import io.gitlab.arturbosch.detekt.test.createRuleInstance
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.net.URI

--- a/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/io/github/detekt/report/xml/XmlOutputReportSpec.kt
@@ -1,10 +1,10 @@
 package io.github.detekt.report.xml
 
+import dev.detekt.api.testfixtures.TestDetektion
+import dev.detekt.api.testfixtures.createEntity
+import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createLocation
 import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.test.TestDetektion
-import io.gitlab.arturbosch.detekt.test.createEntity
-import io.gitlab.arturbosch.detekt.test.createIssue
-import io.gitlab.arturbosch.detekt.test.createLocation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test

--- a/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/AbsentOrWrongFileLicenseSpec.kt
@@ -1,10 +1,10 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import dev.detekt.api.testfixtures.TestSetupContext
 import io.github.detekt.test.utils.compileContentForTest
 import io.github.detekt.test.utils.resourceAsPath
 import io.gitlab.arturbosch.detekt.api.Config
 import io.gitlab.arturbosch.detekt.api.Finding
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
 import io.gitlab.arturbosch.detekt.test.yamlConfig

--- a/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
+++ b/detekt-rules/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/documentation/LicenceHeaderLoaderExtensionSpec.kt
@@ -1,7 +1,7 @@
 package io.gitlab.arturbosch.detekt.rules.documentation
 
+import dev.detekt.api.testfixtures.TestSetupContext
 import io.github.detekt.test.utils.resource
-import io.gitlab.arturbosch.detekt.test.TestSetupContext
 import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 


### PR DESCRIPTION
In this case I decided to use `dev.detekt.api.test` for the firxtures instead of `dev.detekt.api` but I don't have a strong opinion here.