### PR TITLE
Only print paths of reports when detektion fails

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -2,8 +2,6 @@ package dev.detekt.core.reporting
 
 import dev.detekt.api.ConsoleReport
 import dev.detekt.api.Detektion
-import dev.detekt.api.Notification
-import dev.detekt.api.Notification.Level
 import dev.detekt.api.OutputReport
 import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.extensions.loadExtensions
@@ -26,8 +24,6 @@ class OutputFacade(private val settings: ProcessingSettings, private val showRep
     }
 
     fun run(result: Detektion) {
-        // Always run output reports first.
-        // They produce notifications which may get printed on the console.
         handleOutputReports(result)
         handleConsoleReports(result)
     }
@@ -49,7 +45,7 @@ class OutputFacade(private val settings: ProcessingSettings, private val showRep
             if (filePath != null) {
                 report.write(filePath, result)
                 if (showReports) {
-                    result.add(Notification("Successfully generated ${report.id} at ${filePath.toUri()}", Level.Error))
+                    settings.outputChannel.appendLine("Successfully generated ${report.id} at ${filePath.toUri()}")
                 }
             }
         }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.writeText
 
-class OutputFacade(private val settings: ProcessingSettings) {
+class OutputFacade(private val settings: ProcessingSettings, private val showReports: Boolean) {
     private val reports: Map<String, ReportsSpec.Report> = settings.spec.reportsSpec.reports.associateBy { it.type }
 
     init {
@@ -48,7 +48,9 @@ class OutputFacade(private val settings: ProcessingSettings) {
             val filePath = reports[report.id]?.path
             if (filePath != null) {
                 report.write(filePath, result)
-                result.add(Notification("Successfully generated ${report.id} at ${filePath.toUri()}", Level.Error))
+                if (showReports) {
+                    result.add(Notification("Successfully generated ${report.id} at ${filePath.toUri()}", Level.Error))
+                }
             }
         }
     }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -11,7 +11,7 @@ import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.writeText
 
-class OutputFacade(private val settings: ProcessingSettings, private val showReports: Boolean) {
+class OutputFacade(private val settings: ProcessingSettings) {
     private val reports: Map<String, ReportsSpec.Report> = settings.spec.reportsSpec.reports.associateBy { it.type }
 
     init {
@@ -23,8 +23,8 @@ class OutputFacade(private val settings: ProcessingSettings, private val showRep
             }
     }
 
-    fun run(result: Detektion) {
-        handleOutputReports(result)
+    fun run(result: Detektion, reportPaths: ReportPaths = ReportPaths.Hidden) {
+        handleOutputReports(result, reportPaths)
         handleConsoleReports(result)
     }
 
@@ -38,18 +38,20 @@ class OutputFacade(private val settings: ProcessingSettings, private val showRep
         }
     }
 
-    private fun handleOutputReports(result: Detektion) {
+    private fun handleOutputReports(result: Detektion, reportPaths: ReportPaths) {
         val extensions = loadExtensions<OutputReport>(settings)
         for (report in extensions) {
             val filePath = reports[report.id]?.path
             if (filePath != null) {
                 report.write(filePath, result)
-                if (showReports) {
+                if (reportPaths == ReportPaths.Show) {
                     settings.outputChannel.appendLine("Successfully generated ${report.id} at ${filePath.toUri()}")
                 }
             }
         }
     }
+
+    enum class ReportPaths { Show, Hidden }
 }
 
 /*

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/AnalysisFacade.kt
@@ -5,6 +5,8 @@ import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.config.FailurePolicyResult
 import dev.detekt.core.config.check
 import dev.detekt.core.reporting.OutputFacade
+import dev.detekt.core.reporting.OutputFacade.ReportPaths.Hidden
+import dev.detekt.core.reporting.OutputFacade.ReportPaths.Show
 import dev.detekt.tooling.api.AnalysisResult
 import dev.detekt.tooling.api.Detekt
 import dev.detekt.tooling.api.DetektError
@@ -29,7 +31,7 @@ class AnalysisFacade(private val spec: ProcessingSpec) : Detekt {
                     val fail = checkFailurePolicy(detektion)
                     @Suppress("TooGenericExceptionCaught")
                     try {
-                        OutputFacade(this, showReports = fail != null).run(detektion)
+                        OutputFacade(this).run(detektion, if (fail != null) Show else Hidden)
                     } catch (ex: Exception) {
                         DefaultAnalysisResult(detektion, UnexpectedError(ex))
                     }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -11,7 +11,6 @@ import dev.detekt.core.config.validation.checkConfiguration
 import dev.detekt.core.extensions.handleReportingExtensions
 import dev.detekt.core.getRules
 import dev.detekt.core.parser.DetektMessageCollector
-import dev.detekt.core.reporting.OutputFacade
 import dev.detekt.core.rules.createRuleProviders
 import dev.detekt.core.util.PerformanceMonitor.Phase
 import dev.detekt.tooling.api.AnalysisMode
@@ -57,11 +56,7 @@ internal class Lifecycle(
             processors.fold(detektion) { acc, processor -> processor.onFinish(filesToAnalyze, acc) }
         }
 
-        return measure(Phase.Reporting) {
-            val finalResult = handleReportingExtensions(settings, result)
-            OutputFacade(settings, true).run(finalResult)
-            finalResult
-        }
+        return measure(Phase.Reporting) { handleReportingExtensions(settings, result) }
     }
 
     private fun validateClasspath(files: List<KtFile>) {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -59,7 +59,7 @@ internal class Lifecycle(
 
         return measure(Phase.Reporting) {
             val finalResult = handleReportingExtensions(settings, result)
-            OutputFacade(settings).run(finalResult)
+            OutputFacade(settings, true).run(finalResult)
             finalResult
         }
     }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
@@ -17,14 +17,17 @@ import org.assertj.core.api.Assertions.assertThatCode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.ValueSource
+import org.junit.jupiter.params.provider.EnumSource
 import java.nio.file.Path
 
 class OutputFacadeSpec {
 
     @ParameterizedTest
-    @ValueSource(booleans = [true, false])
-    fun `Running the output facade with multiple reports`(showReports: Boolean, @TempDir tempDir: Path) {
+    @EnumSource(OutputFacade.ReportPaths::class)
+    fun `Running the output facade with multiple reports`(
+        showReports: OutputFacade.ReportPaths,
+        @TempDir tempDir: Path,
+    ) {
         val printStream = StringPrintStream()
         val defaultResult = TestDetektion(
             createIssue(
@@ -49,7 +52,7 @@ class OutputFacadeSpec {
             }
         }
 
-        spec.withSettings { OutputFacade(this, showReports).run(defaultResult) }
+        spec.withSettings { OutputFacade(this).run(defaultResult, showReports) }
 
         val expected = listOf(
             "Successfully generated ${CheckstyleOutputReport().id} at ${xmlOutputPath.toUri()}",
@@ -58,10 +61,9 @@ class OutputFacadeSpec {
             "Successfully generated ${SarifOutputReport().id} at ${sarifOutputPath.toUri()}",
         )
 
-        if (showReports) {
-            assertThat(printStream.toString()).contains(expected)
-        } else {
-            assertThat(printStream.toString()).doesNotContain(expected)
+        when (showReports) {
+            OutputFacade.ReportPaths.Show -> assertThat(printStream.toString()).contains(expected)
+            OutputFacade.ReportPaths.Hidden -> assertThat(printStream.toString()).doesNotContain(expected)
         }
         assertThat(xmlOutputPath).isNotEmptyFile()
         assertThat(htmlOutputPath).isNotEmptyFile()
@@ -92,7 +94,7 @@ class OutputFacadeSpec {
         }
 
         assertThatCode {
-            spec.withSettings { OutputFacade(this, true).run(defaultResult) }
+            spec.withSettings { OutputFacade(this).run(defaultResult, OutputFacade.ReportPaths.Show) }
         }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("The path $htmlOutputPath is defined in multiple reports: [html, checkstyle]")
@@ -123,7 +125,7 @@ class OutputFacadeSpec {
         }
 
         assertThatCode {
-            spec.withSettings { OutputFacade(this, true).run(defaultResult) }
+            spec.withSettings { OutputFacade(this).run(defaultResult, OutputFacade.ReportPaths.Show) }
         }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("The path $htmlOutputPath is defined in multiple reports: [html, checkstyle, markdown]")


### PR DESCRIPTION
Closes #8558
Closes #8592

These PR changes the behavior of detekt in two different but related ways:
1. We don't use `NotificationReport` to notify the paths of our reports, we write them directly to the output. Before you could exclude `NotificationReport` and you would never see this output.
   - This helps with #6879
2. We print the paths only and only if there are issues. This mimics the behavior of JUnit. Before we were always reporting them if you had `NotificationReport` enabled (no-excluded).

I think that this is a clear improvement. In general detekt always passes so having the paths of each report of each module is REALLY noisy. You want no output when everything works so you disable `NotificationReport`. But when there are issues you want information. And the paths of the reports in the console are really handy so you can click over them.