### PR TITLE
Migrate maven group to dev.detekt.*

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 nexusPublishing {
-    packageGroup = "io.gitlab.arturbosch"
+    packageGroup = "dev.detekt"
 
     repositories {
         create("sonatype") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
 }
 
 allprojects {
-    group = "io.gitlab.arturbosch.detekt"
+    group = "dev.detekt"
     version = Versions.currentOrSnapshot()
 
     apply(plugin = "dev.detekt")

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -3,7 +3,7 @@ import de.undercouch.gradle.tasks.download.Download
 val kotlinVersion: String = libs.versions.kotlin.get()
 val detektVersion: String = Versions.DETEKT
 
-group = "io.github.detekt"
+group = "dev.detekt"
 version = "$kotlinVersion-$detektVersion"
 
 plugins {
@@ -45,8 +45,7 @@ tasks.shadowJar {
     relocate("org.snakeyaml.engine", "dev.detekt.shaded.snakeyaml")
     mergeServiceFiles()
     dependencies {
-        include(dependency("io.gitlab.arturbosch.detekt:.*"))
-        include(dependency("io.github.detekt:.*"))
+        include(dependency("dev.detekt:.*"))
         include(dependency("org.snakeyaml:snakeyaml-engine"))
     }
 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/io/gitlab/arturbosch/detekt/DetektTaskDslSpec.kt
@@ -467,7 +467,7 @@ class DetektTaskDslSpec {
     inner class `with an additional plugin` {
         private val config = """
             dependencies {
-               detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
+               detektPlugins("dev.detekt:detekt-formatting:$defaultDetektVersion")
             }
         """.trimIndent()
         private val builder = kotlin().dryRun()
@@ -481,7 +481,7 @@ class DetektTaskDslSpec {
 
         @Test
         fun `adds the formatting lib to the project dependencies`() {
-            assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-formatting:$defaultDetektVersion")
+            assertThat(result.output).contains("dev.detekt:detekt-formatting:$defaultDetektVersion")
         }
     }
 
@@ -505,7 +505,7 @@ class DetektTaskDslSpec {
 
         @Test
         fun `adds the custom detekt version to the dependencies`() {
-            assertThat(result.output).contains("io.gitlab.arturbosch.detekt:detekt-cli:$customVersion")
+            assertThat(result.output).contains("dev.detekt:detekt-cli:$customVersion")
         }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektPlugin.kt
@@ -97,7 +97,7 @@ class DetektPlugin : Plugin<Project> {
 
             configuration.defaultDependencies { dependencySet ->
                 val version = extension.toolVersion.get()
-                dependencySet.add(project.dependencies.create("io.gitlab.arturbosch.detekt:detekt-cli:$version"))
+                dependencySet.add(project.dependencies.create("dev.detekt:detekt-cli:$version"))
             }
         }
     }

--- a/detekt-rules-ruleauthors/src/main/kotlin/dev/detekt/rules/ruleauthors/RuleAuthorsProvider.kt
+++ b/detekt-rules-ruleauthors/src/main/kotlin/dev/detekt/rules/ruleauthors/RuleAuthorsProvider.kt
@@ -9,7 +9,7 @@ import dev.detekt.api.RuleSetProvider
  *
  * **Note: The `ruleauthors` rule set is not included in the detekt-cli or Gradle plugin.**
  *
- * To enable this rule set, add `detektPlugins "io.gitlab.arturbosch.detekt:detekt-rules-ruleauthors:$version"`
+ * To enable this rule set, add `detektPlugins "dev.detekt:detekt-rules-ruleauthors:$version"`
  * to your Gradle `dependencies` or reference the `detekt-rules-ruleauthors`-jar with the `--plugins` option
  * in the command line interface.
  */


### PR DESCRIPTION
This migrates the maven group for all the artifacts to be `dev.detekt`.

Fixes: https://github.com/detekt/detekt/issues/8432
