### PR TITLE
Remove redundant workaround

### DIFF
--- a/detekt-formatting/ktlint-repackage/build.gradle.kts
+++ b/detekt-formatting/ktlint-repackage/build.gradle.kts
@@ -17,13 +17,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-configurations.shadowRuntimeElements {
-    attributes {
-        // This is not needed in shadow plugin 9+: https://github.com/GradleUp/shadow/pull/1199
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.VERSION_1_8.majorVersion.toInt())
-    }
-}
-
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
     skip()

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -26,13 +26,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-configurations.shadowRuntimeElements {
-    attributes {
-        // This is not needed in shadow plugin 9+: https://github.com/GradleUp/shadow/pull/1199
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.VERSION_1_8.majorVersion.toInt())
-    }
-}
-
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
     skip()

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -28,13 +28,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-configurations.shadowRuntimeElements {
-    attributes {
-        // This is not needed in shadow plugin 9+: https://github.com/GradleUp/shadow/pull/1199
-        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, JavaVersion.VERSION_1_8.majorVersion.toInt())
-    }
-}
-
 val javaComponent = components["java"] as AdhocComponentWithVariants
 javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
     skip()


### PR DESCRIPTION
This workaround is no longer required after upgrading to Shadow plugin v9.