### PR TITLE
`:detekt-test` doesn't need to depend on `:detekt-test-assertj`

### DIFF
--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     api(projects.detektApi)
-    api(projects.detektTestAssertj)
     api(projects.detektTestUtils)
     api(libs.kotlin.compiler)
     implementation(projects.detektKotlinAnalysisApiStandalone)


### PR DESCRIPTION
It was one of the ideas to split these modules.