### PR TITLE
Don't force specific file extensions for OutputReports

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/OutputReport.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/OutputReport.kt
@@ -2,7 +2,6 @@ package dev.detekt.api
 
 import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
-import kotlin.io.path.extension
 import kotlin.io.path.writeText
 
 /**
@@ -22,9 +21,6 @@ abstract class OutputReport : Extension {
     fun write(filePath: Path, detektion: Detektion) {
         val reportData = render(detektion)
         if (reportData != null) {
-            assert(filePath.extension == ending) {
-                "The $id needs to have a file ending of type .$ending, but was ${filePath.fileName}."
-            }
             filePath.createParentDirectories().writeText(reportData)
         }
     }


### PR DESCRIPTION
Someone might want their html reports with the extension `.htm` there is no reason for us to force them to use `.html`.

We don't have it but if someone wants to render in yaml there are two commons extensions for that format `.yml` and `.yaml`.

For those reasons I think that we can remove this restriction. Also with this and another PR we will be able to remove `OutputReport.ending` from out public api making it a bit smaller.