### PR TITLE
Ensure that two reports doesn't have the same path

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -15,6 +15,15 @@ class OutputFacade(
 ) {
     private val reports: Map<String, ReportsSpec.Report> = settings.spec.reportsSpec.reports.associateBy { it.type }
 
+    init {
+        reports.values.groupBy { it.path }
+            .forEach { (path: Path, reports: List<ReportsSpec.Report>) ->
+                check(reports.count() == 1) {
+                    "The path $path is defined in multiple reports: ${reports.map { it.type }}"
+                }
+            }
+    }
+
     fun run(result: Detektion) {
         // Always run output reports first.
         // They produce notifications which may get printed on the console.


### PR DESCRIPTION
This PR implements this request by @3flex on another PR:

> With these changes (which I support!) is there a need to check that the same output path isn't used for multiple reports?
> 
> Maybe that check should have been in there anyway. But just thinking if someone has a checkstyle report with xml extension and adds a custom report with xml extension with the same output path it will be a bit easier to accidentally write to the same path twice.
> 
> Can be a separate PR, just asking as you're in the code at the moment so might have the answers.

_Originally posted by @3flex in https://github.com/detekt/detekt/issues/8595#issuecomment-3272589050_
            