### PR TITLE
Remove opt-ins that are no longer required

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -7,7 +7,6 @@ import dev.detekt.tooling.api.spec.RulesSpec.RunPolicy.DisableDefaultRuleSets
 import dev.detekt.tooling.api.spec.RulesSpec.RunPolicy.NoRestrictions
 import dev.detekt.utils.PathFilters
 import java.nio.file.Path
-import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.absolute
 import kotlin.io.path.extension
 import kotlin.io.path.relativeTo
@@ -85,7 +84,6 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
     }
 }
 
-@OptIn(ExperimentalPathApi::class)
 private fun Iterable<Path>.walk(): Sequence<Path> = asSequence().flatMap { it.walk() }
 
 private fun Path.isKotlinFile() = extension in KT_ENDINGS

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/io/gitlab/arturbosch/detekt/testkit/DslGradleRunner.kt
@@ -130,7 +130,6 @@ constructor(
         .build()
         .apply(projectScript)
 
-    @OptIn(ExperimentalStdlibApi::class)
     private fun buildGradleRunner(tasks: List<String>): GradleRunner {
         val args = buildList {
             add("--stacktrace")

--- a/detekt-rules-performance/src/test/kotlin/dev/detekt/rules/performance/ForEachOnRangeSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/dev/detekt/rules/performance/ForEachOnRangeSpec.kt
@@ -20,7 +20,6 @@ class ForEachOnRangeSpec {
                 (1.rangeTo(10)).forEach {
                     println(it)
                 }
-                @OptIn(ExperimentalStdlibApi::class)
                 (1..<10).forEach {
                     println(it)
                 }


### PR DESCRIPTION
Some of the opt-ins we are using are no longer required.