### PR TITLE
Remove `TestDetektion.putUserData`

### DIFF
--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
@@ -27,10 +27,6 @@ class TestDetektion(
         userData.remove(key.toString())
     }
 
-    fun <V : Any> putUserData(key: Key<V>, value: V) {
-        userData[key.toString()] = value
-    }
-
     override fun add(notification: Notification) {
         _notifications.add(notification)
     }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/ComplexityReportSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/console/ComplexityReportSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.core.reporting.console
 
+import com.intellij.openapi.util.Key
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.createIssue
 import dev.detekt.api.testfixtures.createRuleInstance
@@ -11,19 +12,22 @@ import dev.detekt.metrics.processors.logicalLinesKey
 import dev.detekt.metrics.processors.sourceLinesKey
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import kotlin.collections.mapKeys
 
 class ComplexityReportSpec {
 
     @Test
     fun `successfully generates a complexity report`() {
-        val detektion = createDetektion().apply {
-            putUserData(complexityKey, 2)
-            putUserData(CognitiveComplexity.KEY, 2)
-            putUserData(linesKey, 10)
-            putUserData(sourceLinesKey, 6)
-            putUserData(logicalLinesKey, 5)
-            putUserData(commentLinesKey, 4)
-        }
+        val detektion = createDetektion(
+            mapOf(
+                complexityKey to 2,
+                CognitiveComplexity.KEY to 2,
+                linesKey to 10,
+                sourceLinesKey to 6,
+                logicalLinesKey to 5,
+                commentLinesKey to 4,
+            )
+        )
         assertThat(ComplexityReport().render(detektion)).isEqualTo(
             """
                 Complexity Report:
@@ -50,4 +54,9 @@ class ComplexityReportSpec {
     }
 }
 
-private fun createDetektion() = TestDetektion(createIssue(createRuleInstance(ruleSetId = "Key")))
+private fun createDetektion(
+    userData: Map<Key<*>, Any> = emptyMap(),
+) = TestDetektion(
+    createIssue(createRuleInstance(ruleSetId = "Key")),
+    userData = userData.mapKeys { (key, _) -> key.toString() },
+)

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -19,8 +19,18 @@ internal class ComplexityReportGeneratorSpec {
 
     @BeforeEach
     fun setupMocks() {
-        detektion = TestDetektion(createIssue("test"), createIssue("test2", suppressReasons = listOf("suppress")))
-            .withTestData()
+        detektion = TestDetektion(
+            createIssue("test"),
+            createIssue("test2", suppressReasons = listOf("suppress")),
+            userData = mapOf(
+                complexityKey.toString() to 2,
+                CognitiveComplexity.KEY.toString() to 2,
+                linesKey.toString() to 1000,
+                sourceLinesKey.toString() to 6,
+                logicalLinesKey.toString() to 5,
+                commentLinesKey.toString() to 4,
+            )
+        )
     }
 
     @Nested
@@ -59,7 +69,7 @@ internal class ComplexityReportGeneratorSpec {
             detektion.removeData(logicalLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.putUserData(logicalLinesKey, 0)
+            detektion.userData[logicalLinesKey.toString()] = 0
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
@@ -68,7 +78,7 @@ internal class ComplexityReportGeneratorSpec {
             detektion.removeData(sourceLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.putUserData(sourceLinesKey, 0)
+            detektion.userData[sourceLinesKey.toString()] = 0
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
@@ -78,16 +88,6 @@ internal class ComplexityReportGeneratorSpec {
             assertThat(generateComplexityReport(detektion)).isNull()
         }
     }
-}
-
-private fun TestDetektion.withTestData(): TestDetektion {
-    putUserData(complexityKey, 2)
-    putUserData(CognitiveComplexity.KEY, 2)
-    putUserData(linesKey, 1000)
-    putUserData(sourceLinesKey, 6)
-    putUserData(logicalLinesKey, 5)
-    putUserData(commentLinesKey, 4)
-    return this
 }
 
 private fun generateComplexityReport(detektion: Detektion): List<String>? {

--- a/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
+++ b/detekt-report-html/src/test/kotlin/dev/detekt/report/html/HtmlOutputReportSpec.kt
@@ -113,13 +113,16 @@ class HtmlOutputReportSpec {
 
     @Test
     fun `renders the complexity report correctly`() {
-        val detektion = TestDetektion()
-        detektion.putUserData(complexityKey, 10)
-        detektion.putUserData(CognitiveComplexity.KEY, 10)
-        detektion.putUserData(sourceLinesKey, 20)
-        detektion.putUserData(logicalLinesKey, 10)
-        detektion.putUserData(commentLinesKey, 2)
-        detektion.putUserData(linesKey, 2222)
+        val detektion = TestDetektion(
+            userData = mapOf(
+                complexityKey.toString() to 10,
+                CognitiveComplexity.KEY.toString() to 10,
+                sourceLinesKey.toString() to 20,
+                logicalLinesKey.toString() to 10,
+                commentLinesKey.toString() to 2,
+                linesKey.toString() to 2222,
+            )
+        )
         val result = htmlReport.render(detektion)
         assertThat(result).contains("<li>2,222 lines of code (loc)</li>")
         assertThat(result).contains("<li>20 source lines of code (sloc)</li>")

--- a/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
+++ b/detekt-report-md/src/test/kotlin/dev/detekt/report/md/MdOutputReportSpec.kt
@@ -228,19 +228,20 @@ private fun createTestDetektionWithMultipleSmells(): Detektion {
             "Issue message 3",
             suppressReasons = listOf("suppress")
         ),
-    ).also {
-        it.putUserData(complexityKey, 10)
-        it.putUserData(CognitiveComplexity.KEY, 10)
-        it.putUserData(sourceLinesKey, 20)
-        it.putUserData(logicalLinesKey, 10)
-        it.putUserData(commentLinesKey, 2)
-        it.putUserData(linesKey, 2222)
-    }
+    )
 }
 
 private fun createMdDetektion(vararg issues: Issue) = TestDetektion(
     *issues,
-    metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2))
+    metrics = listOf(ProjectMetric("M1", 10_000), ProjectMetric("M2", 2)),
+    userData = mapOf(
+        complexityKey.toString() to 10,
+        CognitiveComplexity.KEY.toString() to 10,
+        sourceLinesKey.toString() to 20,
+        logicalLinesKey.toString() to 10,
+        commentLinesKey.toString() to 2,
+        linesKey.toString() to 2222,
+    )
 )
 
 private fun issues(): Array<Issue> {


### PR DESCRIPTION
I created the function `TestDetektion.putUserData` in #8556. It was only to make the diff smaller but we should reduce the usage of `com.intellij.openapi.util.Key`. This PR removes that temporary function `TestDetektion.putUserData`.