### PR TITLE
Improve error messages of `hasXXSourceLocation`

### DIFF
--- a/detekt-test-assertj/src/main/kotlin/dev/detekt/test/assertj/FindingsAssertions.kt
+++ b/detekt-test-assertj/src/main/kotlin/dev/detekt/test/assertj/FindingsAssertions.kt
@@ -58,6 +58,7 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
         val actual = actual.location.source
         if (actual != expected) {
             val code = this.actual.entity.ktElement.containingFile.text
+            assertSourceLocationInRange(code, expected)
             throw failureWithActualExpected(
                 code.addPinAt(actual),
                 code.addPinAt(expected),
@@ -74,6 +75,7 @@ class FindingAssert(val actual: Finding?) : AbstractAssert<FindingAssert, Findin
         val actual = actual.location.endSource
         if (actual != expected) {
             val code = this.actual.entity.ktElement.containingFile.text
+            assertSourceLocationInRange(code, expected)
             throw failureWithActualExpected(
                 code.addPinAt(actual),
                 code.addPinAt(expected),
@@ -118,3 +120,18 @@ private fun String.addPinAt(sourceLocation: SourceLocation): String = lines().to
     val line = this[sourceLocation.line - 1]
     this[sourceLocation.line - 1] = line.replaceRange(sourceLocation.column - 1, sourceLocation.column - 1, "📍")
 }.joinToString("\n")
+
+@Suppress("NOTHING_TO_INLINE") // avoid noise in the Stacktrace
+private inline fun assertSourceLocationInRange(code: String, sourceLocation: SourceLocation) {
+    val lines = code.lines()
+    if (sourceLocation.line - 1 >= lines.count()) {
+        throw IndexOutOfBoundsException(
+            "The line ${sourceLocation.line} doesn't exist in the file. The file has ${lines.count()} lines"
+        )
+    }
+    if (sourceLocation.column - 1 > lines[sourceLocation.line - 1].count()) {
+        throw IndexOutOfBoundsException(
+            "The column ${sourceLocation.column} doesn't exist in the line ${sourceLocation.line}. The line has ${lines[sourceLocation.line - 1].count() + 1} columns"
+        )
+    }
+}

--- a/detekt-test-assertj/src/test/kotlin/dev/detekt/test/assertj/FindingAssertSpec.kt
+++ b/detekt-test-assertj/src/test/kotlin/dev/detekt/test/assertj/FindingAssertSpec.kt
@@ -177,6 +177,32 @@ class FindingAssertSpec {
                         """.trimIndent()
                     )
             }
+
+            @Test
+            fun `hasStartSourceLocation failing when expected line doesn't even exist`() {
+                assertThatThrownBy { FindingAssert(finding).hasStartSourceLocation(SourceLocation(20, 1)) }
+                    .isInstanceOf(IndexOutOfBoundsException::class.java)
+                    .hasMessage("The line 20 doesn't exist in the file. The file has 7 lines")
+            }
+
+            @Test
+            fun `hasStartSourceLocationInt failing when expected column doesn't even exist`() {
+                assertThatThrownBy { FindingAssert(finding).hasStartSourceLocation(1, 20) }
+                    .isInstanceOf(IndexOutOfBoundsException::class.java)
+                    .hasMessage("The column 20 doesn't exist in the line 1. The line has 13 columns")
+            }
+
+            @Test
+            fun `hasStartSourceLocation failing when expected line is the last one`() {
+                assertThatThrownBy { FindingAssert(finding).hasStartSourceLocation(SourceLocation(7, 1)) }
+                    .isInstanceOf(AssertionError::class.java)
+            }
+
+            @Test
+            fun `hasStartSourceLocationInt failing when expected column is the last one`() {
+                assertThatThrownBy { FindingAssert(finding).hasStartSourceLocation(1, 13) }
+                    .isInstanceOf(AssertionError::class.java)
+            }
         }
 
         @Nested
@@ -261,6 +287,32 @@ class FindingAssertSpec {
                             }
                         """.trimIndent()
                     )
+            }
+
+            @Test
+            fun `hasEndSourceLocation failing when expected line doesn't even exist`() {
+                assertThatThrownBy { FindingAssert(finding).hasEndSourceLocation(SourceLocation(20, 1)) }
+                    .isInstanceOf(IndexOutOfBoundsException::class.java)
+                    .hasMessage("The line 20 doesn't exist in the file. The file has 7 lines")
+            }
+
+            @Test
+            fun `hasEndSourceLocationInt failing when expected column doesn't even exist`() {
+                assertThatThrownBy { FindingAssert(finding).hasEndSourceLocation(1, 20) }
+                    .isInstanceOf(IndexOutOfBoundsException::class.java)
+                    .hasMessage("The column 20 doesn't exist in the line 1. The line has 13 columns")
+            }
+
+            @Test
+            fun `hasEndSourceLocation failing when expected line is the last one`() {
+                assertThatThrownBy { FindingAssert(finding).hasEndSourceLocation(SourceLocation(7, 1)) }
+                    .isInstanceOf(AssertionError::class.java)
+            }
+
+            @Test
+            fun `hasEndSourceLocationInt failing when expected column is the last one`() {
+                assertThatThrownBy { FindingAssert(finding).hasEndSourceLocation(1, 13) }
+                    .isInstanceOf(AssertionError::class.java)
             }
         }
     }


### PR DESCRIPTION
Given this test:

```kotlin
@Test
fun `finds two functions in class`() {
    val code = """
        class A {
            fun a() = Unit
            fun b() = Unit
        }
    """.trimIndent()

    val findings = rule.lint(code)
    assertThat(findings).singleElement()
        .hasStartSourceLocation(2, 9)
}
```

Before:
```
[Findings check single element] Expected start source location to be 2:9 but was 1:7
Expected :2:9
Actual   :1:7
<Click to see difference>
```
<img width="919" height="370" alt="Captura de pantalla 2025-08-22 a las 11 09 53" src="https://github.com/user-attachments/assets/59a77d78-7748-43aa-87e2-e79024f2ddbe" />


After:
```
[Findings check single element] Expected start source location to be 2:9 but was 1:7
<Click to see difference>
```
<img width="919" height="439" alt="Captura de pantalla 2025-08-22 a las 11 09 07" src="https://github.com/user-attachments/assets/d0833afb-9490-42b5-8abf-8424db6bae93" />


This improvement is basically for the IDE integration. There is not change in the console output or JUnit report. The `Expected :...` and `Actual :...` are added by IntelliJ.

I'm not sure if the emoji is the best option as a marker but I can't think of any better option. Any suggestion is more than welcome.

Blocked by:
- #8514
- #8515