### PR TITLE
Move RuleProviderSpec.kt to the right package (`dev.detekt.*`)

### DIFF
--- a/detekt-rules/src/test/kotlin/dev/detekt/rules/RuleProviderSpec.kt
+++ b/detekt-rules/src/test/kotlin/dev/detekt/rules/RuleProviderSpec.kt
@@ -1,4 +1,4 @@
-package io.gitlab.arturbosch.detekt.rules
+package dev.detekt.rules
 
 import dev.detekt.api.Config
 import dev.detekt.api.Rule


### PR DESCRIPTION
This test file is still in the old package, while the rest of the module has been migrated, so let's update it.
