### PR TITLE
Add compilation output to friendPaths by default

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -25,7 +25,7 @@ internal fun Project.registerJvmCompilationDetektTask(
 
         detektTask.setSource(siblingTask.sources)
         detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        detektTask.friendPaths.conventionCompat(siblingTask.friendPaths)
+        detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
         detektTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
         /* Note: jvmTarget convention is also set in setDetektTaskDefaults. There may be a race between setting it here
@@ -69,7 +69,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
 
         createBaselineTask.setSource(siblingTask.sources)
         createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        createBaselineTask.friendPaths.conventionCompat(siblingTask.friendPaths)
+        createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
         createBaselineTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
         /* Note: jvmTarget convention is also set in setCreateBaselineTaskDefaults. There may be a race between setting


### PR DESCRIPTION
If files containing internal declarations are excluded from the collection of source files being analysed there will be warnings that internal declarations cannot be accessed.

This is because if a file with an internal declaration is excluded from analysis it will be on the classpath (because compilation outputs are included on the classpath) but the compiler will consider it to be coming from an external module as it's not added to the list of friend paths. This commit updates this so that compilation outputs are also included on the list of friend paths, so internal declarations are accessible during analysis.