### PR TITLE
Detektion doesn't implement `UserDataHolder`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -70,13 +70,14 @@ public class dev/detekt/api/DetektVisitor : org/jetbrains/kotlin/psi/KtTreeVisit
 	public fun <init> ()V
 }
 
-public abstract interface class dev/detekt/api/Detektion : com/intellij/openapi/util/UserDataHolder {
+public abstract interface class dev/detekt/api/Detektion {
 	public abstract fun add (Ldev/detekt/api/Notification;)V
 	public abstract fun add (Ldev/detekt/api/ProjectMetric;)V
 	public abstract fun getIssues ()Ljava/util/List;
 	public abstract fun getMetrics ()Ljava/util/Collection;
 	public abstract fun getNotifications ()Ljava/util/Collection;
 	public abstract fun getRules ()Ljava/util/List;
+	public abstract fun getUserData ()Ljava/util/Map;
 }
 
 public final class dev/detekt/api/Entity {

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
@@ -1,16 +1,15 @@
 package dev.detekt.api
 
-import com.intellij.openapi.util.UserDataHolder
-
 /**
  * Storage for all kinds of findings and additional information
  * which needs to be transferred from the detekt engine to the user.
  */
-interface Detektion : UserDataHolder {
+interface Detektion {
     val issues: List<Issue>
     val rules: List<RuleInstance>
     val notifications: Collection<Notification>
     val metrics: Collection<ProjectMetric>
+    val userData: MutableMap<String, Any>
 
     /**
      * Stores a notification in the result.

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
@@ -1,7 +1,6 @@
 package dev.detekt.api.testfixtures
 
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.UserDataHolderBase
 import dev.detekt.api.Detektion
 import dev.detekt.api.Issue
 import dev.detekt.api.Notification
@@ -13,17 +12,23 @@ class TestDetektion(
     override val rules: List<RuleInstance> = emptyList(),
     metrics: List<ProjectMetric> = emptyList(),
     notifications: List<Notification> = emptyList(),
-) : Detektion, UserDataHolderBase() {
+    userData: Map<String, Any> = emptyMap(),
+) : Detektion {
 
     override val issues: List<Issue> = issues.toList()
     override val metrics: Collection<ProjectMetric> get() = _metrics
     override val notifications: List<Notification> get() = _notifications
+    override val userData: MutableMap<String, Any> = userData.toMutableMap()
 
     private val _metrics = metrics.toMutableList()
     private val _notifications = notifications.toMutableList()
 
     fun <V> removeData(key: Key<V>) {
-        putUserData(key, null)
+        userData.remove(key.toString())
+    }
+
+    fun <V : Any> putUserData(key: Key<V>, value: V) {
+        userData[key.toString()] = value
     }
 
     override fun add(notification: Notification) {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/DetektResult.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/DetektResult.kt
@@ -1,6 +1,5 @@
 package dev.detekt.core
 
-import com.intellij.openapi.util.UserDataHolderBase
 import dev.detekt.api.Detektion
 import dev.detekt.api.Issue
 import dev.detekt.api.Notification
@@ -10,13 +9,15 @@ import dev.detekt.api.RuleInstance
 class DetektResult(
     override val issues: List<Issue>,
     override val rules: List<RuleInstance>,
-) : Detektion, UserDataHolderBase() {
+) : Detektion {
 
     private val _notifications = ArrayList<Notification>()
     override val notifications: Collection<Notification> = _notifications
 
     private val _metrics = ArrayList<ProjectMetric>()
     override val metrics: Collection<ProjectMetric> = _metrics
+
+    override val userData: MutableMap<String, Any> = mutableMapOf()
 
     override fun add(projectMetric: ProjectMetric) {
         _metrics.add(projectMetric)

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -1,9 +1,8 @@
 package dev.detekt.core.reporting.console
 
-import dev.detekt.api.Detektion
+import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createRuleInstance
-import dev.detekt.core.DetektResult
 import dev.detekt.metrics.CognitiveComplexity
 import dev.detekt.metrics.processors.commentLinesKey
 import dev.detekt.metrics.processors.complexityKey
@@ -51,7 +50,4 @@ class ComplexityReportSpec {
     }
 }
 
-private fun createDetektion(): Detektion = DetektResult(
-    issues = listOf(createIssue(createRuleInstance(ruleSetId = "Key"))),
-    rules = emptyList(),
-)
+private fun createDetektion() = TestDetektion(createIssue(createRuleInstance(ruleSetId = "Key")))

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/ComplexityMetric.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/ComplexityMetric.kt
@@ -10,11 +10,11 @@ import dev.detekt.metrics.processors.sourceLinesKey
 
 class ComplexityMetric(detektion: Detektion) {
 
-    val mcc = detektion.getUserData(complexityKey)
-    val cognitiveComplexity = detektion.getUserData(CognitiveComplexity.KEY)
-    val loc = detektion.getUserData(linesKey)
-    val sloc = detektion.getUserData(sourceLinesKey)
-    val lloc = detektion.getUserData(logicalLinesKey)
-    val cloc = detektion.getUserData(commentLinesKey)
+    val mcc = detektion.userData[complexityKey.toString()] as Int?
+    val cognitiveComplexity = detektion.userData[CognitiveComplexity.KEY.toString()] as Int?
+    val loc = detektion.userData[linesKey.toString()] as Int?
+    val sloc = detektion.userData[sourceLinesKey.toString()] as Int?
+    val lloc = detektion.userData[logicalLinesKey.toString()] as Int?
+    val cloc = detektion.userData[commentLinesKey.toString()] as Int?
     val issuesCount = detektion.issues.count { !it.suppressed }
 }

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
@@ -19,6 +19,6 @@ abstract class AbstractProcessor : FileProcessListener {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()
-        result.putUserData(key, count)
+        result.userData[key.toString()] = count
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCLOCProcessorSpec.kt
@@ -16,6 +16,6 @@ class ProjectCLOCProcessorSpec {
             compileContentForTest(complexClass),
         )
 
-        assertThat(detektion.getUserData(commentLinesKey)).isEqualTo(35)
+        assertThat(detektion.userData[commentLinesKey.toString()]).isEqualTo(35)
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCognitiveComplexityProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCognitiveComplexityProcessorSpec.kt
@@ -12,6 +12,6 @@ class ProjectCognitiveComplexityProcessorSpec {
         val detektion = ProjectCognitiveComplexityProcessor()
             .invoke(compileContentForTest(complexClass))
 
-        assertThat(detektion.getUserData(CognitiveComplexity.KEY)).isEqualTo(50)
+        assertThat(detektion.userData[CognitiveComplexity.KEY.toString()]).isEqualTo(50)
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectComplexityProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectComplexityProcessorSpec.kt
@@ -16,6 +16,6 @@ class ProjectComplexityProcessorSpec {
             compileContentForTest(complexClass),
         )
 
-        assertThat(detektion.getUserData(complexityKey)).isEqualTo(45)
+        assertThat(detektion.userData[complexityKey.toString()]).isEqualTo(45)
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLLOCProcessorSpec.kt
@@ -16,6 +16,6 @@ class ProjectLLOCProcessorSpec {
             compileContentForTest(complexClass),
         )
 
-        assertThat(detektion.getUserData(logicalLinesKey)).isEqualTo(102)
+        assertThat(detektion.userData[logicalLinesKey.toString()]).isEqualTo(102)
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLOCProcessorSpec.kt
@@ -16,6 +16,6 @@ class ProjectLOCProcessorSpec {
             compileContentForTest(complexClass),
         )
 
-        assertThat(detektion.getUserData(linesKey)).isEqualTo(190)
+        assertThat(detektion.userData[linesKey.toString()]).isEqualTo(190)
     }
 }

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectSLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectSLOCProcessorSpec.kt
@@ -16,6 +16,6 @@ class ProjectSLOCProcessorSpec {
             compileContentForTest(complexClass),
         )
 
-        assertThat(detektion.getUserData(sourceLinesKey)).isEqualTo(160)
+        assertThat(detektion.userData[sourceLinesKey.toString()]).isEqualTo(160)
     }
 }

--- a/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
@@ -238,11 +238,10 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
     }
 }
 
-private fun createMdDetektion(vararg issues: Issue): Detektion =
-    TestDetektion(
-        *issues,
-        metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2))
-    )
+private fun createMdDetektion(vararg issues: Issue) = TestDetektion(
+    *issues,
+    metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2))
+)
 
 private fun issues(): Array<Issue> {
     val entity1 = createIssueEntity(createIssueLocation("src/main/com/sample/Sample1.kt", position = 11 to 5))

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/internal/EmptyContainer.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/internal/EmptyContainer.kt
@@ -1,6 +1,5 @@
 package dev.detekt.tooling.internal
 
-import com.intellij.openapi.util.Key
 import dev.detekt.api.Detektion
 import dev.detekt.api.Issue
 import dev.detekt.api.Notification
@@ -13,9 +12,8 @@ object EmptyContainer : Detektion {
     override val rules: List<RuleInstance> = emptyList()
     override val notifications: Collection<Notification> = emptyList()
     override val metrics: Collection<ProjectMetric> = emptyList()
+    override val userData: MutableMap<String, Any> = mutableMapOf()
 
-    override fun <V> getUserData(key: Key<V>): V? = throw UnsupportedOperationException()
-    override fun <V> putUserData(key: Key<V>, value: V?) = throw UnsupportedOperationException()
     override fun add(notification: Notification) = throw UnsupportedOperationException()
     override fun add(projectMetric: ProjectMetric) = throw UnsupportedOperationException()
 }


### PR DESCRIPTION
Closes #8381

We need to make `Detektion` serializable. And `UserDataHolder` didn't help with that. For that reason I'm removing it and changing it for a `userData: MutableMap<String, Any?>`.

To be honest, I don't like that we have a mutable class in `:detekt-api`. But `UserDataHolder` was making `Detektion` mutable and it even have two functions `add` that make it mutable too. It would be nice to make `Detektion` immutable but that's a completely different issue that the one that I'm solving here. (I tried for 2 days to solve both at the same time and I failed)

Edit: I created #8561 to track the mutability.