### PR TITLE
Do not put default into the yaml file when it is dynamic.

### DIFF
--- a/detekt-api/src/test/kotlin/dev/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/dev/detekt/api/ConfigPropertySpec.kt
@@ -6,6 +6,10 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.tuple
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.argumentSet
+import org.junit.jupiter.params.provider.MethodSource
 import java.util.concurrent.atomic.AtomicInteger
 
 class ConfigPropertySpec {
@@ -544,6 +548,61 @@ class ConfigPropertySpec {
             }
         }
     }
+
+    @Nested
+    inner class `With android variant` {
+
+        private val androidRulesetConfig = TestConfig("android" to true)
+        private val nonAndroidRulesetConfig = TestConfig("android" to false)
+        private val androidUndefinedRulesetConfig = TestConfig()
+
+        @Test
+        fun `uses default if android property of ruleset is not defined`() {
+            val subject = object : AndroidTestRule(androidUndefinedRulesetConfig) {
+                val configValue: String by configWithAndroidVariants("default", "android")
+            }
+
+            assertThat(subject.configValue).isEqualTo("default")
+        }
+
+        @Test
+        fun `uses default if ruleset is non android`() {
+            val subject = object : AndroidTestRule(nonAndroidRulesetConfig) {
+                val configValue: String by configWithAndroidVariants("default", "android")
+            }
+
+            assertThat(subject.configValue).isEqualTo("default")
+        }
+
+        @Test
+        fun `uses android default if ruleset is android`() {
+            val subject = object : AndroidTestRule(androidRulesetConfig) {
+                val configValue: String by configWithAndroidVariants("default", "android")
+            }
+
+            assertThat(subject.configValue).isEqualTo("android")
+        }
+
+        @ParameterizedTest
+        @MethodSource("rulesetConfigs")
+        fun `always uses explicitly defined value from config`(rulesetConfig: Config) {
+            val explicitlyConfiguredValue = "other"
+            val subject = object : AndroidTestRule(rulesetConfig, "configValue" to explicitlyConfiguredValue) {
+                val configValue: String by configWithAndroidVariants("default", "android")
+            }
+
+            assertThat(subject.configValue).isEqualTo(explicitlyConfiguredValue)
+        }
+
+        fun rulesetConfigs(): List<Arguments.ArgumentSet> = listOf(
+            argumentSet("ruleset has android = true", androidRulesetConfig),
+            argumentSet("ruleset has android = false", nonAndroidRulesetConfig),
+            argumentSet("ruleset has no value for android property", androidUndefinedRulesetConfig)
+        )
+
+        private open inner class AndroidTestRule(rulesetConfig: Config, vararg ruleConfig: Pair<String, Any>) :
+            Rule(TestConfig(parent = rulesetConfig, *ruleConfig), "description")
+    }
 }
 
-open class TestRule(vararg data: Pair<String, Any>) : Rule(TestConfig(*data), "description")
+private open class TestRule(vararg data: Pair<String, Any>) : Rule(TestConfig(*data), "description")

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -13,14 +13,12 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
     ignoreRuleParameterThreshold: 8
   BackingPropertyNaming:
     active: true
   BinaryExpressionWrapping:
     active: true
     autoCorrect: true
-    maxLineLength: 120
     indentSize: 4
   BlankLineBeforeDeclaration:
     active: true
@@ -36,7 +34,6 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
     forceMultilineWhenChainOperatorCountGreaterOrEqualThan: 4
   ChainWrapping:
     active: true
@@ -48,7 +45,6 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
   CommentSpacing:
     active: true
     autoCorrect: true
@@ -63,12 +59,10 @@ formatting:
   ContextReceiverListWrapping:
     active: true
     autoCorrect: true
-    maxLineLength: 120
     indentSize: 4
   ContextReceiverMapping:
     active: true
     autoCorrect: true
-    maxLineLength: 120
     indentSize: 4
   EnumEntryNameCase:
     active: true
@@ -96,24 +90,20 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
   FunctionLiteral:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
   FunctionName:
     active: false
   FunctionReturnTypeSpacing:
     active: true
     autoCorrect: true
-    maxLineLength: 120
   FunctionSignature:
     active: true
     autoCorrect: true
     forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
     functionBodyExpressionWrapping: 'default'
-    maxLineLength: 120
     indentSize: 4
   FunctionStartOfBodySpacing:
     active: true
@@ -135,7 +125,6 @@ formatting:
   ImportOrdering:
     active: true
     autoCorrect: true
