### PR TITLE
Rename DetektReport to DetektCompilerPluginReport to avoid clash when merging packages

### DIFF
--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -15,7 +15,7 @@ public final class io/github/detekt/gradle/DetektKotlinCompilerPlugin : org/jetb
 	public fun isApplicable (Lorg/jetbrains/kotlin/gradle/plugin/KotlinCompilation;)Z
 }
 
-public class io/github/detekt/gradle/extensions/DetektReport {
+public class io/github/detekt/gradle/extensions/DetektCompilerPluginReport {
 	public fun <init> (Ljava/lang/String;Lorg/gradle/api/model/ObjectFactory;)V
 	public final fun getDestination ()Lorg/gradle/api/file/RegularFileProperty;
 	public final fun getEnabled ()Lorg/gradle/api/provider/Property;
@@ -31,11 +31,11 @@ public class io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension
 	public final fun getDebug ()Lorg/gradle/api/provider/Property;
 	public final fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public final fun getExcludes ()Lorg/gradle/api/provider/SetProperty;
-	public final fun getHtml ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun getHtml ()Lio/github/detekt/gradle/extensions/DetektCompilerPluginReport;
 	public final fun getParallel ()Lorg/gradle/api/provider/Property;
 	public final fun getReports ()Lorg/gradle/api/NamedDomainObjectContainer;
-	public final fun getSarif ()Lio/github/detekt/gradle/extensions/DetektReport;
-	public final fun getXml ()Lio/github/detekt/gradle/extensions/DetektReport;
+	public final fun getSarif ()Lio/github/detekt/gradle/extensions/DetektCompilerPluginReport;
+	public final fun getXml ()Lio/github/detekt/gradle/extensions/DetektCompilerPluginReport;
 	public final fun isEnabled ()Lorg/gradle/api/provider/Property;
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/extensions/DetektCompilerPluginReport.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/extensions/DetektCompilerPluginReport.kt
@@ -5,7 +5,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import javax.inject.Inject
 
-open class DetektReport @Inject constructor(val name: String, objects: ObjectFactory) {
+open class DetektCompilerPluginReport @Inject constructor(val name: String, objects: ObjectFactory) {
     val enabled: Property<Boolean> = objects.property(Boolean::class.java)
     val destination: RegularFileProperty = objects.fileProperty()
 }

--- a/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/github/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -9,7 +9,8 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 
 open class KotlinCompileTaskDetektExtension(project: Project) {
-    val reports: NamedDomainObjectContainer<DetektReport> = project.container(DetektReport::class.java)
+    val reports: NamedDomainObjectContainer<DetektCompilerPluginReport> =
+        project.container(DetektCompilerPluginReport::class.java)
 
     init {
         reports.create("xml")
@@ -30,7 +31,7 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 
-    fun getXml(): DetektReport = reports.getByName("xml")
-    fun getHtml(): DetektReport = reports.getByName("html")
-    fun getSarif(): DetektReport = reports.getByName("sarif")
+    fun getXml(): DetektCompilerPluginReport = reports.getByName("xml")
+    fun getHtml(): DetektCompilerPluginReport = reports.getByName("html")
+    fun getSarif(): DetektCompilerPluginReport = reports.getByName("sarif")
 }


### PR DESCRIPTION
This is the change commented here: https://github.com/detekt/detekt/pull/8355#issuecomment-3126584957

I'm moving this out of that PR to make the diff easier