### PR TITLE
Remove functions from `FindingsAssert` in favor of the ones in `FindingAssert`

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/IndentationSpec.kt
@@ -33,9 +33,9 @@ class IndentationSpec {
 
             @Test
             fun `places finding location to the indentation`() {
-                assertThat(subject.lint(code))
+                assertThat(subject.lint(code)).singleElement()
                     .hasStartSourceLocation(2, 1)
-                    .hasTextLocations(13 to 14)
+                    .hasTextLocation(13 to 14)
             }
         }
 

--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/WrappingSpec.kt
@@ -29,9 +29,8 @@ class WrappingSpec {
             
         """.trimIndent()
 
-        assertThat(subject.lint(code))
-            .hasSize(1)
+        assertThat(subject.lint(code)).singleElement()
             .hasStartSourceLocation(1, 12)
-            .hasTextLocations(11 to 12)
+            .hasTextLocation(11 to 12)
     }
 }

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/LabeledExpressionSpec.kt
@@ -38,8 +38,8 @@ class LabeledExpressionSpec {
 
         val findings = subject.lint(code)
 
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(3, 28)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(3, 28)
     }
 
     @Test

--- a/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/complexity/NestedScopeFunctionsSpec.kt
@@ -108,7 +108,7 @@ class NestedScopeFunctionsSpec(private val env: KotlinEnvironmentContainer) {
     }
 
     private fun expectSourceLocation(location: Pair<Int, Int>) {
-        assertThat(actual).hasStartSourceLocation(location.first, location.second)
+        assertThat(actual).singleElement().hasStartSourceLocation(location.first, location.second)
     }
 
     private fun expectFunctionInMsg(scopeFunction: String) {

--- a/detekt-rules-documentation/src/test/kotlin/dev/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/dev/detekt/rules/documentation/EndOfSentenceFormatSpec.kt
@@ -233,7 +233,7 @@ class EndOfSentenceFormatSpec {
                  * This sentence counts too, because it doesn't know where the other ends */
                 fun test() = 3
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).singleElement()
                 .hasStartSourceLocation(2, 2)
                 .hasEndSourceLocation(4, 75)
         }
@@ -247,7 +247,7 @@ class EndOfSentenceFormatSpec {
                     val test = 3
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).singleElement()
                 .hasStartSourceLocation(2, 8)
                 .hasEndSourceLocation(3, 80)
         }
@@ -262,7 +262,7 @@ class EndOfSentenceFormatSpec {
                  */
                 class Test
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).singleElement()
                 .hasStartSourceLocation(2, 2)
                 .hasEndSourceLocation(4, 74)
         }

--- a/detekt-rules-documentation/src/test/kotlin/dev/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-documentation/src/test/kotlin/dev/detekt/rules/documentation/UndocumentedPublicPropertySpec.kt
@@ -327,8 +327,7 @@ class UndocumentedPublicPropertySpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(9, 13)
         }
 
@@ -348,8 +347,7 @@ class UndocumentedPublicPropertySpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(2, 9)
         }
 

--- a/detekt-rules-empty/src/test/kotlin/dev/detekt/rules/empty/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/dev/detekt/rules/empty/EmptyFunctionBlockSpec.kt
@@ -20,7 +20,7 @@ class EmptyFunctionBlockSpec {
                 protected fun stuff() {}
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(2, 27)
+        assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(2, 27)
     }
 
     @Test
@@ -50,7 +50,7 @@ class EmptyFunctionBlockSpec {
                 fun b() {}
             }
         """.trimIndent()
-        assertThat(subject.lint(code)).hasStartSourceLocation(2, 13)
+        assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(2, 13)
     }
 
     @Nested
@@ -88,7 +88,7 @@ class EmptyFunctionBlockSpec {
         @Test
         fun `should not flag overridden functions`() {
             val config = TestConfig(IGNORE_OVERRIDDEN to "true")
-            assertThat(EmptyFunctionBlock(config).lint(code)).hasStartSourceLocation(1, 13)
+            assertThat(EmptyFunctionBlock(config).lint(code)).singleElement().hasStartSourceLocation(1, 13)
         }
     }
 
