### PR TITLE
Request for comments: Proposal to how to assert over multiple `Finding`s

### DIFF
--- a/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
+++ b/detekt-formatting/src/test/kotlin/io/gitlab/arturbosch/detekt/formatting/NoUnusedImportsSpec.kt
@@ -30,12 +30,11 @@ class NoUnusedImportsSpec {
 
         val findings = NoUnusedImports(Config.empty).lint(code)
 
-        assertThat(findings)
-            .hasSize(3)
-            .hasStartSourceLocations(
-                SourceLocation(3, 1),
-                SourceLocation(4, 1),
-                SourceLocation(5, 1)
-            )
+        assertThat(findings).hasSize(3)
+            .iterate {
+                next().hasStartSourceLocation(SourceLocation(3, 1))
+                next().hasStartSourceLocation(SourceLocation(4, 1))
+                next().hasStartSourceLocation(SourceLocation(5, 1))
+            }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -172,14 +172,18 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings)
-            .hasSize(2)
-            .hasStartSourceLocations(SourceLocation(3, 7), SourceLocation(4, 11))
-            .hasEndSourceLocations(SourceLocation(3, 8), SourceLocation(4, 12))
-        assertThat(findings.map { it.message }).containsOnly(
-            "The class A implements the `Serializable` interface and should thus define a `serialVersionUID`.",
-            "The class B implements the `Serializable` interface and should thus define a `serialVersionUID`."
-        )
+        assertThat(findings).hasSize(2).iterate {
+            next().hasStartSourceLocation(SourceLocation(4, 11))
+                .hasEndSourceLocation(SourceLocation(4, 12))
+                .hasMessage(
+                    "The class B implements the `Serializable` interface and should thus define a `serialVersionUID`."
+                )
+            next().hasStartSourceLocation(SourceLocation(3, 7))
+                .hasEndSourceLocation(SourceLocation(3, 8))
+                .hasMessage(
+                    "The class A implements the `Serializable` interface and should thus define a `serialVersionUID`."
+                )
+        }
     }
 
     @Test

--- a/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/io/gitlab/arturbosch/detekt/rules/style/SerialVersionUIDInSerializableClassSpec.kt
@@ -152,14 +152,15 @@ class SerialVersionUIDInSerializableClassSpec {
             }
         """.trimIndent()
         val findings = subject.lint(code)
-        assertThat(findings)
-            .hasSize(2)
-            .hasStartSourceLocations(SourceLocation(6, 25), SourceLocation(11, 21))
-            .hasEndSourceLocations(SourceLocation(6, 41), SourceLocation(11, 37))
-        assertThat(findings.map { it.message }).containsOnly(
-            WRONG_SERIAL_VERSION_UID_MESSAGE,
-            WRONG_SERIAL_VERSION_UID_MESSAGE
-        )
+        assertThat(findings).hasSize(2)
+        assertThat(findings).element(0)
+            .hasStartSourceLocation(SourceLocation(6, 25))
+            .hasEndSourceLocation(SourceLocation(6, 41))
+            .hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
+        assertThat(findings).element(1)
+            .hasStartSourceLocation(SourceLocation(11, 21))
+            .hasEndSourceLocation(SourceLocation(11, 37))
+            .hasMessage(WRONG_SERIAL_VERSION_UID_MESSAGE)
     }
 
     @Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -28,6 +28,7 @@ public final class dev/detekt/test/FindingsAssert : org/assertj/core/api/Abstrac
 	public final fun hasStartSourceLocations ([Ldev/detekt/api/SourceLocation;)Ldev/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Ljava/lang/String;)Ldev/detekt/test/FindingsAssert;
 	public final fun hasTextLocations ([Lkotlin/Pair;)Ldev/detekt/test/FindingsAssert;
+	public final fun iterate (Lkotlin/jvm/functions/Function1;)Ldev/detekt/test/FindingsAssert;
 	public synthetic fun newAbstractIterableAssert (Ljava/lang/Iterable;)Lorg/assertj/core/api/AbstractIterableAssert;
 	public synthetic fun toAssert (Ljava/lang/Object;Ljava/lang/String;)Lorg/assertj/core/api/AbstractAssert;
 }

--- a/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/FindingsAssertions.kt
@@ -5,6 +5,7 @@ import dev.detekt.api.SourceLocation
 import dev.detekt.api.TextLocation
 import org.assertj.core.annotation.CheckReturnValue
 import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.AbstractIterableAssert
 import org.assertj.core.api.AbstractListAssert
 import java.util.Objects
 
@@ -97,6 +98,12 @@ class FindingsAssert(actual: List<Finding>) :
 
         return hasTextLocations(*textLocations)
     }
+
+    fun iterate(block: Iterator<FindingAssert>.() -> Unit) = apply {
+        val iterator = iterator()
+        block(iterator)
+        check(!iterator.hasNext()) { "The iterator wasn't consumed completely" }
+    }
 }
 
 class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Finding>(actual, FindingAssert::class.java) {
@@ -185,5 +192,19 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
         }
 
         hasTextLocation(TextLocation(index, index + expected.length))
+    }
+}
+
+private fun <
+    SELF : AbstractIterableAssert<SELF, ACTUAL, ELEMENT, ELEMENT_ASSERT>,
+    ACTUAL : Iterable<ELEMENT>?,
+    ELEMENT,
+    ELEMENT_ASSERT : AbstractAssert<ELEMENT_ASSERT, ELEMENT>,
+    > SELF.iterator(): Iterator<ELEMENT_ASSERT> {
+    isNotNull()
+    return iterator {
+        for (i in 0..<actual()!!.count()) {
+            yield(element(i))
+        }
     }
 }


### PR DESCRIPTION
I was wondering how to create an easy API to assert over multiple `Finding`s and I think that I have something that I like now.

```kotlin
.iterate {
    next().hasStartSourceLocation(SourceLocation(4, 11))
        .hasEndSourceLocation(SourceLocation(4, 12))
        .hasMessage("The class B implements the `Serializable` interface and should thus define a `serialVersionUID`.")
    next().hasStartSourceLocation(SourceLocation(3, 7))
        .hasEndSourceLocation(SourceLocation(3, 8))
        .hasMessage("The class A implements the `Serializable` interface and should thus define a `serialVersionUID`.")
}
```

The idea is to use `iterator`. In general I don't like `Iterator` because you need to call `hasNext()` but in the test context we don't care about that. If there is not a `next` element we want to fail so we can skip `hasNext` completely.

What do you think? Is this API better that what we had before?

You can check the diff of this PR to see some examples of before/after.