### PR TITLE
Add kotlin-compiler testImplementation dependency to all rules projects

### DIFF
--- a/detekt-formatting/build.gradle.kts
+++ b/detekt-formatting/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     runtimeOnly(libs.slf4j.api)
 
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
     testImplementation(libs.classgraph)

--- a/detekt-rules-complexity/build.gradle.kts
+++ b/detekt-rules-complexity/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektMetrics)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
     testRuntimeOnly(libs.kotlinx.coroutinesCore)

--- a/detekt-rules-documentation/build.gradle.kts
+++ b/detekt-rules-documentation/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
     testImplementation(testFixtures(projects.detektApi))

--- a/detekt-rules-empty/build.gradle.kts
+++ b/detekt-rules-empty/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-errorprone/build.gradle.kts
+++ b/detekt-rules-errorprone/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektKotlinAnalysisApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-exceptions/build.gradle.kts
+++ b/detekt-rules-exceptions/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-naming/build.gradle.kts
+++ b/detekt-rules-naming/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -5,6 +5,8 @@ plugins {
 dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -6,6 +6,8 @@ dependencies {
     compileOnly(projects.detektApi)
     compileOnly(projects.detektMetrics)
     compileOnly(projects.detektPsiUtils)
+
+    testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektTest)
     testImplementation(libs.assertj.core)
 }


### PR DESCRIPTION
This is used in every rules project.

Part of #8349 

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
