### PR TITLE
fix: don't show debug suggestion when debug is already enabled

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -16,6 +16,7 @@ import dev.detekt.core.rules.createRuleProviders
 import dev.detekt.core.util.PerformanceMonitor.Phase
 import dev.detekt.core.util.getOrCreateMonitor
 import dev.detekt.parser.DetektMessageCollector
+import dev.detekt.parser.GenerateBindingContextOptions
 import dev.detekt.parser.generateBindingContext
 import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.analysis.api.analyze
@@ -74,7 +75,12 @@ internal class DefaultLifecycle(
     override val bindingProvider: (files: List<KtFile>) -> BindingContext =
         {
             if (settings.spec.projectSpec.analysisMode == AnalysisMode.full) {
-                val collector = DetektMessageCollector(CompilerMessageSeverity.ERROR, settings::debug, settings::info)
+                val collector = DetektMessageCollector(
+                    minSeverity = CompilerMessageSeverity.ERROR,
+                    debugPrinter = settings::debug,
+                    warningPrinter = settings::info,
+                    isDebugEnabled = settings.spec.loggingSpec.debug
+                )
 
                 it.forEach { file: KtFile ->
                     analyze(file) {
@@ -102,11 +108,14 @@ internal class DefaultLifecycle(
                 collector.printIssuesCountIfAny(k2Mode = true)
 
                 generateBindingContext(
-                    settings.project,
-                    settings.configuration,
-                    it,
-                    settings::debug,
-                    settings::info
+                    project = settings.project,
+                    configuration = settings.configuration,
+                    files = it,
+                    options = GenerateBindingContextOptions(
+                        debugPrinter = settings::debug,
+                        warningPrinter = settings::info,
+                        isDebugEnabled = settings.spec.loggingSpec.debug,
+                    ),
                 )
             } else {
                 BindingContext.EMPTY

--- a/detekt-parser/src/main/kotlin/dev/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/dev/detekt/parser/BindingContextUtils.kt
@@ -22,7 +22,7 @@ import org.jetbrains.kotlin.resolve.BindingContext
 data class GenerateBindingContextOptions(
     val debugPrinter: (() -> String) -> Unit,
     val warningPrinter: (String) -> Unit,
-    val isDebugEnabled: Boolean = false,
+    val isDebugEnabled: Boolean,
 )
 
 fun generateBindingContext(
@@ -81,7 +81,7 @@ class DetektMessageCollector(
     private val minSeverity: CompilerMessageSeverity,
     private val debugPrinter: (() -> String) -> Unit,
     private val warningPrinter: (String) -> Unit,
-    private val isDebugEnabled: Boolean = false,
+    private val isDebugEnabled: Boolean,
 ) : MessageCollector by MessageCollector.NONE {
     private var messages = 0
 

--- a/detekt-parser/src/main/kotlin/dev/detekt/parser/BindingContextUtils.kt
+++ b/detekt-parser/src/main/kotlin/dev/detekt/parser/BindingContextUtils.kt
@@ -18,17 +18,24 @@ import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 
+// Avoid exceeding 5 parameters in the function call below
+data class GenerateBindingContextOptions(
+    val debugPrinter: (() -> String) -> Unit,
+    val warningPrinter: (String) -> Unit,
+    val isDebugEnabled: Boolean = false,
+)
+
 fun generateBindingContext(
     project: Project,
     configuration: CompilerConfiguration,
     files: List<KtFile>,
-    debugPrinter: (() -> String) -> Unit,
-    warningPrinter: (String) -> Unit,
+    options: GenerateBindingContextOptions,
 ): BindingContext {
     val messageCollector = DetektMessageCollector(
         minSeverity = CompilerMessageSeverity.ERROR,
-        debugPrinter = debugPrinter,
-        warningPrinter = warningPrinter,
+        debugPrinter = options.debugPrinter,
+        warningPrinter = options.warningPrinter,
+        isDebugEnabled = options.isDebugEnabled,
     )
 
     val analyzer = AnalyzerWithCompilerReport(
@@ -74,6 +81,7 @@ class DetektMessageCollector(
     private val minSeverity: CompilerMessageSeverity,
     private val debugPrinter: (() -> String) -> Unit,
     private val warningPrinter: (String) -> Unit,
+    private val isDebugEnabled: Boolean = false,
 ) : MessageCollector by MessageCollector.NONE {
     private var messages = 0
 
@@ -86,11 +94,15 @@ class DetektMessageCollector(
 
     fun printIssuesCountIfAny(k2Mode: Boolean = false) {
         if (messages > 0) {
-            warningPrinter(
+            val header =
                 "There were $messages compiler errors found during ${if (!k2Mode) "legacy compiler " else ""}" +
-                    "analysis. This affects accuracy of reporting.\n" +
-                    "Run detekt CLI with --debug or set `detekt { debug = true }` in Gradle to see the error messages."
-            )
+                    "analysis. This affects accuracy of reporting."
+            val suggestion = if (!isDebugEnabled) {
+                "\nRun detekt CLI with --debug or set `detekt { debug = true }` in Gradle to see the error messages."
+            } else {
+                ""
+            }
+            warningPrinter(header + suggestion)
         }
     }
 }

--- a/detekt-parser/src/test/kotlin/dev/detekt/parser/DetektMessageCollectorSpec.kt
+++ b/detekt-parser/src/test/kotlin/dev/detekt/parser/DetektMessageCollectorSpec.kt
@@ -20,6 +20,7 @@ class DetektMessageCollectorSpec {
             minSeverity = CompilerMessageSeverity.INFO,
             debugPrinter = debugPrinter,
             warningPrinter = warningPrinter,
+            isDebugEnabled = false,
         )
     }
 

--- a/detekt-parser/src/test/kotlin/dev/detekt/parser/DetektMessageCollectorSpec.kt
+++ b/detekt-parser/src/test/kotlin/dev/detekt/parser/DetektMessageCollectorSpec.kt
@@ -15,6 +15,7 @@ class DetektMessageCollectorSpec {
     @BeforeEach
     fun setupFakesAndSubject() {
         debugPrinter.messages.clear()
+        warningPrinter.messages.clear()
         subject = DetektMessageCollector(
             minSeverity = CompilerMessageSeverity.INFO,
             debugPrinter = debugPrinter,
@@ -90,6 +91,30 @@ class DetektMessageCollectorSpec {
         subject.printIssuesCountIfAny()
 
         assertThat(warningPrinter.messages).isEmpty()
+    }
+
+    @Nested
+    inner class `debug enabled omits suggestion` {
+        @BeforeEach
+        fun setUp() {
+            debugPrinter.messages.clear()
+            warningPrinter.messages.clear()
+            subject = DetektMessageCollector(
+                minSeverity = CompilerMessageSeverity.INFO,
+                debugPrinter = debugPrinter,
+                warningPrinter = warningPrinter,
+                isDebugEnabled = true,
+            )
+            subject.report(CompilerMessageSeverity.ERROR, "boom", null)
+        }
+
+        @Test
+        fun `prints header without suggestion`() {
+            subject.printIssuesCountIfAny(k2Mode = false)
+            assertThat(warningPrinter.messages).containsExactly(
+                "There were 1 compiler errors found during legacy compiler analysis. This affects accuracy of reporting."
+            )
+        }
     }
 
     class FakePrinter : (() -> String) -> Unit {


### PR DESCRIPTION
## Description

When running detekt with --debug flag, the tool still shows this confusing message:

```
Run detekt CLI with --debug or set `detekt { debug = true }` in Gradle to see the error messages.
```

## Solution

Modified DetektMessageCollector.printIssuesCountIfAny() to check if debug mode is already enabled. If it is, skip the suggestion text.

- Updated printIssuesCountIfAny() method to conditionally show debug suggestion
- Added test cases to verify the behavior
- Works for both CLI --debug flag and Gradle debug = true setting

Fixed: #8567 
