### PR TITLE
Remove explicit kotlin-stdlib dependency

### DIFF
--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
 

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -3,7 +3,6 @@ plugins {
 }
 
 dependencies {
-    compileOnly(libs.kotlin.stdlib)
     compileOnly(projects.detektApi)
     compileOnly(projects.detektPsiUtils)
 

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    api(libs.kotlin.stdlib)
     api(libs.junit.jupiterApi)
     implementation(projects.detektKotlinAnalysisApi)
     implementation(projects.detektKotlinAnalysisApiStandalone)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,6 @@ kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-scriptingJvm = { module = "org.jetbrains.kotlin:kotlin-scripting-jvm", version.ref = "kotlin" }
-kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlinx-coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-serializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.9.0" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }


### PR DESCRIPTION
There is no need to add this explicit dependency in Kotlin projects.