### PR TITLE
Add `max_line_length` in the `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 [*]
 insert_final_newline = true
+max_line_length = 120
 
 [*.{kt, groovy}]
 indent_style = space


### PR DESCRIPTION
This adds the line width so that IDEs doesn't indent the line to multi-line when not required

In case of AS, by default this value is configured to be 100 while in case of Intellije platform it's value is 120. Detekt goes with 120. Adding this prop will ensure that all the IDE considers same 120 value
Context: https://github.com/detekt/detekt/pull/8513#discussion_r2334147345 where AS is indenting the code to multi lines
