### PR TITLE
Disable configuration cache when publishing snapshots

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -43,4 +43,4 @@ jobs:
           ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
           ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-        run: ./gradlew publishToSonatype -Dsnapshot=true --stacktrace
+        run: ./gradlew publishToSonatype -Dsnapshot=true --stacktrace --no-configuration-cache


### PR DESCRIPTION
Workaround for this issue seen with Gradle 9: https://youtrack.jetbrains.com/issue/KT-79047/Gradle-compileKotlin-fails-with-configuration-cache. Fix currently planned for Kotlin 2.3.0.