@@ -114,7 +114,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions with commented body`() {
-            assertThat(subject.lint(code)).hasStartSourceLocation(12, 31)
+            assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(12, 31)
         }
 
         @Test

--- a/detekt-rules-empty/src/test/kotlin/dev/detekt/rules/empty/EmptyKotlinFileSpec.kt
+++ b/detekt-rules-empty/src/test/kotlin/dev/detekt/rules/empty/EmptyKotlinFileSpec.kt
@@ -11,8 +11,7 @@ class EmptyKotlinFileSpec {
     @Test
     fun `reports empty if file is blank`() {
         val code = ""
-        assertThat(subject.lint(code))
-            .singleElement()
+        assertThat(subject.lint(code)).singleElement()
             .hasSourceLocation(1, 1)
     }
 
@@ -21,8 +20,7 @@ class EmptyKotlinFileSpec {
         val codeWithPackageStatement = """
             package my.packagee
         """.trimIndent()
-        assertThat(subject.lint(codeWithPackageStatement))
-            .singleElement()
+        assertThat(subject.lint(codeWithPackageStatement)).singleElement()
             .hasSourceLocation(1, 1)
     }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastNullableToNonNullableTypeSpec.kt
@@ -24,7 +24,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinEnvironmentContai
             "Use separate `null` assertion and type cast like " +
                 "('(bar ?: error(\"null assertion message\")) as String') instead of 'bar as String'."
         )
-        assertThat(findings).hasStartSourceLocation(2, 17)
+        assertThat(findings).singleElement().hasStartSourceLocation(2, 17)
     }
 
     @Test
@@ -43,7 +43,7 @@ class CastNullableToNonNullableTypeSpec(private val env: KotlinEnvironmentContai
             "Use separate `null` assertion and type cast like " +
                 "('(bar() ?: error(\"null assertion message\")) as Int') instead of 'bar() as Int'."
         )
-        assertThat(findings).hasStartSourceLocation(2, 11)
+        assertThat(findings).singleElement().hasStartSourceLocation(2, 11)
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/CastToNullableTypeSpec.kt
@@ -19,8 +19,9 @@ class CastToNullableTypeSpec(private val env: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
         val findings = subject.lintWithContext(env, code)
-        assertThat(findings).singleElement().hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
-        assertThat(findings).hasStartSourceLocation(2, 24)
+        assertThat(findings).singleElement()
+            .hasMessage("Use the safe cast ('as? String') instead of 'as String?'.")
+            .hasStartSourceLocation(2, 24)
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/DoubleMutabilityForCollectionSpec.kt
@@ -29,8 +29,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -41,8 +41,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -53,8 +53,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -65,8 +65,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -77,8 +77,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -89,8 +89,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -101,8 +101,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -113,8 +113,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -130,8 +130,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(3, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(3, 5)
             }
 
             @Test
@@ -148,8 +148,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(4, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(4, 5)
             }
 
             @Test
@@ -165,8 +165,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(5, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(5, 5)
             }
         }
 
@@ -338,8 +338,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myList = mutableListOf(1, 2, 3)
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -348,8 +348,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var mySet = mutableSetOf(1, 2, 3)
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -358,8 +358,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myMap = mutableMapOf("answer" to 42)
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -368,8 +368,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myArrayList = ArrayList<Int>()
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -378,8 +378,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myLinkedHashSet = LinkedHashSet<Int>()
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -388,8 +388,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myHashSet = HashSet<Int>()
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -398,8 +398,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myLinkedHashMap = LinkedHashMap<String, Int>()
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -408,8 +408,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myHashMap = HashMap<String, Int>()
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(1, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -423,8 +423,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myState = MutableState("foo")
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 1)
             }
 
             @Test
@@ -439,8 +439,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myState = mutableStateOf("foo")
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(3, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(3, 1)
             }
 
             @Test
@@ -456,8 +456,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     var myState = remember { mutableStateOf("foo") }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(4, 1)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(4, 1)
             }
         }
 
@@ -607,8 +607,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -619,8 +619,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -631,8 +631,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -643,8 +643,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -655,8 +655,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -667,8 +667,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -679,8 +679,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -691,8 +691,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = subject.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(2, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(2, 5)
             }
 
             @Test
@@ -708,8 +708,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(3, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(3, 5)
             }
 
             @Test
@@ -726,8 +726,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(4, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(4, 5)
             }
 
             @Test
@@ -745,8 +745,8 @@ class DoubleMutabilityForCollectionSpec(private val env: KotlinEnvironmentContai
                     }
                 """.trimIndent()
                 val result = rule.lintWithContext(env, code)
-                assertThat(result).hasSize(1)
-                assertThat(result).hasStartSourceLocation(5, 5)
+                assertThat(result).singleElement()
+                    .hasStartSourceLocation(5, 5)
             }
         }
 

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/IgnoredReturnValueSpec.kt
@@ -223,7 +223,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code, annotationClass, compile = false)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(7, 5)
+                .hasStartSourceLocation(7, 5)
         }
 
         @Test
@@ -244,7 +244,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(9, 5)
+                .hasStartSourceLocation(9, 5)
         }
 
         @Test
@@ -311,7 +311,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(12, 10)
+                .hasStartSourceLocation(12, 10)
         }
 
         @Test
@@ -331,7 +331,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(9, 5)
+                .hasStartSourceLocation(9, 5)
         }
 
         @Test
@@ -352,7 +352,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(9, 20)
+                .hasStartSourceLocation(9, 20)
         }
 
         @Test
@@ -373,7 +373,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(9, 14)
+                .hasStartSourceLocation(9, 14)
         }
 
         @Test
@@ -393,7 +393,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call isTheAnswer is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(8, 11)
+                .hasStartSourceLocation(8, 11)
         }
 
         @Test
@@ -848,7 +848,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(8, 5)
+                .hasStartSourceLocation(8, 5)
         }
 
         @Test
@@ -910,7 +910,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(9, 5)
+                .hasStartSourceLocation(9, 5)
         }
 
         @Test
@@ -926,7 +926,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call listOfChecked is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(4, 5)
+                .hasStartSourceLocation(4, 5)
         }
 
         @Test
@@ -941,7 +941,7 @@ class IgnoredReturnValueSpec {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("The call ignoredReturn is returning a value that is ignored.")
-            assertThat(findings).hasStartSourceLocation(2, 5)
+                .hasStartSourceLocation(2, 5)
         }
 
         @Test
@@ -957,8 +957,7 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(6, 5)
                 .hasMessage("The call flowOfChecked is returning a value that is ignored.")
         }
@@ -1095,8 +1094,7 @@ class IgnoredReturnValueSpec {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
 
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(line = 4, column = 5)
                 .hasMessage("The call flowOf is returning a value that is ignored.")
         }
@@ -1113,8 +1111,7 @@ class IgnoredReturnValueSpec {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
 
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(line = 5, column = 10)
                 .hasMessage("The call onEach is returning a value that is ignored.")
         }
@@ -1158,8 +1155,7 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(6, 5)
                 .hasMessage("The call returnsALambda is returning a value that is ignored.")
         }
@@ -1177,8 +1173,7 @@ class IgnoredReturnValueSpec {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertThat(findings)
-                .singleElement()
+            assertThat(findings).singleElement()
                 .hasSourceLocation(6, 5)
                 .hasMessage("The call returnsALambda is returning a value that is ignored.")
         }

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnreachableCatchBlockSpec.kt
@@ -23,8 +23,8 @@ class UnreachableCatchBlockSpec(private val env: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
         val findings = subject.lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(4, 7)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(4, 7)
     }
 
     @Test
@@ -38,8 +38,8 @@ class UnreachableCatchBlockSpec(private val env: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
         val findings = subject.lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(4, 7)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(4, 7)
     }
 
     @Test

--- a/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/bugs/UnusedUnaryOperatorSpec.kt
@@ -22,7 +22,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinEnvironmentContainer) {
         val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement()
             .hasMessage("This '+ 3' is not used")
-        assertThat(findings).hasStartSourceLocation(3, 9)
+            .hasStartSourceLocation(3, 9)
     }
 
     @Test
@@ -36,7 +36,7 @@ class UnusedUnaryOperatorSpec(private val env: KotlinEnvironmentContainer) {
         val findings = subject.lintWithContext(env, code)
         assertThat(findings).singleElement()
             .hasMessage("This '- 3' is not used")
-        assertThat(findings).hasStartSourceLocation(3, 9)
+            .hasStartSourceLocation(3, 9)
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ConstructorParameterNamingSpec.kt
@@ -75,8 +75,7 @@ class ConstructorParameterNamingSpec {
             val code = """
                 class Foo(private val `PARAM_NAME`: Boolean)
             """.trimIndent()
-            assertThat(ConstructorParameterNaming(Config.empty).lint(code))
-                .hasSize(1)
+            assertThat(ConstructorParameterNaming(Config.empty).lint(code)).singleElement()
                 .hasStartSourceLocation(1, 11)
         }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/FunctionNamingSpec.kt
@@ -52,7 +52,7 @@ class FunctionNamingSpec {
             }
             interface I { fun shouldNotBeFlagged() }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).lint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).lint(code)).singleElement().hasStartSourceLocation(3, 13)
     }
 
     @Test
@@ -96,7 +96,7 @@ class FunctionNamingSpec {
             }
             interface I { @Suppress("FunctionNaming") fun SHOULD_BE_FLAGGED() }
         """.trimIndent()
-        assertThat(FunctionNaming(Config.empty).lint(code)).hasStartSourceLocation(3, 13)
+        assertThat(FunctionNaming(Config.empty).lint(code)).singleElement().hasStartSourceLocation(3, 13)
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -156,14 +156,14 @@ class MatchingDeclarationNameSpec {
         fun `should not pass for object declaration`() {
             val ktFile = compileContentForTest("object O", filename = "Objects.kt")
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 8)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 8)
         }
 
         @Test
         fun `should not pass for class declaration with name and unknown suffix`() {
             val ktFile = compileContentForTest("class C", filename = "Object.mySuffix.kt")
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 7)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 7)
         }
 
         @Test
@@ -173,14 +173,14 @@ class MatchingDeclarationNameSpec {
                 filename = "Objects.kt"
             )
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 45)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 45)
         }
 
         @Test
         fun `should not pass for class declaration`() {
             val ktFile = compileContentForTest("class C", filename = "Classes.kt")
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 7)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 7)
         }
 
         @Test
@@ -194,14 +194,14 @@ class MatchingDeclarationNameSpec {
                 filename = "ClassUtils.kt"
             )
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 7)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 7)
         }
 
         @Test
         fun `should not pass for interface declaration`() {
             val ktFile = compileContentForTest("interface I", filename = "Not_I.kt")
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 11)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 11)
         }
 
         @Test
@@ -215,7 +215,7 @@ class MatchingDeclarationNameSpec {
                 filename = "E.kt"
             )
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 12)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 12)
         }
 
         @Test
@@ -242,14 +242,14 @@ class MatchingDeclarationNameSpec {
             val findings = MatchingDeclarationName(
                 TestConfig("mustBeFirst" to "false")
             ).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(3, 7)
+            assertThat(findings).singleElement().hasStartSourceLocation(3, 7)
         }
 
         @Test
         fun `should not pass for class declaration and name with common suffix`() {
             val ktFile = compileContentForTest("class C", filename = "C.common.kt")
             val findings = MatchingDeclarationName(Config.empty).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 7)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 7)
         }
 
         @Test
@@ -258,7 +258,7 @@ class MatchingDeclarationNameSpec {
             val findings = MatchingDeclarationName(
                 TestConfig("multiplatformTargets" to emptyList<String>())
             ).lint(ktFile)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
     }
 

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/NoNameShadowingSpec.kt
@@ -19,8 +19,9 @@ class NoNameShadowingSpec(val env: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
         val findings = subject.lintWithContext(env, code)
-        assertThat(findings).singleElement().hasMessage("Name shadowed: i")
-        assertThat(findings).hasStartSourceLocation(2, 9)
+        assertThat(findings).singleElement()
+            .hasMessage("Name shadowed: i")
+            .hasStartSourceLocation(2, 9)
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/naming/ObjectPropertyNamingSpec.kt
@@ -65,7 +65,7 @@ class ObjectPropertyNamingSpec {
                     ${PublicConst.positive}
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasStartSourceLocation(2, 15)
+            assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(2, 15)
         }
     }
 
@@ -131,7 +131,7 @@ class ObjectPropertyNamingSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasStartSourceLocation(3, 19)
+            assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(3, 19)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
@@ -1,6 +1,5 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
-import dev.detekt.api.Finding
 import dev.detekt.test.TestConfig
 import dev.detekt.test.assertThat
 import dev.detekt.test.lintWithContext
@@ -167,7 +166,8 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
         }
 
         @Test
@@ -180,7 +180,8 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
         }
 
         @Test
@@ -193,14 +194,16 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor`() {
             val code = "abstract class A(val i: Int)"
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
@@ -208,14 +211,16 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
         fun `does not report no abstract members in an abstract class with a body and a constructor`() {
             val code = "abstract class A(val i: Int) {}"
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
         }
 
         @Test
         fun `does not report no abstract members in an abstract class with just a constructor parameter`() {
             val code = "abstract class A(i: Int)"
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
@@ -238,7 +243,8 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
         }
     }
 
