### PR TITLE
Split displayName/description for each Gradle Plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -171,19 +171,23 @@ gradlePlugin {
     plugins {
         create("detektBasePlugin") {
             id = "dev.detekt.gradle.base"
+            displayName = "Static code analysis for Kotlin v2 - Base Plugin"
+            description = "Static code analysis for Kotlin v2 - Base Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
         }
         create("detektPlugin") {
             id = "dev.detekt"
+            displayName = "Static code analysis for Kotlin v2"
+            description = "Static code analysis for Kotlin v2"
             implementationClass = "dev.detekt.gradle.plugin.DetektPlugin"
         }
         create("detektCompilerPlugin") {
             id = "dev.detekt.gradle.compiler-plugin"
+            displayName = "Static code analysis for Kotlin v2 - Compiler Plugin"
+            description = "Static code analysis for Kotlin v2 - Compiler Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektKotlinCompilerPlugin"
         }
         configureEach {
-            displayName = "Static code analysis for Kotlin"
-            description = "Static code analysis for Kotlin"
             tags = listOf("kotlin", "detekt", "code-analysis", "linter", "codesmells", "android")
         }
     }


### PR DESCRIPTION
This is apparently needed, because Gradle Portal would reject a plugin that has a duplicate description 🤷‍♂️ So I'm updating all the descriptions to be distinct + adding a "v2" suffix to avoid clashing with the `1.x` plugins
