### PR TITLE
Make `Detektion` immutable

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -74,6 +74,7 @@ public final class dev/detekt/api/Detektion {
 	public final fun getUserData ()Ljava/util/Map;
 	public final fun plus (Ldev/detekt/api/Notification;)Ldev/detekt/api/Detektion;
 	public final fun plus (Ldev/detekt/api/ProjectMetric;)Ldev/detekt/api/Detektion;
+	public final fun plus (Lkotlin/Pair;)Ldev/detekt/api/Detektion;
 }
 
 public final class dev/detekt/api/Entity {

--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -65,14 +65,15 @@ public class dev/detekt/api/DetektVisitor : org/jetbrains/kotlin/psi/KtTreeVisit
 }
 
 public final class dev/detekt/api/Detektion {
-	public fun <init> (Ljava/util/List;Ljava/util/List;)V
-	public final fun add (Ldev/detekt/api/Notification;)V
-	public final fun add (Ldev/detekt/api/ProjectMetric;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getIssues ()Ljava/util/List;
-	public final fun getMetrics ()Ljava/util/Collection;
-	public final fun getNotifications ()Ljava/util/Collection;
+	public final fun getMetrics ()Ljava/util/List;
+	public final fun getNotifications ()Ljava/util/List;
 	public final fun getRules ()Ljava/util/List;
 	public final fun getUserData ()Ljava/util/Map;
+	public final fun plus (Ldev/detekt/api/Notification;)Ldev/detekt/api/Detektion;
+	public final fun plus (Ldev/detekt/api/ProjectMetric;)Ldev/detekt/api/Detektion;
 }
 
 public final class dev/detekt/api/Entity {

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
@@ -4,7 +4,13 @@ package dev.detekt.api
  * Storage for all kinds of findings and additional information
  * which needs to be transferred from the detekt engine to the user.
  */
-class Detektion(val issues: List<Issue>, val rules: List<RuleInstance>) {
+class Detektion(
+    val issues: List<Issue>,
+    val rules: List<RuleInstance>,
+    val notifications: List<Notification> = emptyList(),
+    val metrics: List<ProjectMetric> = emptyList(),
+    val userData: MutableMap<String, Any> = mutableMapOf(),
+) {
     init {
         val notReportedRules = issues.map { it.ruleInstance }.distinct().minus(rules.toSet())
         require(notReportedRules.isEmpty()) {
@@ -15,20 +21,15 @@ class Detektion(val issues: List<Issue>, val rules: List<RuleInstance>) {
             }
         }
     }
+    fun plus(projectMetric: ProjectMetric): Detektion = this.copy(metrics = metrics + projectMetric)
 
-    private val _notifications = mutableListOf<Notification>()
-    val notifications: Collection<Notification> = _notifications
+    fun plus(notification: Notification): Detektion = this.copy(notifications = notifications + notification)
 
-    private val _metrics = mutableListOf<ProjectMetric>()
-    val metrics: Collection<ProjectMetric> = _metrics
-
-    val userData: MutableMap<String, Any> = mutableMapOf()
-
-    fun add(projectMetric: ProjectMetric) {
-        _metrics.add(projectMetric)
-    }
-
-    fun add(notification: Notification) {
-        _notifications.add(notification)
-    }
+    private fun copy(
+        issues: List<Issue> = this.issues,
+        rules: List<RuleInstance> = this.rules,
+        notifications: List<Notification> = this.notifications,
+        metrics: List<ProjectMetric> = this.metrics,
+        userData: Map<String, Any> = this.userData,
+    ) = Detektion(issues, rules, notifications, metrics, userData.toMutableMap())
 }

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Detektion.kt
@@ -9,7 +9,7 @@ class Detektion(
     val rules: List<RuleInstance>,
     val notifications: List<Notification> = emptyList(),
     val metrics: List<ProjectMetric> = emptyList(),
-    val userData: MutableMap<String, Any> = mutableMapOf(),
+    val userData: Map<String, Any> = emptyMap(),
 ) {
     init {
         val notReportedRules = issues.map { it.ruleInstance }.distinct().minus(rules.toSet())
@@ -25,11 +25,13 @@ class Detektion(
 
     fun plus(notification: Notification): Detektion = this.copy(notifications = notifications + notification)
 
+    fun plus(userData: Pair<String, Any>): Detektion = this.copy(userData = this.userData.plus(userData))
+
     private fun copy(
         issues: List<Issue> = this.issues,
         rules: List<RuleInstance> = this.rules,
         notifications: List<Notification> = this.notifications,
         metrics: List<ProjectMetric> = this.metrics,
         userData: Map<String, Any> = this.userData,
-    ) = Detektion(issues, rules, notifications, metrics, userData.toMutableMap())
+    ) = Detektion(issues, rules, notifications, metrics, userData)
 }

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
@@ -11,18 +11,17 @@ import dev.detekt.api.RuleInstance
 fun TestDetektion(
     vararg issues: Issue,
     rules: List<RuleInstance> = issues.map { it.ruleInstance },
-    metrics: List<ProjectMetric> = emptyList(),
     notifications: List<Notification> = emptyList(),
+    metrics: List<ProjectMetric> = emptyList(),
     userData: Map<String, Any> = emptyMap(),
 ): Detektion =
     Detektion(
-        issues.toList(),
-        rules,
-    ).apply {
-        metrics.forEach { add(it) }
-        notifications.forEach { add(it) }
-        this.userData.putAll(userData)
-    }
+        issues = issues.toList(),
+        rules = rules,
+        notifications = notifications,
+        metrics = metrics,
+        userData = userData.toMutableMap()
+    )
 
 fun <V> Detektion.removeData(key: Key<V>) {
     userData.remove(key.toString())

--- a/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
+++ b/detekt-api/src/testFixtures/kotlin/dev/detekt/api/testfixtures/TestDetektion.kt
@@ -1,6 +1,5 @@
 package dev.detekt.api.testfixtures
 
-import com.intellij.openapi.util.Key
 import dev.detekt.api.Detektion
 import dev.detekt.api.Issue
 import dev.detekt.api.Notification
@@ -22,7 +21,3 @@ fun TestDetektion(
         metrics = metrics,
         userData = userData.toMutableMap()
     )
-
-fun <V> Detektion.removeData(key: Key<V>) {
-    userData.remove(key.toString())
-}

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
@@ -14,15 +14,16 @@ class KtFileModifier : FileProcessListener {
     override val id: String = "KtFileModifier"
 
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
+        var finalResult = result
         files.filter { it.modifiedText != null }
             .forEach { ktFile ->
                 val path = ktFile.absolutePath()
-                result.add(Notification("File $path was modified.", Notification.Level.Info))
+                finalResult = finalResult.plus(Notification("File $path was modified.", Notification.Level.Info))
                 path.writeText(ktFile.unnormalizeContent())
                 // reset modification text after writing as the PsiFile may be reused in tests or an IDE session
                 ktFile.modifiedText = null
             }
-        return result
+        return finalResult
     }
 
     private fun KtFile.unnormalizeContent(): String =

--- a/detekt-core/src/main/kotlin/dev/detekt/core/extensions/Reporting.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/extensions/Reporting.kt
@@ -18,8 +18,7 @@ private fun Detektion.copy(issues: List<Issue> = this.issues): Detektion =
     Detektion(
         issues = issues,
         rules = rules,
-    ).also { copy ->
-        metrics.forEach { copy.add(it) }
-        notifications.forEach { copy.add(it) }
-        copy.userData.putAll(userData)
-    }
+        metrics = metrics,
+        notifications = notifications,
+        userData = userData,
+    )

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/AbstractProcessor.kt
@@ -19,7 +19,6 @@ abstract class AbstractProcessor : FileProcessListener {
         val count = files
             .mapNotNull { it.getUserData(key) }
             .sum()
-        result.userData[key.toString()] = count
-        return result
+        return result.plus(key.toString() to count)
     }
 }

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/ClassCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/ClassCountProcessor.kt
@@ -13,8 +13,7 @@ class ClassCountProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files.sumOf { it.collectDescendantsOfType<KtClass>().size }
-        result.add(ProjectMetric(numberOfClassesKey.toString(), count))
-        return result
+        return result.plus(ProjectMetric(numberOfClassesKey.toString(), count))
     }
 }
 

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/FunctionCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/FunctionCountProcessor.kt
@@ -13,8 +13,7 @@ class FunctionCountProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files.sumOf { it.collectDescendantsOfType<KtNamedFunction>().size }
-        result.add(ProjectMetric(numberOfFunctionsKey.toString(), count))
-        return result
+        return result.plus(ProjectMetric(numberOfFunctionsKey.toString(), count))
     }
 }
 

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/KtFileCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/KtFileCountProcessor.kt
@@ -9,10 +9,8 @@ import org.jetbrains.kotlin.psi.KtFile
 class KtFileCountProcessor : FileProcessListener {
     override val id: String = "KtFileCountProcessor"
 
-    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
-        result.add(ProjectMetric(numberOfFilesKey.toString(), files.count()))
-        return result
-    }
+    override fun onFinish(files: List<KtFile>, result: Detektion): Detektion =
+        result.plus(ProjectMetric(numberOfFilesKey.toString(), files.count()))
 }
 
 val numberOfFilesKey = Key<Int>("number of kt files")

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PackageCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PackageCountProcessor.kt
@@ -14,8 +14,7 @@ class PackageCountProcessor : FileProcessListener {
             .map { it.packageFqName }
             .distinct()
             .size
-        result.add(ProjectMetric(numberOfPackagesKey.toString(), count))
-        return result
+        return result.plus(ProjectMetric(numberOfPackagesKey.toString(), count))
     }
 }
 

