### PR TITLE
Don't disable configuration cache for publishPlugins task

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -253,10 +253,6 @@ tasks {
     ideaModule {
         notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/13480")
     }
-
-    publishPlugins {
-        notCompatibleWithConfigurationCache("https://github.com/gradle/gradle/issues/21283")
-    }
 }
 
 // Skip publishing of test fixture API & runtime variants


### PR DESCRIPTION
The task is now compatible with configuration cache. 

https://plugins.gradle.org/plugin/com.gradle.plugin-publish/2.0.0

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
