### PR TITLE
Fix RedundantSuspendModifier bugs

### DIFF
--- a/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -76,14 +76,16 @@ class RedundantSuspendModifier(config: Config) :
 
     private fun KtExpression.isValidCandidateExpression(): Boolean =
         when (this) {
-            is KtOperationReferenceExpression, is KtForExpression, is KtProperty, is KtNameReferenceExpression -> true
+            is KtOperationReferenceExpression,
+            is KtForExpression,
+            is KtProperty,
+            is KtNameReferenceExpression,
+            is KtCallExpression
+                -> true
+
             else -> {
                 val parent = parent
-                if (parent is KtCallExpression && parent.calleeExpression == this) {
-                    true
-                } else {
-                    this is KtCallExpression && this.calleeExpression is KtCallExpression
-                }
+                parent is KtCallExpression && parent.calleeExpression == this
             }
         }
 
@@ -113,6 +115,7 @@ class RedundantSuspendModifier(config: Config) :
 
                         is KaVariableAccessCall -> {
                             call.symbol.callableId == CoroutineCallableIds.CoroutineContextCallableId
+                                || call.symbol.returnType.isSuspendFunctionType
                         }
                     }
                 }

--- a/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifier.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifier.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtArrayAccessExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtForExpression
@@ -75,19 +76,12 @@ class RedundantSuspendModifier(config: Config) :
     }
 
     private fun KtExpression.isValidCandidateExpression(): Boolean =
-        when (this) {
-            is KtOperationReferenceExpression,
-            is KtForExpression,
-            is KtProperty,
-            is KtNameReferenceExpression,
-            is KtCallExpression
-                -> true
-
-            else -> {
-                val parent = parent
-                parent is KtCallExpression && parent.calleeExpression == this
-            }
-        }
+        this is KtOperationReferenceExpression ||
+            this is KtForExpression ||
+            this is KtProperty ||
+            this is KtNameReferenceExpression ||
+            this is KtCallExpression ||
+            this is KtArrayAccessExpression // for get() operator function calls
 
     private fun KtExpression.hasSuspendCalls(): Boolean {
         if (!isValidCandidateExpression()) return false
@@ -115,7 +109,6 @@ class RedundantSuspendModifier(config: Config) :
 
                         is KaVariableAccessCall -> {
                             call.symbol.callableId == CoroutineCallableIds.CoroutineContextCallableId
-                                || call.symbol.returnType.isSuspendFunctionType
                         }
                     }
                 }

--- a/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -178,6 +178,36 @@ class RedundantSuspendModifierSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Test
+    fun `does not report if a suspending get operator function is called`() {
+        val code = """
+            class Foo {
+                suspend operator fun get(ms: Long): Unit = kotlinx.coroutines.delay(ms)
+            }
+
+            suspend fun bar() {
+                val foo = Foo()
+                foo[1234L]
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report if a suspending set operator function is called`() {
+        val code = """
+            class Foo {
+                suspend operator fun set(key: String, value: Long): Unit = kotlinx.coroutines.delay(value)
+            }
+
+            suspend fun bar() {
+                val foo = Foo()
+                foo["key"] = 1234L
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
     fun `does not report if a suspending lambda is called`() {
         val code = """
             suspend fun bar(foo: suspend () -> Unit) {

--- a/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -165,14 +165,22 @@ class RedundantSuspendModifierSpec(val env: KotlinEnvironmentContainer) {
     @Test
     fun `does not report if a suspending invoke operator function is called`() {
         val code = """
-            import kotlinx.coroutines.delay
-
             class Foo {
-                suspend operator fun invoke() = delay(123)
+                suspend operator fun invoke(ms: Long): Unit = kotlinx.coroutines.delay(ms)
             }
 
             suspend fun bar() {
                 val foo = Foo()
+                foo(1234L)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report if a suspending lambda is called`() {
+        val code = """
+            suspend fun bar(foo: suspend () -> Unit) {
                 foo()
             }
         """.trimIndent()

--- a/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/RedundantSuspendModifierSpec.kt
@@ -161,4 +161,21 @@ class RedundantSuspendModifierSpec(val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `does not report if a suspending invoke operator function is called`() {
+        val code = """
+            import kotlinx.coroutines.delay
+
+            class Foo {
+                suspend operator fun invoke() = delay(123)
+            }
+
+            suspend fun bar() {
+                val foo = Foo()
+                foo()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes an issue where RedundantSuspendModifier raises a false positive in a couple of cases in the new 2.0.0 alpha release:

1. a suspending lambda parameter is being invoked (fixes https://github.com/detekt/detekt/issues/8602)
2. a a `suspend operator fun` function is being called. Added tests for invoke, get and set.

We could go through [all operator overload functions](https://kotlinlang.org/docs/operator-overloading.html) and make sure a suspending variant of each doesn't trigger the rule, but that might be a bit much? Not sure where to draw the line really.