--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PropertyCountProcessor.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/processors/PropertyCountProcessor.kt
@@ -13,8 +13,7 @@ class PropertyCountProcessor : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         val count = files.sumOf { it.collectDescendantsOfType<KtProperty>().size }
-        result.add(ProjectMetric(numberOfFieldsKey.toString(), count))
-        return result
+        return result.plus(ProjectMetric(numberOfFieldsKey.toString(), count))
     }
 }
 

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -67,19 +67,19 @@ internal class ComplexityReportGeneratorSpec {
 
         @Test
         fun `returns null for missing lloc`() {
-            val detektion = detektion.removeData(logicalLinesKey)
+            var detektion = detektion.removeData(logicalLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.userData[logicalLinesKey.toString()] = 0
+            detektion = detektion.plus(logicalLinesKey.toString() to 0)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
         @Test
         fun `returns null for missing sloc`() {
-            val detektion = detektion.removeData(sourceLinesKey)
+            var detektion = detektion.removeData(sourceLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
-            detektion.userData[sourceLinesKey.toString()] = 0
+            detektion = detektion.plus(sourceLinesKey.toString() to 0)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/ComplexityReportGeneratorSpec.kt
@@ -1,9 +1,9 @@
 package dev.detekt.metrics
 
+import com.intellij.openapi.util.Key
 import dev.detekt.api.Detektion
 import dev.detekt.api.testfixtures.TestDetektion
 import dev.detekt.api.testfixtures.createIssue
-import dev.detekt.api.testfixtures.removeData
 import dev.detekt.metrics.processors.commentLinesKey
 import dev.detekt.metrics.processors.cyclomaticComplexityKey
 import dev.detekt.metrics.processors.linesKey
@@ -61,13 +61,13 @@ internal class ComplexityReportGeneratorSpec {
 
         @Test
         fun `returns null for missing mcc`() {
-            detektion.removeData(cyclomaticComplexityKey)
+            val detektion = detektion.removeData(cyclomaticComplexityKey)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
 
         @Test
         fun `returns null for missing lloc`() {
-            detektion.removeData(logicalLinesKey)
+            val detektion = detektion.removeData(logicalLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
             detektion.userData[logicalLinesKey.toString()] = 0
@@ -76,7 +76,7 @@ internal class ComplexityReportGeneratorSpec {
 
         @Test
         fun `returns null for missing sloc`() {
-            detektion.removeData(sourceLinesKey)
+            val detektion = detektion.removeData(sourceLinesKey)
             assertThat(generateComplexityReport(detektion)).isNull()
 
             detektion.userData[sourceLinesKey.toString()] = 0
@@ -85,7 +85,7 @@ internal class ComplexityReportGeneratorSpec {
 
         @Test
         fun `returns null for missing cloc`() {
-            detektion.removeData(cyclomaticComplexityKey)
+            val detektion = detektion.removeData(cyclomaticComplexityKey)
             assertThat(generateComplexityReport(detektion)).isNull()
         }
     }
@@ -96,3 +96,12 @@ private fun generateComplexityReport(detektion: Detektion): List<String>? {
     val generator = ComplexityReportGenerator(complexityMetric)
     return generator.generate()
 }
+
+private fun <V> Detektion.removeData(key: Key<V>): Detektion =
+    Detektion(
+        issues = issues,
+        rules = rules,
+        notifications = notifications,
+        metrics = metrics,
+        userData = userData.toMutableMap().apply { remove(key.toString()) },
+    )


### PR DESCRIPTION
Close #8561

Make `Detektion` immutable. This should make easier to reason about `Detektion` and make it easier to maintain.

~Blocked by:~
- ~#8579~
- ~#8580~
- ~#8560~
- ~#8557~