### PR TITLE
Increase maximum heap size for builds

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -40,7 +40,7 @@ tasks.withType<Test>().configureEach {
     if (compileTestSnippetsAa) {
         maxHeapSize = "3g"
     } else {
-        maxHeapSize = "1g"
+        maxHeapSize = "2g"
     }
 
     testLogging {


### PR DESCRIPTION
macOS seems to be running into issues with maximum heap when running large test suites (i.e. detekt-rules-style). Bump max heap to 2GB to accommodate this.

See #8116
