### PR TITLE
Properly configure test suite in detekt-sample-extensions

### DIFF
--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -11,3 +11,11 @@ dependencies {
     testImplementation("io.gitlab.arturbosch.detekt:detekt-test:1.23.8")
     testImplementation("org.assertj:assertj-core:3.27.3")
 }
+
+testing {
+    suites {
+        val test by getting(JvmTestSuite::class) {
+            useJUnitJupiter()
+        }
+    }
+}


### PR DESCRIPTION
Gradle 9 has a check to ensure at least one test is executed if test sources are present. The sample extension was not executing any tests.