### PR TITLE
Delete unused `bindingContext` using methods for `firstParameter`

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -50,8 +50,6 @@ public final class dev/detekt/psi/KtFilesKt {
 public final class dev/detekt/psi/KtLambdaExpressionKt {
 	public static final fun firstParameterOrNull (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;)Lorg/jetbrains/kotlin/analysis/api/symbols/KaValueParameterSymbol;
 	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;)Z
-	public static final fun hasImplicitParameterReference (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;Lorg/jetbrains/kotlin/resolve/BindingContext;)Z
-	public static final fun implicitParameter (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;Lorg/jetbrains/kotlin/resolve/BindingContext;)Lorg/jetbrains/kotlin/descriptors/ValueParameterDescriptor;
 	public static final fun implicitParameterOrNull (Lorg/jetbrains/kotlin/psi/KtLambdaExpression;)Lorg/jetbrains/kotlin/analysis/api/symbols/KaValueParameterSymbol;
 }
 

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/KtLambdaExpression.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/KtLambdaExpression.kt
@@ -2,28 +2,14 @@ package dev.detekt.psi
 
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
-import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
-import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
-
-private fun KtLambdaExpression.firstParameter(bindingContext: BindingContext) =
-    bindingContext[BindingContext.FUNCTION, functionLiteral]?.valueParameters?.singleOrNull()
 
 fun KtLambdaExpression.firstParameterOrNull(): KaValueParameterSymbol? = analyze(this) {
     functionLiteral.symbol.valueParameters.singleOrNull()
 }
-
-fun KtLambdaExpression.implicitParameter(bindingContext: BindingContext): ValueParameterDescriptor? =
-    if (valueParameters.isNotEmpty()) {
-        null
-    } else {
-        firstParameter(bindingContext)
-    }
 
 fun KtLambdaExpression.implicitParameterOrNull(): KaValueParameterSymbol? =
     if (valueParameters.isNotEmpty()) {
@@ -31,23 +17,6 @@ fun KtLambdaExpression.implicitParameterOrNull(): KaValueParameterSymbol? =
     } else {
         firstParameterOrNull()
     }
-
-fun KtLambdaExpression.hasImplicitParameterReference(
-    implicitParameter: ValueParameterDescriptor,
-    bindingContext: BindingContext,
-): Boolean =
-    anyDescendantOfType<KtNameReferenceExpression> {
-        it.isImplicitParameterReference(this, implicitParameter, bindingContext)
-    }
-
-private fun KtNameReferenceExpression.isImplicitParameterReference(
-    lambda: KtLambdaExpression,
-    implicitParameter: ValueParameterDescriptor,
-    bindingContext: BindingContext,
-): Boolean =
-    text == "it" &&
-        getStrictParentOfType<KtLambdaExpression>() == lambda &&
-        getResolvedCall(bindingContext)?.resultingDescriptor == implicitParameter
 
 fun KtLambdaExpression.hasImplicitParameterReference(): Boolean {
     if (valueParameters.isNotEmpty()) return false


### PR DESCRIPTION
This is unused and meant to be deleted after https://github.com/detekt/detekt/pull/8513 got merged and discussed in https://github.com/detekt/detekt/pull/8513#discussion_r2303776885
