### PR TITLE
Remove outdated gitignore paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,8 +158,6 @@ target/
 */build/
 /detekt-formatting/ktlint-repackage/build/
 .gradletasknamecache
-/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/ReproduceSpec.kt
-/detekt-cli/src/test/kotlin/io/gitlab/arturbosch/detekt/cli/Test.kt
 *.iml
 */out
 


### PR DESCRIPTION
These paths doesn't exist anymore. They were added at 2016