@@ -315,9 +321,4 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
-}
-
-private fun assertFindingMessage(findings: List<Finding>, message: String) {
-    assertThat(findings).hasSize(1)
-    assertThat(findings.first()).hasMessage(message)
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeConcreteClassSpec.kt
@@ -204,7 +204,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage(message)
-            assertThat(findings).hasStartSourceLocation(1, 16)
+                .hasStartSourceLocation(1, 16)
         }
 
         @Test
@@ -221,7 +221,7 @@ class AbstractClassCanBeConcreteClassSpec(val env: KotlinEnvironmentContainer) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage(message)
-            assertThat(findings).hasStartSourceLocation(1, 16)
+                .hasStartSourceLocation(1, 16)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -28,7 +28,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage(message)
-            assertThat(findings).hasStartSourceLocation(1, 16)
+                .hasStartSourceLocation(1, 16)
         }
 
         @Nested
@@ -39,7 +39,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
                     .hasMessage(message)
-                assertThat(findings).hasStartSourceLocation(1, 16)
+                    .hasStartSourceLocation(1, 16)
             }
 
             @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import dev.detekt.api.Config
-import dev.detekt.api.Finding
 import dev.detekt.test.assertThat
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinCoreEnvironmentTest
@@ -27,7 +26,8 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
-            assertFindingMessage(findings, message)
+            assertThat(findings).singleElement()
+                .hasMessage(message)
             assertThat(findings).hasStartSourceLocation(1, 16)
         }
 
