### PR TITLE
Unblock publishing of detekt-gradle-plugin due to config cache

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -282,3 +282,9 @@ dependencyAnalysis {
         }
     }
 }
+
+tasks {
+    withType<PublishToMavenRepository>().configureEach {
+        notCompatibleWithConfigurationCache("https://github.com/detekt/detekt/issues/8484")
+    }
+}


### PR DESCRIPTION
See https://github.com/detekt/detekt/issues/8484#issuecomment-3240154361

Snapshots are currently failing on `main` due to the nexus-publish plugin not being compatible with Gradle Configuration cache. This unblocks it.