### PR TITLE
Don't execute `generateDocumentation` every single time

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -83,6 +83,15 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
         configurations.runtimeClasspath,
         sourceSets.main.map { it.output },
     )
+
+    inputs.files(ruleModules)
+    outputs.dir(documentationDir)
+    outputs.file(defaultConfigFile)
+    outputs.file(deprecationFile)
+    outputs.file(formattingConfigFile)
+    outputs.file(librariesConfigFile)
+    outputs.file(ruleauthorsConfigFile)
+
     mainClass = "dev.detekt.generator.Main"
     args = listOf(
         "--input",


### PR DESCRIPTION
This is something that was bothering me for long time. `generateDocumentation` was never UP-TO-DATE. This should fix it. I'm configuring the inputs and outputs so it's only executed when needed.

Right now I can't enable the cache because one of the output dirs contain files that aren't generated by the task so it doesn't work. Probably this task should generate inside `/build` and then use `Copy` to move the files. But I don't care that much about this to take care of it.