@@ -37,7 +37,8 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             fun `case 1`() {
                 val code = "abstract class A"
                 val findings = subject.lintWithContext(env, code)
-                assertFindingMessage(findings, message)
+                assertThat(findings).singleElement()
+                    .hasMessage(message)
                 assertThat(findings).hasStartSourceLocation(1, 16)
             }
 
@@ -45,21 +46,24 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             fun `case 2`() {
                 val code = "abstract class A()"
                 val findings = subject.lintWithContext(env, code)
-                assertFindingMessage(findings, message)
+                assertThat(findings).singleElement()
+                    .hasMessage(message)
             }
 
             @Test
             fun `case 3`() {
                 val code = "abstract class A {}"
                 val findings = subject.lintWithContext(env, code)
-                assertFindingMessage(findings, message)
+                assertThat(findings).singleElement()
+                    .hasMessage(message)
             }
 
             @Test
             fun `case 4`() {
                 val code = "abstract class A() {}"
                 val findings = subject.lintWithContext(env, code)
-                assertFindingMessage(findings, message)
+                assertThat(findings).singleElement()
+                    .hasMessage(message)
             }
 
             @Test
@@ -71,7 +75,8 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                     abstract class B : A
                 """.trimIndent()
                 val findings = subject.lintWithContext(env, code)
-                assertFindingMessage(findings, message)
+                assertThat(findings).singleElement()
+                    .hasMessage(message)
             }
 
             @Test
@@ -303,9 +308,4 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
-}
-
-private fun assertFindingMessage(findings: List<Finding>, message: String) {
-    assertThat(findings).hasSize(1)
-    assertThat(findings.first()).hasMessage(message)
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApplySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/AlsoCouldBeApplySpec.kt
@@ -45,9 +45,9 @@ class AlsoCouldBeApplySpec {
 
         val findings = subject.lint(code)
 
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(2, 7)
-        assertThat(findings).hasEndSourceLocation(2, 11)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(2, 7)
+            .hasEndSourceLocation(2, 11)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/DoubleNegativeLambdaSpec.kt
@@ -220,8 +220,9 @@ class DoubleNegativeLambdaSpec {
         assertThat(findings).singleElement().hasMessage(
             "Double negative through using `!in`, `!=` inside a `takeUnless` lambda. Use `takeIf` instead."
         )
-        assertThat(findings).hasStartSourceLocation(3, 37)
-        assertThat(findings).hasEndSourceLocation(3, 74)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(3, 37)
+            .hasEndSourceLocation(3, 74)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -187,8 +187,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.now()"))
         ).lintWithContext(env, code)
-        assertThat(findings).hasStartSourceLocation(5, 26)
         assertThat(findings).singleElement()
+            .hasStartSourceLocation(5, 26)
             .hasMessage("The method `java.time.LocalDate.now()` has been forbidden in the detekt config.")
     }
 
@@ -206,8 +206,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.now(java.time.Clock)"))
         ).lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(6, 27)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(6, 27)
     }
 
     @Test
@@ -221,8 +221,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)"))
         ).lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(3, 26)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(3, 26)
     }
 
     @Test
@@ -236,8 +236,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("java.time.LocalDate.of(kotlin.Int,kotlin.Int,kotlin.Int)"))
         ).lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(3, 26)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(3, 26)
     }
 
     @Test
@@ -254,8 +254,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val findings = ForbiddenMethodCall(
             TestConfig(METHODS to listOf("io.gitlab.arturbosch.detekt.rules.style.`some, test`()"))
         ).lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -275,8 +275,8 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
                     listOf("io.gitlab.arturbosch.detekt.rules.style.defaultParamsMethod(kotlin.String,kotlin.Int)")
             )
         ).lintWithContext(env, code)
-        assertThat(findings).hasSize(1)
-        assertThat(findings).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement()
+            .hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -293,7 +293,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.arrayMethod(kotlin.Array)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement().hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -310,7 +310,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.listMethod(kotlin.collections.List)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement().hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -329,7 +329,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.varargMethod(vararg kotlin.String)"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(8, 13)
+        assertThat(findings).singleElement().hasStartSourceLocation(8, 13)
     }
 
     @Test
@@ -350,7 +350,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(10, 15)
+        assertThat(findings).singleElement().hasStartSourceLocation(10, 15)
     }
 
     @Test
@@ -372,7 +372,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "io.gitlab.arturbosch.detekt.rules.style.TestClass.Companion.staticMethod()"
         val findings = ForbiddenMethodCall(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(11, 15)
+        assertThat(findings).singleElement().hasStartSourceLocation(11, 15)
     }
 
     @Test
@@ -601,8 +601,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("kotlin.runCatching(() -> R)"))
             ).lintWithContext(env, code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(5, 16)
         }
 
@@ -611,8 +610,7 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
             val findings = ForbiddenMethodCall(
                 TestConfig(METHODS to listOf("kotlin.runCatching(T, (T) -> R)"))
             ).lintWithContext(env, code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(6, 9)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenNamedParamSpec.kt
@@ -170,7 +170,7 @@ class ForbiddenNamedParamSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "com.example.arrayMethod(kotlin.Array)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement().hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -187,7 +187,7 @@ class ForbiddenNamedParamSpec(val env: KotlinEnvironmentContainer) {
         val methodName = "com.example.varargMethod(vararg kotlin.Any)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(6, 13)
+        assertThat(findings).singleElement().hasStartSourceLocation(6, 13)
     }
 
     @Test
@@ -210,7 +210,7 @@ class ForbiddenNamedParamSpec(val env: KotlinEnvironmentContainer) {
             "com.example.TestClass.Companion.staticMethod(kotlin.Int)"
         val findings = ForbiddenNamedParam(TestConfig(METHODS to listOf(methodName)))
             .lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(11, 15)
+        assertThat(findings).singleElement().hasStartSourceLocation(11, 15)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ForbiddenSuppressSpec.kt
@@ -23,8 +23,8 @@ internal class ForbiddenSuppressSpec {
                 class Foo
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -37,8 +37,8 @@ internal class ForbiddenSuppressSpec {
                 package config
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(1, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -53,8 +53,8 @@ internal class ForbiddenSuppressSpec {
                 fun foo() { }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -71,8 +71,8 @@ internal class ForbiddenSuppressSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(4, 5)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(4, 5)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"ARule\" due to the current configuration."
             )
@@ -132,8 +132,8 @@ internal class ForbiddenSuppressSpec {
                 package config
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(1, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(1, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rules \"ARule\", \"BRule\" " +
                     "due to the current configuration."
@@ -149,8 +149,8 @@ internal class ForbiddenSuppressSpec {
                 fun foo() { }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 1)
             assertThat(findings.first()).hasMessage(
                 "Cannot @Suppress rule \"BRule\" due to the current configuration."
             )

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MagicNumberSpec.kt
@@ -39,7 +39,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
     }
 
@@ -73,7 +73,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 13)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 13)
         }
     }
 
@@ -107,7 +107,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
     }
 
@@ -124,7 +124,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
     }
 
@@ -135,7 +135,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
 
         @Test
@@ -154,7 +154,7 @@ class MagicNumberSpec {
         fun `should not be ignored when ignoredNumbers contains 2 but not -2`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to listOf("1", "2", "3", "-1", "0")))
                 .lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
     }
 
@@ -188,7 +188,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 16)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 16)
         }
     }
 
@@ -222,7 +222,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported when ignoredNumbers is empty`() {
             val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 13)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 13)
         }
     }
 
@@ -284,7 +284,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 13)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 13)
         }
 
         @Test
@@ -398,7 +398,7 @@ class MagicNumberSpec {
         @Test
         fun `should be reported by default`() {
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 12)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 12)
         }
 
         @Test
@@ -580,7 +580,7 @@ class MagicNumberSpec {
             )
 
             val findings = MagicNumber(config).lint(code)
-            assertThat(findings).hasStartSourceLocation(4, 35)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 35)
         }
 
         @Test
@@ -1015,7 +1015,7 @@ class MagicNumberSpec {
         fun `should report unsigned integer literal`() {
             val code = "val myUInt = 65520U"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
 
         @Test
@@ -1029,7 +1029,7 @@ class MagicNumberSpec {
         fun `should report unsigned long literal`() {
             val code = "val myULong = 65520UL"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
 
         @Test
@@ -1043,7 +1043,7 @@ class MagicNumberSpec {
         fun `should report unsigned hex literal`() {
             val code = "val myUHex = 0xFFF0U"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
 
         @Test
@@ -1057,7 +1057,7 @@ class MagicNumberSpec {
         fun `should report unsigned hex long literal`() {
             val code = "val myUHexLong = 0xFFF0UL"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 18)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 18)
         }
 
         @Test
@@ -1067,21 +1067,21 @@ class MagicNumberSpec {
                 fun test() { someFunction(65520U) }
             """.trimIndent()
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(2, 27)
+            assertThat(findings).singleElement().hasStartSourceLocation(2, 27)
         }
 
         @Test
         fun `should report unsigned literals in array initialization`() {
             val code = "val array = arrayOf(1U, 2U, 65520U)"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 29)
         }
 
         @Test
         fun `should not report unsigned literals in property declarations by default`() {
             val code = "val myUInt = 65520U"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
 
         @Test
@@ -1110,7 +1110,7 @@ class MagicNumberSpec {
         fun `should report unsigned integer literal with lowercase u`() {
             val code = "val myUInt = 65520u"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
 
         @Test
@@ -1124,7 +1124,7 @@ class MagicNumberSpec {
         fun `should report unsigned long literal with lowercase uL`() {
             val code = "val myULong = 65520uL"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 15)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 15)
         }
 
         @Test
@@ -1138,7 +1138,7 @@ class MagicNumberSpec {
         fun `should report unsigned hex literal with lowercase u`() {
             val code = "val myUHex = 0xFFF0u"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 14)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 14)
         }
 
         @Test
@@ -1152,7 +1152,7 @@ class MagicNumberSpec {
         fun `should report unsigned hex long literal with lowercase uL`() {
             val code = "val myUHexLong = 0xFFF0uL"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 18)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 18)
         }
 
         @Test
