### PR TITLE
Make sure detekt-gradle-plugin is also published to Snapshot repository

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -117,3 +117,13 @@ tasks.register("publishToMavenLocal") {
     }
     dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToMavenLocal"))
 }
+
+tasks.register("publishToSonatype") {
+    description = "Publish all the projects to Sonatype"
+    subprojects {
+        if (this.plugins.hasPlugin("packaging")) {
+            dependsOn(tasks.named("publishToSonatype"))
+        }
+    }
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToSonatype"))
+}

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -16,6 +16,7 @@ plugins {
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
     id("org.jetbrains.dokka") version "2.0.0"
     id("signing")
+    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 repositories {
@@ -25,6 +26,17 @@ repositories {
 
 group = "dev.detekt"
 version = Versions.currentOrSnapshot()
+
+nexusPublishing {
+    repositories {
+        create("sonatype") {
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
+            username = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_USERNAME")
+            password = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_PASSWORD")
+        }
+    }
+}
 
 detekt {
     source.from("src/functionalTest/kotlin")


### PR DESCRIPTION
Fixes: https://github.com/detekt/detekt/issues/8484

This creates a new top level task called `publishToSonatype` which will take care of publishing all the modules **and** the detekt-gradle-plugin artifact to the Snapshot repository.

I've noticed this while I was investigating #8484
The DGP binaries are missing in the snapshot repository, they should be located here:
https://central.sonatype.com/repository/maven-snapshots/dev/detekt/detekt-gradle-plugin/maven-metadata.xml