### PR TITLE
Impose invariants over `TextLocation`

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/Location.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Location.kt
@@ -89,5 +89,10 @@ class SourceLocation(val line: Int, val column: Int) : Comparable<SourceLocation
  */
 @Poko
 class TextLocation(val start: Int, val end: Int) {
+    init {
+        require(start >= 0) { "start can't be negative" }
+        require(end >= start) { "end must be greater than or equal to start" }
+    }
+
     override fun toString(): String = "$start:$end"
 }


### PR DESCRIPTION
`TextLocation` represents from which char to which other char there is an issue. The chars of a file can't be negative and the end should be always greater or equals than the start.

I'm adding this because I'm working on the test for `TextLocation` and it have not sense to cover the case with negatives or with a end smaller than the start. Without this those tests should be added.

`SourceLocation` had them already.