@@ -1169,14 +1169,14 @@ class MagicNumberSpec {
                 fun test() { someFunction(65520u) }
             """.trimIndent()
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(2, 27)
+            assertThat(findings).singleElement().hasStartSourceLocation(2, 27)
         }
 
         @Test
         fun `should report lowercase unsigned literals in array initialization`() {
             val code = "val array = arrayOf(1u, 2u, 65520u)"
             val findings = MagicNumber(Config.empty).lint(code)
-            assertThat(findings).hasStartSourceLocation(1, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(1, 29)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MaxLineLengthSpec.kt
@@ -1,7 +1,6 @@
 package io.gitlab.arturbosch.detekt.rules.style
 
 import dev.detekt.api.Config
-import dev.detekt.api.SourceLocation
 import dev.detekt.test.TestConfig
 import dev.detekt.test.assertThat
 import dev.detekt.test.lint
@@ -399,9 +398,8 @@ class MaxLineLengthSpec {
             )
 
             val findings = rule.lint(code)
-            assertThat(findings)
-                .hasSize(1)
-                .hasStartSourceLocations(SourceLocation(6, 1))
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(6, 1)
                 .hasEndSourceLocation(6, 109)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/MultilineRawStringIndentationSpec.kt
@@ -20,11 +20,10 @@ class MultilineRawStringIndentationSpec {
                 $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(2, 1)
                 .hasEndSourceLocation(2, 13)
-                .hasTextLocations("Hello world!")
+                .hasTextLocation("Hello world!")
         }
 
         @Test
@@ -50,11 +49,10 @@ class MultilineRawStringIndentationSpec {
                 $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(2, 2)
                 .hasEndSourceLocation(2, 14)
-                .hasTextLocations("Hello world!")
+                .hasTextLocation("Hello world!")
         }
 
         @Test
@@ -66,11 +64,10 @@ class MultilineRawStringIndentationSpec {
                 $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(2, 5)
                 .hasEndSourceLocation(3, 18)
-                .hasTextLocations(" Hello world!\n     How are you?")
+                .hasTextLocation(" Hello world!\n     How are you?")
         }
 
         @Test
@@ -123,8 +120,7 @@ class MultilineRawStringIndentationSpec {
                 $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(3, 1)
                 .hasEndSourceLocation(3, 3)
         }
@@ -138,8 +134,7 @@ class MultilineRawStringIndentationSpec {
                     $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(4, 1)
                 .hasEndSourceLocation(4, 5)
         }
@@ -156,8 +151,7 @@ class MultilineRawStringIndentationSpec {
                     $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(3, 5)
                 .hasEndSourceLocation(3, 17)
         }
@@ -186,8 +180,7 @@ class MultilineRawStringIndentationSpec {
                     $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(3, 6)
                 .hasEndSourceLocation(3, 18)
         }
@@ -202,11 +195,10 @@ class MultilineRawStringIndentationSpec {
                     $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(3, 9)
                 .hasEndSourceLocation(4, 22)
-                .hasTextLocations(" Hello world!\n         How are you?")
+                .hasTextLocation(" Hello world!\n         How are you?")
         }
 
         @Test
@@ -247,8 +239,7 @@ class MultilineRawStringIndentationSpec {
                         $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(5, 5)
                 .hasEndSourceLocation(5, 9)
         }
@@ -263,8 +254,7 @@ class MultilineRawStringIndentationSpec {
                   $TQ.trimIndent()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings)
-                .hasSize(1)
+            assertThat(findings).singleElement()
                 .hasStartSourceLocation(5, 3)
                 .hasEndSourceLocation(5, 6)
         }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/NewLineAtEndOfFileSpec.kt
@@ -18,7 +18,7 @@ class NewLineAtEndOfFileSpec {
     @Test
     fun `should flag a kt file not containing new line at the end`() {
         val code = "class Test"
-        assertThat(subject.lint(code)).hasSize(1)
+        assertThat(subject.lint(code)).singleElement()
             .hasStartSourceLocation(1, 11)
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/ProtectedMemberInFinalClassSpec.kt
@@ -21,8 +21,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(2, 5)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(2, 5)
         }
 
         @Test
@@ -36,8 +36,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 5)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 5)
         }
 
         @Test
@@ -48,8 +48,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(2, 5)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(2, 5)
         }
 
         @Test
@@ -62,8 +62,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 9)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 9)
         }
 
         @Test
@@ -115,8 +115,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(4, 13)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(4, 13)
         }
 
         @Test
@@ -129,8 +129,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(3, 9)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(3, 9)
         }
 
         @Test
@@ -139,8 +139,8 @@ class ProtectedMemberInFinalClassSpec {
                 class FinalClassWithProtectedConstructor protected constructor()
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(1, 42)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(1, 42)
         }
 
         @Test
@@ -153,8 +153,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(2, 6)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(2, 6)
         }
 
         @Test
@@ -165,8 +165,8 @@ class ProtectedMemberInFinalClassSpec {
                 }
             """.trimIndent()
             val findings = subject.lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(2, 6)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(2, 6)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/RedundantHigherOrderMapUsageSpec.kt
@@ -25,7 +25,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'map' call can be removed.")
-            assertThat(findings).hasStartSourceLocation(4, 10)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 10)
         }
 
         @Test