-    layout: '*,java.**,javax.**,kotlin.**,^'
   Indentation:
     active: true
     autoCorrect: true
@@ -150,7 +139,6 @@ formatting:
   MaximumLineLength:
     active: true
     aliases: ['MaxLineLength']
-    maxLineLength: 120
     ignoreBackTickedIdentifier: false
   MixedConditionOperators:
     active: false
@@ -236,17 +224,14 @@ formatting:
   ParameterListSpacing:
     active: true
     autoCorrect: true
-    maxLineLength: 120
   ParameterListWrapping:
     active: true
     autoCorrect: true
-    maxLineLength: 120
     indentSize: 4
   ParameterWrapping:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
   PropertyName:
     active: true
     constantNamingStyle: 'screaming_snake_case'
@@ -254,7 +239,6 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120
   SpacingAroundAngleBrackets:
     active: true
     autoCorrect: true
@@ -315,11 +299,9 @@ formatting:
   TrailingCommaOnCallSite:
     active: true
     autoCorrect: true
-    useTrailingCommaOnCallSite: true
   TrailingCommaOnDeclarationSite:
     active: true
     autoCorrect: true
-    useTrailingCommaOnDeclarationSite: true
   TryCatchFinallySpacing:
     active: true
     autoCorrect: true
@@ -351,4 +333,3 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
-    maxLineLength: 120

--- a/detekt-formatting/src/main/resources/config/config.yml
+++ b/detekt-formatting/src/main/resources/config/config.yml
@@ -13,12 +13,14 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     ignoreRuleParameterThreshold: 8
   BackingPropertyNaming:
     active: true
   BinaryExpressionWrapping:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     indentSize: 4
   BlankLineBeforeDeclaration:
     active: true
@@ -34,6 +36,7 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     forceMultilineWhenChainOperatorCountGreaterOrEqualThan: 4
   ChainWrapping:
     active: true
@@ -45,6 +48,7 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   CommentSpacing:
     active: true
     autoCorrect: true
@@ -59,10 +63,12 @@ formatting:
   ContextReceiverListWrapping:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     indentSize: 4
   ContextReceiverMapping:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     indentSize: 4
   EnumEntryNameCase:
     active: true
@@ -90,20 +96,24 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   FunctionLiteral:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   FunctionName:
     active: false
   FunctionReturnTypeSpacing:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   FunctionSignature:
     active: true
     autoCorrect: true
     forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
     functionBodyExpressionWrapping: 'default'
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     indentSize: 4
   FunctionStartOfBodySpacing:
     active: true
@@ -125,6 +135,7 @@ formatting:
   ImportOrdering:
     active: true
     autoCorrect: true
+    # layout: If the 'android' ruleset property is set to true, the default is '*', otherwise '*,java.**,javax.**,kotlin.**,^'.
   Indentation:
     active: true
     autoCorrect: true
@@ -139,6 +150,7 @@ formatting:
   MaximumLineLength:
     active: true
     aliases: ['MaxLineLength']
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     ignoreBackTickedIdentifier: false
   MixedConditionOperators:
     active: false
@@ -224,14 +236,17 @@ formatting:
   ParameterListSpacing:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   ParameterListWrapping:
     active: true
     autoCorrect: true
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
     indentSize: 4
   ParameterWrapping:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   PropertyName:
     active: true
     constantNamingStyle: 'screaming_snake_case'
@@ -239,6 +254,7 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
   SpacingAroundAngleBrackets:
     active: true
     autoCorrect: true
@@ -299,9 +315,11 @@ formatting:
   TrailingCommaOnCallSite:
     active: true
     autoCorrect: true
+    # useTrailingCommaOnCallSite: If the 'android' ruleset property is set to true, the default is 'false', otherwise 'true'.
   TrailingCommaOnDeclarationSite:
     active: true
     autoCorrect: true
+    # useTrailingCommaOnDeclarationSite: If the 'android' ruleset property is set to true, the default is 'false', otherwise 'true'.
   TryCatchFinallySpacing:
     active: true
     autoCorrect: true
@@ -333,3 +351,4 @@ formatting:
     active: true
     autoCorrect: true
     indentSize: 4
