### PR TITLE
Migrate Gradle plugin IDs to dev.detekt.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import io.gitlab.arturbosch.detekt.report.ReportMergeTask
 
 plugins {
     id("releasing")
-    id("io.gitlab.arturbosch.detekt")
+    id("dev.detekt")
     id("org.jetbrains.dokka") version "2.0.0"
 }
 
@@ -42,7 +42,7 @@ allprojects {
     group = "io.gitlab.arturbosch.detekt"
     version = Versions.currentOrSnapshot()
 
-    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "dev.detekt")
 
     detekt {
         buildUponDefaultConfig = true

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
     google()
 }
 
-group = "io.gitlab.arturbosch.detekt"
+group = "dev.detekt"
 version = Versions.currentOrSnapshot()
 
 detekt {
@@ -149,15 +149,15 @@ gradlePlugin {
     vcsUrl = "https://github.com/detekt/detekt"
     plugins {
         create("detektBasePlugin") {
-            id = "io.github.detekt.gradle.base"
+            id = "dev.detekt.gradle.base"
             implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
         }
         create("detektPlugin") {
-            id = "io.gitlab.arturbosch.detekt"
+            id = "dev.detekt"
             implementationClass = "io.gitlab.arturbosch.detekt.DetektPlugin"
         }
         create("detektCompilerPlugin") {
-            id = "io.github.detekt.gradle.compiler-plugin"
+            id = "dev.detekt.gradle.compiler-plugin"
             implementationClass = "io.github.detekt.gradle.DetektKotlinCompilerPlugin"
         }
         configureEach {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -22,7 +22,7 @@ class DetektBasePluginSpec {
             buildFileName = "build.gradle.kts",
             mainBuildFileContent = """
                 plugins {
-                    id("io.gitlab.arturbosch.detekt")
+                    id("dev.detekt")
                     kotlin("jvm")
                 }
                 
@@ -55,7 +55,7 @@ class DetektBasePluginSpec {
             buildFileName = "build.gradle.kts",
             mainBuildFileContent = """
                 plugins {
-                    id("io.gitlab.arturbosch.detekt")
+                    id("dev.detekt")
                     id("com.android.library")
                     kotlin("android")
                 }
@@ -108,7 +108,7 @@ class DetektBasePluginSpec {
             buildFileName = "build.gradle.kts",
             mainBuildFileContent = """
                 plugins {
-                    id("io.gitlab.arturbosch.detekt")
+                    id("dev.detekt")
                     kotlin("multiplatform")
                     id("com.android.library")
                 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektAndroidSpec.kt
@@ -635,7 +635,7 @@ private val APP_PLUGIN_BLOCK = """
     plugins {
         id("com.android.application")
         kotlin("android")
-        id("io.gitlab.arturbosch.detekt")
+        id("dev.detekt")
     }
     kotlin {
         compilerOptions {
@@ -649,7 +649,7 @@ private val LIB_PLUGIN_BLOCK = """
     plugins {
         id("com.android.library")
         kotlin("android")
-        id("io.gitlab.arturbosch.detekt")
+        id("dev.detekt")
     }
     kotlin {
         compilerOptions {
@@ -662,7 +662,7 @@ private val LIB_PLUGIN_BLOCK = """
 private val KOTLIN_ONLY_LIB_PLUGIN_BLOCK = """
     plugins {
         kotlin("jvm")
-        id("io.gitlab.arturbosch.detekt")
+        id("dev.detekt")
     }
 """.trimIndent()
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektMultiplatformSpec.kt
@@ -146,7 +146,7 @@ class DetektMultiplatformSpec {
                             plugins {
                                 kotlin("multiplatform")
                                 id("com.android.library")
-                                id("io.gitlab.arturbosch.detekt")
+                                id("dev.detekt")
                             }
                             android {
                                 compileSdk = 34
@@ -381,7 +381,7 @@ private fun assertDetektWithClasspath(buildResult: BuildResult) {
 private val KMM_PLUGIN_BLOCK = """
     plugins {
         kotlin("multiplatform")
-        id("io.gitlab.arturbosch.detekt")
+        id("dev.detekt")
     }
 """.trimIndent()
 

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/report/ReportMergeSpec.kt
@@ -34,7 +34,7 @@ class ReportMergeSpec {
         }
         val mainBuildFileContent: String = """
             plugins {
-                id("io.gitlab.arturbosch.detekt")
+                id("dev.detekt")
             }
             
             val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
@@ -45,7 +45,7 @@ class ReportMergeSpec {
             
             subprojects {
                 apply(plugin = "org.jetbrains.kotlin.jvm")
-                apply(plugin = "io.gitlab.arturbosch.detekt")
+                apply(plugin = "dev.detekt")
             
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
@@ -96,7 +96,7 @@ class ReportMergeSpec {
                     plugins {
                         id("com.android.application")
                         kotlin("android")
-                        id("io.gitlab.arturbosch.detekt")
+                        id("dev.detekt")
                     }
                     android {
                        compileSdk = 34
@@ -144,7 +144,7 @@ class ReportMergeSpec {
         }
         val mainBuildFileContent: String = """
             plugins {
-                id("io.gitlab.arturbosch.detekt")
+                id("dev.detekt")
             }
             
             val reportMerge by tasks.registering(io.gitlab.arturbosch.detekt.report.ReportMergeTask::class) {
@@ -154,7 +154,7 @@ class ReportMergeSpec {
             }
             
             subprojects {
-                apply(plugin = "io.gitlab.arturbosch.detekt")
+                apply(plugin = "dev.detekt")
             
                 plugins.withType<io.gitlab.arturbosch.detekt.DetektPlugin> {
                     tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
-    id("io.gitlab.arturbosch.detekt")
+    id("dev.detekt")
 }
 
 repositories {

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslTestBuilder.kt
@@ -90,7 +90,7 @@ private class GroovyBuilder : DslTestBuilder() {
     override val gradlePlugins = """
         plugins {
             id 'org.jetbrains.kotlin.jvm'
-            id "io.gitlab.arturbosch.detekt"
+            id "dev.detekt"
         }
     """.trimIndent()
 
@@ -106,7 +106,7 @@ private class GroovyBuilder : DslTestBuilder() {
 
     @Language("gradle")
     override val gradleSubprojectsApplyPlugins = """
-        apply plugin: "io.gitlab.arturbosch.detekt"
+        apply plugin: "dev.detekt"
     """.trimIndent()
 
     override fun toString() = "build.gradle"
@@ -119,7 +119,7 @@ private class KotlinBuilder : DslTestBuilder() {
     override val gradlePlugins = """
         plugins {
             kotlin("jvm")
-            id("io.gitlab.arturbosch.detekt")
+            id("dev.detekt")
         }
     """.trimIndent()
 
@@ -135,7 +135,7 @@ private class KotlinBuilder : DslTestBuilder() {
 
     @Language("gradle.kts")
     override val gradleSubprojectsApplyPlugins = """
-        plugins.apply("io.gitlab.arturbosch.detekt")
+        plugins.apply("dev.detekt")
     """.trimIndent()
 
     override fun toString() = "build.gradle.kts"


### PR DESCRIPTION
This is part of:
- https://github.com/detekt/detekt/issues/8432

It migrates all the Gradle plugin IDs to be `dev.detekt.*`.