@@ -45,7 +45,7 @@ class RedundantHigherOrderMapUsageSpec(val env: KotlinEnvironmentContainer) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("This 'map' call can be replaced with 'onEach' or 'forEach'.")
-            assertThat(findings).hasStartSourceLocation(5, 10)
+            assertThat(findings).singleElement().hasStartSourceLocation(5, 10)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -23,7 +23,7 @@ class SerialVersionUIDInSerializableClassSpec {
                 "The class C implements the `Serializable` interface and should thus define " +
                     "a `serialVersionUID`."
             )
-        assertThat(findings)
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(3, 7)
             .hasEndSourceLocation(3, 8)
     }
@@ -40,8 +40,8 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
-        assertThat(findings)
+        assertThat(findings).singleElement()
+            .hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
             .hasStartSourceLocation(5, 27)
             .hasEndSourceLocation(5, 43)
     }
@@ -58,8 +58,8 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
-        assertThat(findings)
+        assertThat(findings).singleElement()
+            .hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
             .hasStartSourceLocation(5, 27)
             .hasEndSourceLocation(5, 43)
     }
@@ -76,8 +76,8 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings).singleElement().hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
-        assertThat(findings)
+        assertThat(findings).singleElement()
+            .hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
             .hasStartSourceLocation(5, 19)
             .hasEndSourceLocation(5, 35)
     }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnnecessaryReversedSpec.kt
