### PR TITLE
Expand `FindingAssert`

### DIFF
--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -12,6 +12,9 @@ public final class dev/detekt/test/FindingAssert : org/assertj/core/api/Abstract
 	public final fun hasSourceLocation (II)Ldev/detekt/test/FindingAssert;
 	public final fun hasStartSourceLocation (II)Ldev/detekt/test/FindingAssert;
 	public final fun hasStartSourceLocation (Ldev/detekt/api/SourceLocation;)Ldev/detekt/test/FindingAssert;
+	public final fun hasTextLocation (Ldev/detekt/api/TextLocation;)Ldev/detekt/test/FindingAssert;
+	public final fun hasTextLocation (Ljava/lang/String;)Ldev/detekt/test/FindingAssert;
+	public final fun hasTextLocation (Lkotlin/Pair;)Ldev/detekt/test/FindingAssert;
 	public final fun noSuppress ()Ldev/detekt/test/FindingAssert;
 }
 

--- a/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
@@ -164,4 +164,34 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
             )
         }
     }
+
+    fun hasTextLocation(expected: Pair<Int, Int>) = apply {
+        hasTextLocation(TextLocation(expected.first, expected.second))
+    }
+
+    fun hasTextLocation(expected: TextLocation) = apply {
+        val actual = actual!!.location.text
+        if (actual != expected) {
+            throw failureWithActualExpected(
+                actual,
+                expected,
+                "Expected text location to be $expected but was $actual"
+            )
+        }
+    }
+
+    fun hasTextLocation(expected: String) = apply {
+        val code = actual!!.entity.ktElement.containingKtFile.text
+
+        val index = code.indexOf(expected)
+        if (index < 0) {
+            failWithMessage("The snippet \"$expected\" doesn't exist in the code")
+        } else {
+            if (code.indexOf(expected, index + 1) >= 0) {
+                failWithMessage("The snippet \"$expected\" appears multiple times in the code")
+            }
+        }
+
+        hasTextLocation(TextLocation(index, index + expected.length))
+    }
 }


### PR DESCRIPTION
This expands `FindingAssert`. The idea is to remove code from `FindingsAssert` and move it to `FindingAssert`. This is the frist step. The next PR will remove some functions from `FindingsAssert` and use the new functions that I'm adding on thi PR.