### PR TITLE
Enable parallel configuration caching

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ kotlin.daemon.useFallbackStrategy=false
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.kotlin.dsl.skipMetadataVersionCheck=false


### PR DESCRIPTION
https://docs.gradle.org/9.0.0/userguide/configuration_cache_enabling.html#config_cache:usage:parallel
> By default, Configuration Cache storing and loading are sequential. Enabling parallel storing and loading can improve performance