@@ -26,8 +26,7 @@ class UnnecessaryReversedSpec(
 
         val findings = subject.lintWithContext(env, code)
 
-        assertThat(findings)
-            .isNotEmpty
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(4, 7)
             .withFailMessage("Replace `sorted().asReversed()` by single `sortedDescending()`")
             .isNotNull()
@@ -80,8 +79,7 @@ class UnnecessaryReversedSpec(
 
         val findings = subject.lintWithContext(env, code)
 
-        assertThat(findings)
-            .isNotEmpty
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(4, 10)
             .withFailMessage("Replace `sorted().reversed()` by single `sortedDescending()`")
             .isNotNull()
@@ -100,8 +98,7 @@ class UnnecessaryReversedSpec(
 
         val findings = subject.lintWithContext(env, code)
 
-        assertThat(findings)
-            .isNotEmpty
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(4, 10)
             .withFailMessage("Replace `sorted().reversed()` by single `sortedDescending()`")
             .isNotNull()
@@ -120,8 +117,7 @@ class UnnecessaryReversedSpec(
 
         val findings = subject.lintWithContext(env, code)
 
-        assertThat(findings)
-            .isNotEmpty
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(4, 10)
             .withFailMessage("Replace `sortedDescending().asReversed()` by single `sorted()`")
             .isNotNull()
@@ -140,8 +136,7 @@ class UnnecessaryReversedSpec(
 
         val findings = subject.lintWithContext(env, code)
 
-        assertThat(findings)
-            .isNotEmpty
+        assertThat(findings).singleElement()
             .hasStartSourceLocation(4, 10)
             .withFailMessage("Replace `sortedDescending().reversed()` by single `sorted()`")
             .isNotNull()

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedParameterSpec.kt
@@ -306,7 +306,7 @@ class UnusedParameterSpec {
                     ) = 1
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(6, 9)
+            assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(6, 9)
         }
     }
 
@@ -323,7 +323,7 @@ class UnusedParameterSpec {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1).hasStartSourceLocation(1, 9)
+            assertThat(subject.lint(code)).singleElement().hasStartSourceLocation(1, 9)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateClassSpec.kt
@@ -22,8 +22,8 @@ class UnusedPrivateClassSpec {
 
             val findings = subject.lint(code)
 
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(1, 1)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(1, 1)
         }
 
         @Nested
@@ -38,8 +38,8 @@ class UnusedPrivateClassSpec {
 
                 val findings = subject.lint(code)
 
-                assertThat(findings).hasSize(1)
-                assertThat(findings).hasStartSourceLocation(1, 1)
+                assertThat(findings).singleElement()
+                    .hasStartSourceLocation(1, 1)
             }
 
             @Test
@@ -51,8 +51,8 @@ class UnusedPrivateClassSpec {
 
                 val findings = subject.lint(code)
 
-                assertThat(findings).hasSize(1)
-                assertThat(findings).hasStartSourceLocation(2, 1)
+                assertThat(findings).singleElement()
+                    .hasStartSourceLocation(2, 1)
             }
 
             @Test
@@ -454,8 +454,8 @@ class UnusedPrivateClassSpec {
                 }
             """.trimIndent()
             val findings = UnusedPrivateClass(Config.empty).lint(code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(10, 5)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(10, 5)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -927,7 +927,7 @@ class UnusedPrivateFunctionSpec(val env: KotlinEnvironmentContainer) {
                     private fun foo() = 1
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
+            assertThat(subject.lintWithContext(env, code)).singleElement().hasStartSourceLocation(5, 17)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -128,8 +128,7 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
-                .hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).singleElement()
                 .hasStartSourceLocation(4, 21)
         }
 
@@ -588,7 +587,7 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
                     private val foo = 1
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1).hasStartSourceLocation(5, 17)
+            assertThat(subject.lintWithContext(env, code)).singleElement().hasStartSourceLocation(5, 17)
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseCheckOrErrorSpec.kt
@@ -19,7 +19,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                 if (a < 0) throw IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -32,7 +33,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                 }
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(4, 9)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(4, 9)
     }
 
     @Test
@@ -43,7 +45,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                 if (a < 0) throw IllegalStateException("More details")
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -55,7 +58,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                     else -> throw IllegalStateException()
                 }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(4, 17)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(4, 17)
     }
 
     @Test
@@ -66,7 +70,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                 if (a < 0) throw java.lang.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -77,7 +82,8 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
                 if (a < 0) throw kotlin.IllegalStateException()
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(3, 16)
     }
 
     @Test
@@ -126,13 +132,15 @@ class UseCheckOrErrorSpec(val env: KotlinEnvironmentContainer) {
     @Test
     fun `reports an issue if the exception thrown as the only action in a function`() {
         val code = """fun doThrow(): Nothing = throw IllegalStateException("message")"""
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(1, 26)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(1, 26)
     }
 
     @Test
     fun `reports an issue if the exception thrown as the only action in a function block`() {
         val code = """fun doThrow(): Nothing { throw IllegalStateException("message") }"""
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(1, 26)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(1, 26)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseDataClassSpec.kt
@@ -167,9 +167,9 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
 
             val findings = subject.lintWithContext(env, code)
 
-            assertThat(findings).hasSize(1)
-            assertThat(findings).hasStartSourceLocation(1, 7)
-            assertThat(findings).hasEndSourceLocation(1, 26)
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(1, 7)
+                .hasEndSourceLocation(1, 26)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIfEmptyOrIfBlankSpec.kt
@@ -27,7 +27,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isBlank' call can be replaced with 'ifBlank'")
-            assertThat(findings).hasStartSourceLocation(4, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 29)
         }
 
         @Test
@@ -45,7 +45,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isNotBlank' call can be replaced with 'ifBlank'")
-            assertThat(findings).hasStartSourceLocation(4, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 29)
         }
 
         @Test
@@ -60,7 +60,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isEmpty' call can be replaced with 'ifEmpty'")
-            assertThat(findings).hasStartSourceLocation(4, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 29)
         }
 
         @Test
@@ -78,7 +78,7 @@ class UseIfEmptyOrIfBlankSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement().hasMessage("This 'isNotEmpty' call can be replaced with 'ifEmpty'")
-            assertThat(findings).hasStartSourceLocation(4, 29)
+            assertThat(findings).singleElement().hasStartSourceLocation(4, 29)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseIsNullOrEmptySpec.kt
@@ -27,7 +27,7 @@ class UseIsNullOrEmptySpec(val env: KotlinEnvironmentContainer) {
                 assertThat(findings).singleElement().hasMessage(
                     "This 'x == null || x.isEmpty()' can be replaced with 'isNullOrEmpty()' call"
                 )
-                assertThat(findings).hasStartSourceLocation(2, 9)
+                assertThat(findings).singleElement().hasStartSourceLocation(2, 9)
             }
 
             @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseOrEmptySpec.kt
@@ -24,7 +24,7 @@ class UseOrEmptySpec(val env: KotlinEnvironmentContainer) {
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
                 .hasMessage("This '?: emptyList()' can be replaced with 'orEmpty()' call")
-            assertThat(findings).hasStartSourceLocation(2, 13)
+            assertThat(findings).singleElement().hasStartSourceLocation(2, 13)
         }
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/UseRequireSpec.kt
@@ -20,7 +20,8 @@ class UseRequireSpec(val env: KotlinEnvironmentContainer) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -34,7 +35,8 @@ class UseRequireSpec(val env: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
 
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(3, 9)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(3, 9)
     }
 
     @Test
@@ -45,7 +47,8 @@ class UseRequireSpec(val env: KotlinEnvironmentContainer) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -56,7 +59,8 @@ class UseRequireSpec(val env: KotlinEnvironmentContainer) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(2, 16)
     }
 
     @Test
@@ -67,7 +71,8 @@ class UseRequireSpec(val env: KotlinEnvironmentContainer) {
                 println("something")
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasStartSourceLocation(2, 16)
+        assertThat(subject.lintWithContext(env, code)).singleElement()
+            .hasStartSourceLocation(2, 16)
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/movelambdaout/UnnecessaryBracesAroundTrailingLambdaSpec.kt
@@ -151,7 +151,7 @@ class UnnecessaryBracesAroundTrailingLambdaSpec(val env: KotlinEnvironmentContai
             }
         """.trimIndent()
         val findings = subject.lintWithContext(env, code)
-        assertThat(findings).hasSize(1).hasStartSourceLocation(2, 5).hasEndSourceLocation(2, 8)
+        assertThat(findings).singleElement().hasStartSourceLocation(2, 5).hasEndSourceLocation(2, 8)
     }
 
     @Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -24,9 +24,7 @@ public final class dev/detekt/test/FindingExtensionsKt {
 
 public final class dev/detekt/test/FindingsAssert : org/assertj/core/api/AbstractListAssert {
 	public fun <init> (Ljava/util/List;)V
-	public final fun hasEndSourceLocation (II)Ldev/detekt/test/FindingsAssert;
 	public final fun hasEndSourceLocations ([Ldev/detekt/api/SourceLocation;)Ldev/detekt/test/FindingsAssert;
-	public final fun hasStartSourceLocation (II)Ldev/detekt/test/FindingsAssert;
 	public final fun hasStartSourceLocations ([Ldev/detekt/api/SourceLocation;)Ldev/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Ljava/lang/String;)Ldev/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Lkotlin/Pair;)Ldev/detekt/test/FindingsAssert;

--- a/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
@@ -53,14 +53,6 @@ class FindingsAssert(actual: List<Finding>) :
         }
     }
 
-    fun hasStartSourceLocation(line: Int, column: Int) = apply {
-        hasStartSourceLocations(SourceLocation(line, column))
-    }
-
-    fun hasEndSourceLocation(line: Int, column: Int) = apply {
-        hasEndSourceLocations(SourceLocation(line, column))
-    }
-
     fun hasTextLocations(vararg expected: Pair<Int, Int>) = apply {
         val actualSources = actual.asSequence()
             .map { it.location.text }


### PR DESCRIPTION
These asserts are easier to read and describe better what they do. They also simplify the API. The final goal (I'm not sure if it's possible) is to remove `FindingsAssert`. Probably we could replace them to extensions functions. But I'm not sure yet.