### PR TITLE
Refactor `Detektion` implementations in core

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/DelegatingResult.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/DelegatingResult.kt
@@ -1,9 +1,0 @@
-package dev.detekt.core
-
-import dev.detekt.api.Detektion
-import dev.detekt.api.Issue
-
-class DelegatingResult(
-    result: Detektion,
-    override val issues: List<Issue>,
-) : Detektion by result

--- a/detekt-core/src/main/kotlin/dev/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/DetektResult.kt
@@ -7,8 +7,7 @@ import dev.detekt.api.Notification
 import dev.detekt.api.ProjectMetric
 import dev.detekt.api.RuleInstance
 
-@Suppress("DataClassShouldBeImmutable")
-data class DetektResult(
+class DetektResult(
     override val issues: List<Issue>,
     override val rules: List<RuleInstance>,
 ) : Detektion, UserDataHolderBase() {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/extensions/Reporting.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/extensions/Reporting.kt
@@ -1,8 +1,8 @@
 package dev.detekt.core.extensions
 
 import dev.detekt.api.Detektion
+import dev.detekt.api.Issue
 import dev.detekt.api.ReportingExtension
-import dev.detekt.core.DelegatingResult
 import dev.detekt.core.ProcessingSettings
 
 fun handleReportingExtensions(settings: ProcessingSettings, initialResult: Detektion): Detektion {
@@ -15,3 +15,8 @@ fun handleReportingExtensions(settings: ProcessingSettings, initialResult: Detek
     extensions.forEach { it.onFinalResult(finalResult) }
     return finalResult
 }
+
+private class DelegatingResult(
+    result: Detektion,
+    override val issues: List<Issue>,
+) : Detektion by result


### PR DESCRIPTION
`DetektResult`. Was a `data class`. But the "data" features were not used. And that was for the better because if someone uses `copy` or `equals` it wouldn't return the expected value.

This also moves `DelegatingResult` to make it an implementation detail inside `extensions/Reporting.kt` because it's the only place where it is used. Probably this class will be removed in the near future but at least not it's clear that its only usage is in that file.

Again I'm trying to refactor `Detektion` in general. But everything there is really messy so I need this type of boy-scout PRs to understand the code better.