+    # maxLineLength: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
@@ -51,5 +51,11 @@ internal fun YamlNode.printRule(rule: Rule) {
 internal fun YamlNode.printConfiguration(configuration: Configuration) {
     if (configuration.isDeprecated()) return
 
-    configuration.defaultValue.printAsYaml(configuration.name, this)
+    // Whenever there are dynamic default, we must not put the value into the yaml file.
+    val hasStaticDefaultValue = configuration.defaultAndroidValue == null ||
+        configuration.defaultValue == configuration.defaultAndroidValue
+
+    if (hasStaticDefaultValue) {
+        configuration.defaultValue.printAsYaml(configuration.name, this)
+    }
 }

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
@@ -6,6 +6,7 @@ import dev.detekt.generator.collection.Rule
 import dev.detekt.generator.collection.RuleSetPage
 import dev.detekt.generator.collection.RuleSetProvider
 import dev.detekt.utils.YamlNode
+import dev.detekt.utils.comment
 import dev.detekt.utils.keyValue
 import dev.detekt.utils.node
 
@@ -51,11 +52,16 @@ internal fun YamlNode.printRule(rule: Rule) {
 internal fun YamlNode.printConfiguration(configuration: Configuration) {
     if (configuration.isDeprecated()) return
 
-    // Whenever there are dynamic default, we must not put the value into the yaml file.
-    val hasStaticDefaultValue = configuration.defaultAndroidValue == null ||
-        configuration.defaultValue == configuration.defaultAndroidValue
+    val hasDeviatingAndroidDefault = configuration.defaultAndroidValue != null &&
+        configuration.defaultValue != configuration.defaultAndroidValue
 
-    if (hasStaticDefaultValue) {
+    if (hasDeviatingAndroidDefault) {
+        val description =
+            "If the 'android' ruleset property is set to true, " +
+                "the default is '${configuration.defaultAndroidValue.getPlainValue()}', " +
+                "otherwise '${configuration.defaultValue.getPlainValue()}'."
+        comment("${configuration.name}: $description")
+    } else {
         configuration.defaultValue.printAsYaml(configuration.name, this)
     }
 }

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
@@ -29,7 +29,6 @@ class ConfigPrinterSpec {
                 conf3:
                   - 'a'
                   - 'b'
-                conf5: 120
               EqualsNull:
                 active: false
               NoUnitKeyword:

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
@@ -29,6 +29,7 @@ class ConfigPrinterSpec {
                 conf3:
                   - 'a'
                   - 'b'
+                # conf5: If the 'android' ruleset property is set to true, the default is '100', otherwise '120'.
               EqualsNull:
                 active: false
               NoUnitKeyword:

--- a/detekt-utils/src/main/kotlin/dev/detekt/utils/Yaml.kt
+++ b/detekt-utils/src/main/kotlin/dev/detekt/utils/Yaml.kt
@@ -39,6 +39,10 @@ inline fun YamlNode.keyValue(comment: String = "", keyValue: () -> Pair<String, 
     }
 }
 
+fun YamlNode.comment(comment: String = "") {
+    append("# $comment")
+}
+
 fun YamlNode.list(name: String, list: List<String>) {
     if (list.isEmpty()) {
         keyValue { name to EMPTY_LIST }
@@ -84,6 +88,7 @@ private fun String.ensureQuoted(): String =
             endsWith(SINGLE_QUOTE) ||
             startsWith(DOUBLE_QUOTE) &&
             endsWith(DOUBLE_QUOTE) -> this
+
         else -> quoted()
     }
 


### PR DESCRIPTION
This fixes #7972 

I guess this is not so obvious, why this fixes the issue. 

**Current behavior** with `--build-upon-default-config`

When calculating the value for `ArgumentListWrapping.maxLineLength`, we correctly determine if the android configuration should be used or not and the correct value is chosen. But because there is a default value in the (default) yaml file, that value is always preferred over the one that was calculated. 

```kotlin
       // ConfigProperty:104-106
        val isAndroid = getValueOrDefault(rulesetConfig, "android", false)
        val value = if (isAndroid) defaultAndroidValue else defaultValue
        return transform(getValueOrDefault(thisRef.config, property.name, value))
```

By not putting a default value into the generated default yaml files when there are multiple options, the correct default value is calculated, depending on the `android` setting of the rule set.

**How to test?**
If this is the solution, we can agree on, I will try to create a test. In the meantime, please verify the behavior by:
* run ` ./gradlew :detekt-cli:runWithArgsFile` . There should be no issues
* add `android: true` to the formatting rule set configuration in `config/detekt/detekt.yml`
* run ` ./gradlew :detekt-cli:runWithArgsFile` again. There are now more than 4000 issues due to the different defaults.

Is there anything, that I am missing? Any downside to this solution?