### PR TITLE
`FileProcessListener.onFinish` returns a `Detektion`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -104,7 +104,7 @@ public abstract interface class dev/detekt/api/Extension {
 }
 
 public abstract interface class dev/detekt/api/FileProcessListener : dev/detekt/api/Extension {
-	public fun onFinish (Ljava/util/List;Ldev/detekt/api/Detektion;)V
+	public fun onFinish (Ljava/util/List;Ldev/detekt/api/Detektion;)Ldev/detekt/api/Detektion;
 	public fun onProcess (Lorg/jetbrains/kotlin/psi/KtFile;)V
 	public fun onProcessComplete (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
 	public fun onStart (Ljava/util/List;)V

--- a/detekt-api/src/main/kotlin/dev/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/FileProcessListener.kt
@@ -35,5 +35,5 @@ interface FileProcessListener : Extension {
      *
      * This method is called before any [ReportingExtension].
      */
-    fun onFinish(files: List<KtFile>, result: Detektion) {}
+    fun onFinish(files: List<KtFile>, result: Detektion): Detektion = result
 }

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/DetektProgressListener.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/DetektProgressListener.kt
@@ -19,8 +19,9 @@ class DetektProgressListener : FileProcessListener {
         outPrinter.append('.')
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val middlePart = if (files.size == 1) "file was" else "files were"
         outPrinter.appendLine("\n\n${files.size} kotlin $middlePart analyzed.")
+        return result
     }
 }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
@@ -14,7 +14,7 @@ class KtFileModifier : FileProcessListener {
 
     override val id: String = "KtFileModifier"
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         files.filter { it.modifiedText != null }
             .forEach { ktFile ->
                 val path = ktFile.absolutePath()
@@ -23,6 +23,7 @@ class KtFileModifier : FileProcessListener {
                 // reset modification text after writing as the PsiFile may be reused in tests or an IDE session
                 ktFile.modifiedText = null
             }
+        return result
     }
 
     private fun KtFile.unnormalizeContent(): String =

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -55,9 +55,8 @@ internal interface Lifecycle {
             val analyzer = Analyzer(settings, rules.filter { it.ruleInstance.active }, processors, bindingContext)
             processors.forEach { it.onStart(filesToAnalyze) }
             val issues = analyzer.run(filesToAnalyze)
-            val result: Detektion = DetektResult(issues, rules.map { it.ruleInstance })
-            processors.forEach { it.onFinish(filesToAnalyze, result) }
-            result
+            val detektion: Detektion = DetektResult(issues, rules.map { it.ruleInstance })
+            processors.fold(detektion) { acc, processor -> processor.onFinish(filesToAnalyze, acc) }
         }
 
         return measure(Phase.Reporting) {

--- a/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -43,9 +43,10 @@ class TopLevelAutoCorrectSpec {
         val contentChangedListener = object : FileProcessListener {
             override val id: String = "ContentChangedListener"
 
-            override fun onFinish(files: List<KtFile>, result: Detektion) {
+            override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
                 assertThat(files).hasSize(1)
                 assertThat(files[0].text).isNotEqualToIgnoringWhitespace(fileContentBeforeAutoCorrect)
+                return result
             }
         }
 

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
@@ -15,10 +15,11 @@ abstract class AbstractProcessor : FileProcessListener {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()
         result.userData[key.toString()] = count
+        return result
     }
 }

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProjectMetricProcessor.kt
@@ -8,10 +8,11 @@ abstract class AbstractProjectMetricProcessor : AbstractProcessor() {
 
     val type: String get() = key.toString()
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()
         result.add(ProjectMetric(type, count))
+        return result
     }
 }

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PackageCountProcessor.kt
@@ -18,12 +18,13 @@ class PackageCountProcessor : FileProcessListener {
         file.accept(visitor)
     }
 
-    override fun onFinish(files: List<KtFile>, result: Detektion) {
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .distinct()
             .size
         result.add(ProjectMetric(key.toString(), count))
+        return result
     }
 }
 

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/FileProcessListenerExtensions.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/FileProcessListenerExtensions.kt
@@ -1,18 +1,18 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.api.Detektion
 import dev.detekt.api.FileProcessListener
 import dev.detekt.api.testfixtures.TestDetektion
 import org.jetbrains.kotlin.psi.KtFile
 
 fun FileProcessListener.invoke(vararg files: KtFile) = invoke(files.toList())
 
-fun FileProcessListener.invoke(files: List<KtFile>): TestDetektion {
+fun FileProcessListener.invoke(files: List<KtFile>): Detektion {
     val result = TestDetektion()
     onStart(files)
     files.forEach {
         onProcess(it)
         onProcessComplete(it, emptyList())
     }
-    onFinish(files, result)
-    return result
+    return onFinish(files, result)
 }


### PR DESCRIPTION
This change is to allow make `Detektion` immutable. Right now the only way to change a `Detektion` inside `FileProcessListener` was to mutate it. With this change we are still mutating it but at the instance that is used is always the one returned and not the one that was passed as parameter. In next PRs `Detektion` will be immutable so that mutability will dissapear.