### PR TITLE
Filter when `hasStableParameterNames` is true(this means that named p…

### DIFF
--- a/detekt-rules-errorprone/src/main/kotlin/dev/detekt/rules/bugs/UnnamedParameterUse.kt
+++ b/detekt-rules-errorprone/src/main/kotlin/dev/detekt/rules/bugs/UnnamedParameterUse.kt
@@ -120,6 +120,7 @@ class UnnamedParameterUse(config: Config) :
         analyze(expression) {
             val call = expression.resolveToCall()?.singleFunctionCallOrNull() ?: return
             val symbol = call.symbol
+            if (!symbol.hasStableParameterNames) return
             if (symbol.origin.let { it == KaSymbolOrigin.JAVA_SOURCE || it == KaSymbolOrigin.JAVA_LIBRARY }) return
             if (ignoreFunctionCall.any { it.match(symbol) }) return
 

--- a/detekt-rules-errorprone/src/test/kotlin/dev/detekt/rules/bugs/UnnamedParameterUseSpec.kt
+++ b/detekt-rules-errorprone/src/test/kotlin/dev/detekt/rules/bugs/UnnamedParameterUseSpec.kt
@@ -472,6 +472,46 @@ class UnnamedParameterUseSpec(private val env: KotlinEnvironmentContainer) {
     }
 
     @Test
+    fun `does not report for lambda invocation - #8601`() {
+        val code = """
+            class OnboardingPhoneNumberNavigator(
+                private val onNavigateToRequestPin: (String, String) -> Unit,
+            ) {
+                fun navigateToRequestPin(
+                    country: String,
+                    phoneNumber: String,
+                ) {
+                    onNavigateToRequestPin(country, phoneNumber)
+                }
+            }
+        """.trimIndent()
+
+        assertThat(
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
+        ).isEmpty()
+    }
+
+    @Test
+    fun `does not report for lambda invocation with named param`() {
+        val code = """
+            class OnboardingPhoneNumberNavigator(
+                private val onNavigateToRequestPin: (country: String, phoneNumber: String) -> Unit,
+            ) {
+                fun navigateToRequestPin(
+                    country: String,
+                    phoneNumber: String,
+                ) {
+                    onNavigateToRequestPin(country, phoneNumber)
+                }
+            }
+        """.trimIndent()
+
+        assertThat(
+            getSubject(allowAdjacentDifferentTypeParams = true).lintWithContext(env, code)
+        ).isEmpty()
+    }
+
+    @Test
     fun `does report class constructor is called without name`() {
         val code = """
             class A(x: Int, y: Int)


### PR DESCRIPTION
…aram can't be used)

Fixes https://github.com/detekt/detekt/issues/8601
