### PR TITLE
Create a DAGP dependency bundle for junit-jupiter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dokka {
 
 dependencyAnalysis {
     structure {
+        // Could potentially remove in future if DAGP starts handling this natively https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1269
         bundle("junit-jupiter") {
             includeDependency("org.junit.jupiter:junit-jupiter")
             includeDependency("org.junit.jupiter:junit-jupiter-api")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,16 @@ dokka {
     }
 }
 
+dependencyAnalysis {
+    structure {
+        bundle("junit-jupiter") {
+            includeDependency("org.junit.jupiter:junit-jupiter")
+            includeDependency("org.junit.jupiter:junit-jupiter-api")
+            includeDependency("org.junit.jupiter:junit-jupiter-params")
+        }
+    }
+}
+
 val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
     output = layout.buildDirectory.file("reports/detekt/merge.sarif.json")
 }


### PR DESCRIPTION
`junit-jupiter` is added by Gradle's test suite plugin when applying `useJUnitJupiter()`. That dependency contains no classes and adds `junit-jupiter-api` and `junit-jupiter-params` as transitive dependencies on the test compilation classpath.

Technically it's more accurate to add explicit dependencies only on `junit-jupiter-api` (and `junit-jupiter-params` if required) but it's much more convenient to rely on the test suite configuration and create this bundle so Dependency Analysis Gradle Plugin stops providing advice about this.

Also see https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1269#issuecomment-3146237505. There may be a native solution in DAGP that we could adopt in future.

Part of #8349