### PR TITLE
Remove `output-report` config

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -5,6 +5,7 @@ import dev.detekt.api.Notification
 import dev.detekt.api.Notification.Level
 import dev.detekt.api.OutputReport
 import dev.detekt.core.ProcessingSettings
+import dev.detekt.core.extensions.loadExtensions
 import dev.detekt.tooling.api.spec.ReportsSpec
 import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
@@ -42,7 +43,7 @@ class OutputFacade(
     }
 
     private fun handleOutputReports(result: Detektion) {
-        val extensions = OutputReportLocator(settings).load()
+        val extensions = loadExtensions<OutputReport>(settings)
         for (report in extensions) {
             val filePath = reports[defaultReportMapping(report)]?.path
             if (filePath != null) {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/ReportLocator.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/ReportLocator.kt
@@ -2,7 +2,6 @@ package dev.detekt.core.reporting
 
 import dev.detekt.api.ConsoleReport
 import dev.detekt.api.Extension
-import dev.detekt.api.OutputReport
 import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.extensions.loadExtensions
 import dev.detekt.core.util.isActiveOrDefault
@@ -27,10 +26,4 @@ internal class ConsoleReportLocator(settings: ProcessingSettings) :
     ReportLocator<ConsoleReport>("console-reports", settings) {
 
     override fun loadReports(): List<ConsoleReport> = loadExtensions(settings) { it.id !in excludes }
-}
-
-internal class OutputReportLocator(settings: ProcessingSettings) :
-    ReportLocator<OutputReport>("output-reports", settings) {
-
-    override fun loadReports(): List<OutputReport> = loadExtensions(settings) { it.id !in excludes }
 }

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -32,14 +32,6 @@ console-reports:
      - 'FileBasedIssuesReport'
   #  - 'LiteIssuesReport'
 
-output-reports:
-  active: true
-  exclude:
-  # - 'CheckstyleOutputReport'
-  # - 'HtmlOutputReport'
-  # - 'MarkdownOutputReport'
-  # - 'sarif'
-
 comments:
   active: true
   AbsentOrWrongFileLicense:

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DetektYmlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DetektYmlConfigSpec.kt
@@ -15,7 +15,6 @@ class DetektYmlConfigSpec {
         "config",
         "processors",
         "console-reports",
-        "output-reports"
     )
 
     private val config: YamlConfig = YamlConfig.load(

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputReportsSpec.kt
@@ -4,6 +4,7 @@ import dev.detekt.api.Detektion
 import dev.detekt.api.OutputReport
 import dev.detekt.core.createNullLoggingSpec
 import dev.detekt.core.createProcessingSettings
+import dev.detekt.core.extensions.loadExtensions
 import dev.detekt.core.tooling.withSettings
 import dev.detekt.report.html.HtmlOutputReport
 import dev.detekt.report.markdown.MarkdownOutputReport
@@ -67,7 +68,7 @@ class OutputReportsSpec {
         @Nested
         inner class `default report ids` {
 
-            private val extensions = createProcessingSettings().use { OutputReportLocator(it).load() }
+            private val extensions = createProcessingSettings().use { loadExtensions<OutputReport>(it) }
             private val extensionsIds = extensions.mapTo(HashSet()) { defaultReportMapping(it) }
 
             @Test

--- a/detekt-core/src/test/resources/config_validation/baseline.yml
+++ b/detekt-core/src/test/resources/config_validation/baseline.yml
@@ -5,8 +5,6 @@ processors:
   active: true
 console-reports:
   active: true
-output-reports:
-  active: true
 
 complexity:
   LongMethod:

--- a/detekt-core/src/test/resources/reporting/disabled-reports.yml
+++ b/detekt-core/src/test/resources/reporting/disabled-reports.yml
@@ -1,5 +1,2 @@
 console-reports:
   active: false
-
-output-reports:
-  active: false

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -14,8 +14,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             emptyLine()
             yaml { defaultConsoleReportsConfiguration() }
             emptyLine()
-            yaml { defaultOutputReportsConfiguration() }
-            emptyLine()
 
             item.sortedBy { it.ruleSet.name }
                 .forEach { printRuleSetPage(it) }
@@ -65,15 +63,5 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
              - 'IssuesReport'
              - 'FileBasedIssuesReport'
           #  - 'LiteIssuesReport'
-    """.trimIndent()
-
-    private fun defaultOutputReportsConfiguration(): String = """
-        output-reports:
-          active: true
-          exclude:
-          # - 'CheckstyleOutputReport'
-          # - 'HtmlOutputReport'
-          # - 'MarkdownOutputReport'
-          # - 'sarif'
     """.trimIndent()
 }

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
@@ -52,12 +52,6 @@ class ConfigPrinterSpec {
     }
 
     @Test
-    fun `prints default report configuration`() {
-        assertThat(yamlString).contains("output-reports:")
-        assertThat(yamlString).contains("console-reports:")
-    }
-
-    @Test
     fun `omits deprecated ruleset properties`() {
         assertThat(yamlString).doesNotContain("deprecatedSimpleConfig")
         assertThat(yamlString).doesNotContain("deprecatedListConfig")

--- a/detekt-report-checkstyle/src/main/kotlin/dev/detekt/report/xml/CheckstyleOutputReport.kt
+++ b/detekt-report-checkstyle/src/main/kotlin/dev/detekt/report/xml/CheckstyleOutputReport.kt
@@ -10,7 +10,6 @@ import kotlin.io.path.invariantSeparatorsPathString
 
 /**
  * Contains rule violations in an XML format. The report follows the structure of a Checkstyle report.
- * See: https://detekt.dev/configurations.html#output-reports
  */
 class CheckstyleOutputReport : BuiltInOutputReport, OutputReport {
 

--- a/detekt-report-html/src/main/kotlin/dev/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/dev/detekt/report/html/HtmlOutputReport.kt
@@ -46,7 +46,6 @@ private const val PLACEHOLDER_DATE = "@@@date@@@"
 
 /**
  * Contains rule violations and metrics formatted in a human friendly way, so that it can be inspected in a web browser.
- * See: https://detekt.dev/configurations.html#output-reports
  */
 class HtmlOutputReport : BuiltInOutputReport, OutputReport {
 

--- a/detekt-report-markdown/src/main/kotlin/dev/detekt/report/markdown/MarkdownOutputReport.kt
+++ b/detekt-report-markdown/src/main/kotlin/dev/detekt/report/markdown/MarkdownOutputReport.kt
@@ -36,7 +36,6 @@ private const val EXTRA_LINES_IN_SNIPPET = 3
 
 /**
  * Contains rule violations in Markdown format report.
- * [See](https://detekt.dev/docs/introduction/configurations/#output-reports)
  */
 class MarkdownOutputReport : BuiltInOutputReport, OutputReport {
     override val id: String = "MarkdownOutputReport"

--- a/website/docs/introduction/configurations.mdx
+++ b/website/docs/introduction/configurations.mdx
@@ -154,21 +154,6 @@ It's simply a way of alerting users to information that they have opted-in to.
 **FileBasedFindingsReport** is similar to the FindingsReport shown above. 
 The rule violations are grouped by file location.
 
-## Output Reports
-
-Uncomment the reports you don't care about. The detailed description can be found in [reporting](reporting.md).
-
-```yaml
-output-reports:
-  active: true
-  exclude:
-  #  - 'HtmlOutputReport'
-  #  - 'CheckstyleOutputReport'
-  #  - 'sarif'
-  #  - 'MarkdownOutputReport'
-```
-
-
 ## Processors
 
 Count processors are used to calculate project metrics.


### PR DESCRIPTION
Closes #8649 

For full context read #8649

I don't know how to test this change. It removes a feature that never had tests.