### PR TITLE
Ensure SourceSet-based tasks are registered once

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -82,6 +82,40 @@ class DetektBasePluginSpec {
         gradleRunner.checkTask("androidTest")
     }
 
+    @Test
+    fun `generates source set tasks when multiple plugins of type KotlinBasePlugin are applied #8613`() {
+        val gradleRunner = DslGradleRunner(
+            projectLayout = ProjectLayout(
+                numberOfSourceFilesInRootPerSourceDir = 1,
+                srcDirs = listOf(
+                    "src/main/kotlin",
+                    "src/test/kotlin",
+                ),
+            ),
+            buildFileName = "build.gradle.kts",
+            mainBuildFileContent = """
+                plugins {
+                    id("dev.detekt")
+                    kotlin("jvm") // This plugin has type KotlinBasePlugin
+                }
+            
+                // This plugin also has type KotlinBasePlugin
+                apply<org.jetbrains.kotlin.gradle.plugin.KotlinBaseApiPlugin>()
+            
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                }
+            """.trimIndent(),
+            dryRun = true,
+        ).also {
+            it.setupProject()
+        }
+
+        gradleRunner.checkTask("main")
+        gradleRunner.checkTask("test")
+    }
+
     @Nested
     inner class `generates source set tasks for KMP project` {
         val gradleRunner = DslGradleRunner(

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -19,7 +19,7 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 
 class DetektBasePlugin : Plugin<Project> {
-    var sourceSetListenerConfigured = false
+    private var sourceSetListenerConfigured = false
 
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -19,6 +19,8 @@ import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 
 class DetektBasePlugin : Plugin<Project> {
+    var sourceSetListenerConfigured = false
+
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)
 
@@ -73,6 +75,10 @@ class DetektBasePlugin : Plugin<Project> {
 
     private fun Project.registerSourceSetTasks(extension: DetektExtension) {
         project.plugins.withType(KotlinBasePlugin::class.java) {
+            if (sourceSetListenerConfigured) return@withType
+
+            sourceSetListenerConfigured = true
+
             project.extensions.getByType(KotlinSourceSetContainer::class.java)
                 .sourceSets
                 .all { sourceSet ->


### PR DESCRIPTION
Should fix #8613 

We don't need to worry about threading since configuration is single threaded within a given project, but this could be made an AtomicBoolean if there are concerns.