### PR TITLE
Set duplicatesStrategy to EXCLUDE explicitly for ShadowJar tasks

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -57,7 +57,8 @@ publishing {
 
 tasks {
     shadowJar {
-        mergeServiceFiles()
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        failOnDuplicateEntries = true
     }
 
     shadowDistZip {

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -42,8 +42,9 @@ publishing {
 }
 
 tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
     relocate("org.snakeyaml.engine", "dev.detekt.shaded.snakeyaml")
-    mergeServiceFiles()
     dependencies {
         include(dependency("dev.detekt:.*"))
         include(dependency("org.snakeyaml:snakeyaml-engine"))

--- a/detekt-formatting/ktlint-repackage/build.gradle.kts
+++ b/detekt-formatting/ktlint-repackage/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
 }
 
 tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
     relocate("org.jetbrains.kotlin.com.intellij", "com.intellij")
 }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -28,6 +28,11 @@ dependencies {
     testImplementation(libs.assertj.core)
 }
 
+tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
+}
+
 val generateCliOptions by tasks.registering(JavaExec::class) {
     classpath = detektCliClasspath
     mainClass = "dev.detekt.cli.Main"

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -33,3 +33,8 @@ javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
 javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) {
     skip()
 }
+
+tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
+}

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -35,3 +35,8 @@ javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
 javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) {
     skip()
 }
+
+tasks.shadowJar {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    failOnDuplicateEntries = true
+}


### PR DESCRIPTION
- `mergeServiceFiles` will not work with the default strategy (`EXCLUDE`), seems we don't need it for merging service files.
- Enable `failOnDuplicateEntries` for stricter entry check.

https://github.com/GradleUp/shadow/releases/tag/9.0.1

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
