### PR TITLE
Remove KDocImpl import

### DIFF
--- a/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
+++ b/detekt-metrics/src/main/kotlin/io/github/detekt/metrics/LinesOfCode.kt
@@ -11,7 +11,6 @@ import org.jetbrains.kotlin.diagnostics.DiagnosticUtils
 import org.jetbrains.kotlin.kdoc.psi.api.KDoc
 import org.jetbrains.kotlin.kdoc.psi.api.KDocElement
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocElementImpl
-import org.jetbrains.kotlin.kdoc.psi.impl.KDocImpl
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocName
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocSection
@@ -49,7 +48,6 @@ private val comments: Set<Class<out PsiElement>> = setOf(
     PsiComment::class.java,
     PsiCommentImpl::class.java,
     KDoc::class.java,
-    KDocImpl::class.java,
     KDocElementImpl::class.java,
     KDocElement::class.java,
     KDocLink::class.java,


### PR DESCRIPTION
This is not part of the PSI API as of v2.2.20-Beta2 https://github.com/JetBrains/kotlin/blob/v2.2.20-Beta2/compiler/psi/psi-api/api/psi-api.api