### PR TITLE
Remove redundant KDoc

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/FileProcessListener.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/FileProcessListener.kt
@@ -3,10 +3,8 @@ package dev.detekt.api
 import org.jetbrains.kotlin.psi.KtFile
 
 /**
- * Gather additional metrics about the analyzed kotlin file.
+ * Gather additional metrics about the analyzed Kotlin file.
  * Pay attention to the thread policy of each function!
- *
- * A bindingContext != BindingContext.EMPTY is only available if Kotlin compiler settings are used.
  */
 @Suppress("EmptyFunctionBlock")
 interface FileProcessListener : Extension {


### PR DESCRIPTION
BindingContext hasn't been part of the FileProcessListener API for some time

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
