### PR TITLE
Remove `buildRunner` function from detekt-cli

### DIFF
--- a/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/io/gitlab/arturbosch/detekt/cli/Main.kt
@@ -6,14 +6,6 @@ import io.github.detekt.tooling.api.AnalysisResult
 import io.github.detekt.tooling.api.InvalidConfig
 import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.UnexpectedError
-import io.github.detekt.tooling.internal.NotApiButProbablyUsedByUsers
-import io.gitlab.arturbosch.detekt.api.internal.whichKotlin
-import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
-import io.gitlab.arturbosch.detekt.cli.runners.Executable
-import io.gitlab.arturbosch.detekt.cli.runners.Runner
-import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
-import org.jetbrains.kotlin.config.KotlinCompilerVersion
-import java.io.PrintStream
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
@@ -37,33 +29,6 @@ fun main(args: Array<String>) {
         else -> Unit // print nothing extra when there is no error
     }
     exitProcess(result.exitCode())
-}
-
-@NotApiButProbablyUsedByUsers
-@Deprecated(
-    "Don't build a runner yourself.",
-    ReplaceWith(
-        "DetektCli.load().run(args, outputPrinter, errorPrinter)",
-        "io.github.detekt.tooling.api.DetektCli"
-    )
-)
-fun buildRunner(
-    args: Array<String>,
-    outputPrinter: PrintStream,
-    errorPrinter: PrintStream,
-): Executable {
-    check(KotlinCompilerVersion.VERSION == whichKotlin()) {
-        """
-            detekt was compiled with Kotlin ${whichKotlin()} but is currently running with ${KotlinCompilerVersion.VERSION}.
-            This is not supported. See https://detekt.dev/docs/gettingstarted/gradle#dependencies for more information.
-        """.trimIndent()
-    }
-    val arguments = parseArguments(args)
-    return when {
-        arguments.showVersion -> VersionPrinter(outputPrinter)
-        arguments.generateConfig != null -> ConfigExporter(arguments, outputPrinter)
-        else -> Runner(arguments, outputPrinter, errorPrinter)
-    }
 }
 
 @Suppress("detekt.MagicNumber")

--- a/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
+++ b/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/MainSpec.kt
@@ -2,7 +2,6 @@
 
 package io.gitlab.arturbosch.detekt.cli
 
-import io.github.detekt.test.utils.NullPrintStream
 import io.github.detekt.test.utils.StringPrintStream
 import io.github.detekt.test.utils.resourceAsPath
 import io.github.detekt.tooling.api.InvalidConfig
@@ -10,40 +9,12 @@ import io.github.detekt.tooling.api.IssuesFound
 import io.github.detekt.tooling.api.UnexpectedError
 import io.github.detekt.tooling.internal.DefaultAnalysisResult
 import io.github.detekt.tooling.internal.EmptyContainer
-import io.gitlab.arturbosch.detekt.cli.runners.ConfigExporter
 import io.gitlab.arturbosch.detekt.cli.runners.Runner
-import io.gitlab.arturbosch.detekt.cli.runners.VersionPrinter
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.Arguments.arguments
-import org.junit.jupiter.params.provider.MethodSource
-import kotlin.reflect.KClass
 
 class MainSpec {
-
-    @Nested
-    inner class `Build runner` {
-
-        @Suppress("UnusedPrivateFunction")
-        private fun runnerConfigs(): List<Arguments> =
-            listOf(
-                arguments(arrayOf("--generate-config", "detekt-test.yml"), ConfigExporter::class),
-                arguments(arrayOf("--run-rule", "RuleSet:Rule"), Runner::class),
-                arguments(arrayOf("--version"), VersionPrinter::class),
-                arguments(emptyArray<String>(), Runner::class),
-            )
-
-        @ParameterizedTest
-        @MethodSource("runnerConfigs")
-        fun `builds correct runner`(args: Array<String>, expectedRunnerClass: KClass<*>) {
-            val runner = buildRunner(args, NullPrintStream(), NullPrintStream())
-
-            assertThat(runner).isExactlyInstanceOf(expectedRunnerClass.java)
-        }
-    }
 
     @Nested
     inner class `Runner creates baselines` {
@@ -59,7 +30,7 @@ class MainSpec {
                 "baseline.xml"
             )
 
-            buildRunner(args, out, err)
+            Runner(parseArguments(args).createSpec(out, err))
 
             assertThat(err.toString()).isEmpty()
         }
@@ -73,7 +44,7 @@ class MainSpec {
 
             val args = arrayOf("--baseline", path.toString())
 
-            buildRunner(args, out, err)
+            Runner(parseArguments(args).createSpec(out, err))
 
             assertThat(err.toString()).isEmpty()
         }


### PR DESCRIPTION
We are creating 2.0 so we can clean this up. This is probably a breaking change for few users.