### PR TITLE
Add tests to `FindingAssert` - Prerequisites

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
     testImplementation(libs.assertj.core)
 
     testFixturesApi(libs.kotlin.compiler)
+    testFixturesApi(projects.detektTestUtils)
 }
 
 detekt {

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
@@ -11,7 +11,7 @@ import kotlin.io.path.Path
 
 fun createIssue(
     ruleId: String = "TestSmell/id",
-    entity: Issue.Entity = createEntity(),
+    entity: Issue.Entity = createIssueEntity(),
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     suppressReasons: List<String> = emptyList(),
@@ -25,7 +25,7 @@ fun createIssue(
 
 fun createIssue(
     ruleInstance: RuleInstance,
-    entity: Issue.Entity = createEntity(),
+    entity: Issue.Entity = createIssueEntity(),
     message: String = "TestMessage",
     severity: Severity = Severity.Error,
     suppressReasons: List<String> = emptyList(),
@@ -46,7 +46,7 @@ fun createIssue(
     suppressReasons: List<String> = emptyList(),
 ): Issue = Issue(
     ruleInstance = ruleInstance,
-    entity = createEntity(location = location),
+    entity = createIssueEntity(location = location),
     references = emptyList(),
     message = message,
     severity = severity,
@@ -70,7 +70,7 @@ fun createRuleInstance(
     active = active,
 )
 
-fun createEntity(
+fun createIssueEntity(
     signature: String = "TestEntitySignature",
     location: Issue.Location = createLocation(),
 ): Issue.Entity = Issue.Entity(

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
@@ -64,7 +64,7 @@ fun createIssue(
     suppressReasons: List<String> = emptyList(),
 ): Issue = Issue(
     ruleInstance = ruleInstance,
-    entity = createIssueEntity(location = location),
+    entity = createIssueEntity(location),
     references = emptyList(),
     message = message,
     severity = severity,
@@ -91,7 +91,7 @@ fun createRuleInstance(
 fun createEntity(
     location: Location = createLocation(),
     signature: String = "TestEntitySignature",
-    ktElement: KtElement = FakeKtElement()
+    ktElement: KtElement = FakeKtElement(),
 ): Entity = Entity(
     signature = signature,
     location = location,
@@ -111,8 +111,8 @@ fun createLocation(
 )
 
 fun createIssueEntity(
-    signature: String = "TestEntitySignature",
     location: Issue.Location = createIssueLocation(),
+    signature: String = "TestEntitySignature",
 ): Issue.Entity = Issue.Entity(
     signature = signature,
     location = location,

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
@@ -72,13 +72,13 @@ fun createRuleInstance(
 
 fun createIssueEntity(
     signature: String = "TestEntitySignature",
-    location: Issue.Location = createLocation(),
+    location: Issue.Location = createIssueLocation(),
 ): Issue.Entity = Issue.Entity(
     signature = signature,
     location = location,
 )
 
-fun createLocation(
+fun createIssueLocation(
     path: String = "TestFile.kt",
     position: Pair<Int, Int> = 1 to 1,
     endPosition: Pair<Int, Int> = 1 to 1,

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestFactory.kt
@@ -1,13 +1,31 @@
 package dev.detekt.api.testfixtures
 
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
 import dev.detekt.api.Issue
+import dev.detekt.api.Location
 import dev.detekt.api.RuleInstance
 import dev.detekt.api.RuleSet
 import dev.detekt.api.Severity
 import dev.detekt.api.SourceLocation
 import dev.detekt.api.TextLocation
+import dev.detekt.test.utils.internal.FakeKtElement
+import org.jetbrains.kotlin.psi.KtElement
 import java.net.URI
+import java.nio.file.Path
 import kotlin.io.path.Path
+
+fun createFinding(
+    entity: Entity = createEntity(),
+    message: String = "TestMessage",
+    references: List<Entity> = emptyList(),
+    suppressReasons: List<String> = emptyList(),
+) = Finding(
+    entity = entity,
+    message = message,
+    references = references,
+    suppressReasons = suppressReasons.toList(),
+)
 
 fun createIssue(
     ruleId: String = "TestSmell/id",
@@ -68,6 +86,28 @@ fun createRuleInstance(
     description = description,
     severity = severity,
     active = active,
+)
+
+fun createEntity(
+    location: Location = createLocation(),
+    signature: String = "TestEntitySignature",
+    ktElement: KtElement = FakeKtElement()
+): Entity = Entity(
+    signature = signature,
+    location = location,
+    ktElement = ktElement,
+)
+
+fun createLocation(
+    source: Pair<Int, Int> = 1 to 1,
+    endSource: Pair<Int, Int> = 1 to 1,
+    text: IntRange = 0..0,
+    path: Path = Path("TestFile.kt"),
+): Location = Location(
+    source = SourceLocation(source.first, source.second),
+    endSource = SourceLocation(endSource.first, endSource.second),
+    text = TextLocation(text.first, text.last),
+    path = path,
 )
 
 fun createIssueEntity(

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -1,8 +1,8 @@
 package dev.detekt.core.baseline
 
 import dev.detekt.api.testfixtures.TestSetupContext
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.test.utils.createTempDirectoryForTest
 import dev.detekt.test.utils.resourceAsPath
@@ -21,19 +21,19 @@ class BaselineResultMappingSpec {
     private val issues = listOf(
         createIssue(
             ruleInstance = createRuleInstance("SomeIssue", "RuleSet"),
-            entity = createEntity(signature = "SomeSignature"),
+            entity = createIssueEntity(signature = "SomeSignature"),
         ),
         createIssue(
             ruleId = "LongParameterList",
-            entity = createEntity(signature = "Signature")
+            entity = createIssueEntity(signature = "Signature")
         ),
         createIssue(
             ruleId = "LongMethod",
-            entity = createEntity(signature = "Signature")
+            entity = createIssueEntity(signature = "Signature")
         ),
         createIssue(
             ruleId = "FeatureEnvy",
-            entity = createEntity(signature = "Signature")
+            entity = createIssueEntity(signature = "Signature")
         ),
     )
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
@@ -27,7 +27,7 @@ class OutputFacadeSpec {
             issues = listOf(
                 createIssue(
                     createRuleInstance(ruleSetId = "Key"),
-                    createIssueEntity(location = createIssueLocation("TestFile.kt"))
+                    createIssueEntity(createIssueLocation("TestFile.kt"))
                 )
             ),
             rules = emptyList(),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
@@ -2,7 +2,7 @@ package dev.detekt.core.reporting
 
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createIssueEntity
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.core.DetektResult
 import dev.detekt.core.createNullLoggingSpec
@@ -27,7 +27,7 @@ class OutputFacadeSpec {
             issues = listOf(
                 createIssue(
                     createRuleInstance(ruleSetId = "Key"),
-                    createIssueEntity(location = createLocation("TestFile.kt"))
+                    createIssueEntity(location = createIssueLocation("TestFile.kt"))
                 )
             ),
             rules = emptyList(),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
@@ -1,7 +1,7 @@
 package dev.detekt.core.reporting
 
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.core.DetektResult
@@ -27,7 +27,7 @@ class OutputFacadeSpec {
             issues = listOf(
                 createIssue(
                     createRuleInstance(ruleSetId = "Key"),
-                    createEntity(location = createLocation("TestFile.kt"))
+                    createIssueEntity(location = createLocation("TestFile.kt"))
                 )
             ),
             rules = emptyList(),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/FileBasedIssuesReportSpec.kt
@@ -3,7 +3,7 @@ package dev.detekt.core.reporting.console
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.core.reporting.SuppressedIssueAssert
 import dev.detekt.core.reporting.decolorized
@@ -18,8 +18,8 @@ class FileBasedIssuesReportSpec {
 
     @Test
     fun `has the reference content`() {
-        val location1 = createLocation("File1.kt")
-        val location2 = createLocation("File2.kt")
+        val location1 = createIssueLocation("File1.kt")
+        val location2 = createIssueLocation("File2.kt")
         val detektion = TestDetektion(
             createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location1),
             createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location2),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/IssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/IssuesReportSpec.kt
@@ -3,7 +3,7 @@ package dev.detekt.core.reporting.console
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.core.reporting.SuppressedIssueAssert
 import dev.detekt.core.reporting.decolorized
@@ -18,7 +18,7 @@ class IssuesReportSpec {
 
     @Test
     fun `has the reference content`() {
-        val location = createLocation()
+        val location = createIssueLocation()
         val detektion = TestDetektion(
             createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location),
             createIssue(createRuleInstance(ruleSetId = "Ruleset1"), location),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/LiteIssuesReportSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/LiteIssuesReportSpec.kt
@@ -3,7 +3,7 @@ package dev.detekt.core.reporting.console
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.core.reporting.SuppressedIssueAssert
 import org.assertj.core.api.Assertions.assertThat
@@ -17,7 +17,7 @@ class LiteIssuesReportSpec {
 
     @Test
     fun `reports non-empty issues`() {
-        val location = createLocation()
+        val location = createIssueLocation()
         val detektion = TestDetektion(
             createIssue(createRuleInstance("SpacingAfterPackageDeclaration/id"), location),
             createIssue(createRuleInstance("UnnecessarySafeCall"), location),

--- a/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
@@ -6,8 +6,8 @@ import dev.detekt.api.ProjectMetric
 import dev.detekt.api.internal.whichDetekt
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.metrics.CognitiveComplexity
@@ -157,13 +157,13 @@ class HtmlOutputReportSpec {
 }
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
-    val entity1 = createEntity(
+    val entity1 = createIssueEntity(
         location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 1, text = 10..14),
     )
-    val entity2 = createEntity(
+    val entity2 = createIssueEntity(
         location = createLocation("src/main/com/sample/Sample2.kt", position = 22 to 2, text = 10..14),
     )
-    val entity3 = createEntity(
+    val entity3 = createIssueEntity(
         location = createLocation("src/main/com/sample/Sample3.kt", position = 33 to 3, text = 10..14),
     )
 
@@ -193,10 +193,10 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
 }
 
 private fun issues(): Array<Issue> {
-    val entity1 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
@@ -193,10 +193,10 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
 }
 
 private fun issues(): Array<Issue> {
-    val entity1 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
@@ -8,7 +8,7 @@ import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createIssueEntity
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.metrics.CognitiveComplexity
 import dev.detekt.metrics.processors.commentLinesKey
@@ -158,13 +158,13 @@ class HtmlOutputReportSpec {
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = createIssueEntity(
-        location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 1, text = 10..14),
+        location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 1, text = 10..14),
     )
     val entity2 = createIssueEntity(
-        location = createLocation("src/main/com/sample/Sample2.kt", position = 22 to 2, text = 10..14),
+        location = createIssueLocation("src/main/com/sample/Sample2.kt", position = 22 to 2, text = 10..14),
     )
     val entity3 = createIssueEntity(
-        location = createLocation("src/main/com/sample/Sample3.kt", position = 33 to 3, text = 10..14),
+        location = createIssueLocation("src/main/com/sample/Sample3.kt", position = 33 to 3, text = 10..14),
     )
 
     return TestDetektion(
@@ -193,10 +193,10 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
 }
 
 private fun issues(): Array<Issue> {
-    val entity1 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createIssueEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
@@ -6,8 +6,8 @@ import dev.detekt.api.ProjectMetric
 import dev.detekt.api.internal.whichDetekt
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.metrics.CognitiveComplexity
@@ -196,13 +196,13 @@ class MdOutputReportSpec {
 }
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
-    val entity1 = createEntity(
+    val entity1 = createIssueEntity(
         location = createLocation(path = "src/main/com/sample/Sample1.kt", position = 9 to 17, text = 17..20),
     )
-    val entity2 = createEntity(
+    val entity2 = createIssueEntity(
         location = createLocation(path = "src/main/com/sample/Sample2.kt", position = 13 to 17),
     )
-    val entity3 = createEntity(
+    val entity3 = createIssueEntity(
         location = createLocation(path = "src/main/com/sample/Sample3.kt", position = 14 to 16),
     )
 
@@ -245,10 +245,10 @@ private fun createMdDetektion(vararg issues: Issue): Detektion =
     )
 
 private fun issues(): Array<Issue> {
-    val entity1 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
@@ -8,7 +8,7 @@ import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createIssueEntity
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.metrics.CognitiveComplexity
 import dev.detekt.metrics.processors.commentLinesKey
@@ -197,13 +197,13 @@ class MdOutputReportSpec {
 
 private fun createTestDetektionWithMultipleSmells(): Detektion {
     val entity1 = createIssueEntity(
-        location = createLocation(path = "src/main/com/sample/Sample1.kt", position = 9 to 17, text = 17..20),
+        location = createIssueLocation(path = "src/main/com/sample/Sample1.kt", position = 9 to 17, text = 17..20),
     )
     val entity2 = createIssueEntity(
-        location = createLocation(path = "src/main/com/sample/Sample2.kt", position = 13 to 17),
+        location = createIssueLocation(path = "src/main/com/sample/Sample2.kt", position = 13 to 17),
     )
     val entity3 = createIssueEntity(
-        location = createLocation(path = "src/main/com/sample/Sample3.kt", position = 14 to 16),
+        location = createIssueLocation(path = "src/main/com/sample/Sample3.kt", position = 14 to 16),
     )
 
     return createMdDetektion(
@@ -245,10 +245,10 @@ private fun createMdDetektion(vararg issues: Issue): Detektion =
     )
 
 private fun issues(): Array<Issue> {
-    val entity1 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createIssueEntity(location = createLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createIssueEntity(location = createLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
@@ -245,10 +245,10 @@ private fun createMdDetektion(vararg issues: Issue): Detektion =
     )
 
 private fun issues(): Array<Issue> {
-    val entity1 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
-    val entity2 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
-    val entity3 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
-    val entity4 = createIssueEntity(location = createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
+    val entity1 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))
+    val entity2 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 22 to 2))
+    val entity3 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 2))
+    val entity4 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample2.kt", position = 1 to 1))
 
     return arrayOf(
         createIssue(createRuleInstance("rule_a", "RuleSet1"), entity1),

--- a/detekt-report-sarif/src/test/kotlin/dev/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/dev/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createIssueEntity
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.test.utils.readResourceContent
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +23,7 @@ class SarifOutputReportSpec {
                 ruleInstance = createRuleInstance("TestSmellA/id", "RuleSet1"),
                 entity = createIssueEntity(
                     signature = "one",
-                    location = createLocation(position = 1 to 1, endPosition = 2 to 3),
+                    location = createIssueLocation(position = 1 to 1, endPosition = 2 to 3),
                 ),
                 severity = Severity.Error
             ),
@@ -31,7 +31,7 @@ class SarifOutputReportSpec {
                 ruleInstance = createRuleInstance("TestSmellD/id", "RuleSet1"),
                 entity = createIssueEntity(
                     signature = "two",
-                    location = createLocation(position = 1 to 1, endPosition = 2 to 3),
+                    location = createIssueLocation(position = 1 to 1, endPosition = 2 to 3),
                 ),
                 severity = Severity.Error,
                 suppressReasons = listOf("suppress")
@@ -40,7 +40,7 @@ class SarifOutputReportSpec {
                 ruleInstance = createRuleInstance("TestSmellB/id", "RuleSet2"),
                 entity = createIssueEntity(
                     signature = "three",
-                    location = createLocation(position = 3 to 5, endPosition = 3 to 5),
+                    location = createIssueLocation(position = 3 to 5, endPosition = 3 to 5),
                 ),
                 severity = Severity.Warning
             ),
@@ -48,7 +48,7 @@ class SarifOutputReportSpec {
                 ruleInstance = createRuleInstance("TestSmellC/id", "RuleSet2"),
                 entity = createIssueEntity(
                     signature = "four",
-                    location = createLocation(position = 2 to 1, endPosition = 3 to 1),
+                    location = createIssueLocation(position = 2 to 1, endPosition = 3 to 1),
                 ),
                 severity = Severity.Info
             ),

--- a/detekt-report-sarif/src/test/kotlin/dev/detekt/report/sarif/SarifOutputReportSpec.kt
+++ b/detekt-report-sarif/src/test/kotlin/dev/detekt/report/sarif/SarifOutputReportSpec.kt
@@ -5,8 +5,8 @@ import dev.detekt.api.RuleSet
 import dev.detekt.api.Severity
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.TestSetupContext
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createLocation
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.test.utils.readResourceContent
@@ -21,7 +21,7 @@ class SarifOutputReportSpec {
         val result = TestDetektion(
             createIssue(
                 ruleInstance = createRuleInstance("TestSmellA/id", "RuleSet1"),
-                entity = createEntity(
+                entity = createIssueEntity(
                     signature = "one",
                     location = createLocation(position = 1 to 1, endPosition = 2 to 3),
                 ),
@@ -29,7 +29,7 @@ class SarifOutputReportSpec {
             ),
             createIssue(
                 ruleInstance = createRuleInstance("TestSmellD/id", "RuleSet1"),
-                entity = createEntity(
+                entity = createIssueEntity(
                     signature = "two",
                     location = createLocation(position = 1 to 1, endPosition = 2 to 3),
                 ),
@@ -38,7 +38,7 @@ class SarifOutputReportSpec {
             ),
             createIssue(
                 ruleInstance = createRuleInstance("TestSmellB/id", "RuleSet2"),
-                entity = createEntity(
+                entity = createIssueEntity(
                     signature = "three",
                     location = createLocation(position = 3 to 5, endPosition = 3 to 5),
                 ),
@@ -46,7 +46,7 @@ class SarifOutputReportSpec {
             ),
             createIssue(
                 ruleInstance = createRuleInstance("TestSmellC/id", "RuleSet2"),
-                entity = createEntity(
+                entity = createIssueEntity(
                     signature = "four",
                     location = createLocation(position = 2 to 1, endPosition = 3 to 1),
                 ),

--- a/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
@@ -2,8 +2,8 @@ package dev.detekt.report.xml
 
 import dev.detekt.api.Severity
 import dev.detekt.api.testfixtures.TestDetektion
-import dev.detekt.api.testfixtures.createEntity
 import dev.detekt.api.testfixtures.createIssue
+import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createLocation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
@@ -16,14 +16,14 @@ private const val TAB = "\t"
 
 class XmlOutputReportSpec {
 
-    private val entity1 = createEntity(
+    private val entity1 = createIssueEntity(
         "Sample1",
         createLocation(
             path = "src/main/com/sample/Sample1.kt",
             position = 11 to 1,
         ),
     )
-    private val entity2 = createEntity(
+    private val entity2 = createIssueEntity(
         "Sample2",
         createLocation(
             path = "src/main/com/sample/Sample2.kt",

--- a/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
@@ -4,7 +4,7 @@ import dev.detekt.api.Severity
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createIssueEntity
-import dev.detekt.api.testfixtures.createLocation
+import dev.detekt.api.testfixtures.createIssueLocation
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -18,14 +18,14 @@ class XmlOutputReportSpec {
 
     private val entity1 = createIssueEntity(
         "Sample1",
-        createLocation(
+        createIssueLocation(
             path = "src/main/com/sample/Sample1.kt",
             position = 11 to 1,
         ),
     )
     private val entity2 = createIssueEntity(
         "Sample2",
-        createLocation(
+        createIssueLocation(
             path = "src/main/com/sample/Sample2.kt",
             position = 22 to 2,
         ),

--- a/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
+++ b/detekt-report-xml/src/test/kotlin/dev/detekt/report/xml/XmlOutputReportSpec.kt
@@ -17,15 +17,15 @@ private const val TAB = "\t"
 class XmlOutputReportSpec {
 
     private val entity1 = createIssueEntity(
-        "Sample1",
-        createIssueLocation(
+        signature = "Sample1",
+        location = createIssueLocation(
             path = "src/main/com/sample/Sample1.kt",
             position = 11 to 1,
         ),
     )
     private val entity2 = createIssueEntity(
-        "Sample2",
-        createIssueLocation(
+        signature = "Sample2",
+        location = createIssueLocation(
             path = "src/main/com/sample/Sample2.kt",
             position = 22 to 2,
         ),


### PR DESCRIPTION
Rename some functions in the test fixtures of `:detekt-api` so I can create `createFinding`. This function is added in this PR without any use, the next PR will start using it to test `FindingAssert`.