### PR TITLE
Add boolean to know in AnnotationExcluder if we have analysis api enabled

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
@@ -16,6 +16,7 @@ import dev.detekt.core.suppressors.buildSuppressors
 import dev.detekt.core.suppressors.isSuppressedBy
 import dev.detekt.core.util.shouldAnalyzeFile
 import dev.detekt.psi.absolutePath
+import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.config.languageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile
@@ -99,7 +100,8 @@ internal class Analyzer(
 }
 
 private fun List<Finding>.filterSuppressedFindings(rule: Rule, bindingContext: BindingContext): List<Finding> {
-    val suppressors = buildSuppressors(rule, bindingContext, bindingContext != BindingContext.EMPTY)
+    val analysisMode = if (bindingContext == BindingContext.EMPTY) AnalysisMode.light else AnalysisMode.full
+    val suppressors = buildSuppressors(rule, bindingContext, analysisMode)
     return if (suppressors.isNotEmpty()) {
         filter { finding -> !suppressors.any { suppressor -> suppressor.shouldSuppress(finding) } }
     } else {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
@@ -99,7 +99,7 @@ internal class Analyzer(
 }
 
 private fun List<Finding>.filterSuppressedFindings(rule: Rule, bindingContext: BindingContext): List<Finding> {
-    val suppressors = buildSuppressors(rule, bindingContext)
+    val suppressors = buildSuppressors(rule, bindingContext, bindingContext != BindingContext.EMPTY)
     return if (suppressors.isNotEmpty()) {
         filter { finding -> !suppressors.any { suppressor -> suppressor.shouldSuppress(finding) } }
     } else {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -13,14 +13,14 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * @config ignoreAnnotated: List<String> The annotations can be defined just by its name or with its fully qualified
  * name. If you don't run detekt with type solving the fully qualified name does not work.
  */
-internal fun annotationSuppressorFactory(rule: Rule): Suppressor? {
+internal fun annotationSuppressorFactory(rule: Rule, analysisApi: Boolean): Suppressor? {
     val annotations = rule.config.valueOrDefault("ignoreAnnotated", emptyList<String>()).map {
         it.qualifiedNameGlobToRegex()
     }
     return if (annotations.isNotEmpty()) {
         Suppressor { finding ->
             val element = finding.entity.ktElement
-            element.isAnnotatedWith(AnnotationExcluder(element.containingKtFile, annotations))
+            element.isAnnotatedWith(AnnotationExcluder(element.containingKtFile, annotations, analysisApi))
         }
     } else {
         null

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -2,6 +2,7 @@ package dev.detekt.core.suppressors
 
 import dev.detekt.api.Rule
 import dev.detekt.psi.AnnotationExcluder
+import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
@@ -13,14 +14,16 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  * @config ignoreAnnotated: List<String> The annotations can be defined just by its name or with its fully qualified
  * name. If you don't run detekt with type solving the fully qualified name does not work.
  */
-internal fun annotationSuppressorFactory(rule: Rule, analysisApi: Boolean): Suppressor? {
+internal fun annotationSuppressorFactory(rule: Rule, analysisMode: AnalysisMode): Suppressor? {
     val annotations = rule.config.valueOrDefault("ignoreAnnotated", emptyList<String>()).map {
         it.qualifiedNameGlobToRegex()
     }
     return if (annotations.isNotEmpty()) {
         Suppressor { finding ->
             val element = finding.entity.ktElement
-            element.isAnnotatedWith(AnnotationExcluder(element.containingKtFile, annotations, analysisApi))
+            element.isAnnotatedWith(
+                AnnotationExcluder(element.containingKtFile, annotations, analysisMode == AnalysisMode.full),
+            )
         }
     } else {
         null

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/Suppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/Suppressor.kt
@@ -11,8 +11,8 @@ fun interface Suppressor {
     fun shouldSuppress(finding: Finding): Boolean
 }
 
-internal fun buildSuppressors(rule: Rule, bindingContext: BindingContext): List<Suppressor> =
+internal fun buildSuppressors(rule: Rule, bindingContext: BindingContext, analysisApi: Boolean): List<Suppressor> =
     listOfNotNull(
-        annotationSuppressorFactory(rule),
+        annotationSuppressorFactory(rule, analysisApi),
         functionSuppressorFactory(rule, bindingContext),
     )

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/Suppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/Suppressor.kt
@@ -2,6 +2,7 @@ package dev.detekt.core.suppressors
 
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
+import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.resolve.BindingContext
 
 fun interface Suppressor {
@@ -11,8 +12,11 @@ fun interface Suppressor {
     fun shouldSuppress(finding: Finding): Boolean
 }
 
-internal fun buildSuppressors(rule: Rule, bindingContext: BindingContext, analysisApi: Boolean): List<Suppressor> =
-    listOfNotNull(
-        annotationSuppressorFactory(rule, analysisApi),
-        functionSuppressorFactory(rule, bindingContext),
-    )
+internal fun buildSuppressors(
+    rule: Rule,
+    bindingContext: BindingContext,
+    analysisMode: AnalysisMode,
+): List<Suppressor> = listOfNotNull(
+    annotationSuppressorFactory(rule, analysisMode),
+    functionSuppressorFactory(rule, bindingContext),
+)

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class AnnotationSuppressorSpec {
@@ -21,7 +22,7 @@ class AnnotationSuppressorSpec {
     inner class AnnotationSuppressorFactory {
         @Test
         fun `Factory returns null if ignoreAnnotated is not set`() {
-            val suppressor = annotationSuppressorFactory(buildRule())
+            val suppressor = annotationSuppressorFactory(buildRule(), true)
 
             assertThat(suppressor).isNull()
         }
@@ -30,6 +31,7 @@ class AnnotationSuppressorSpec {
         fun `Factory returns null if ignoreAnnotated is set to empty`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to emptyList<String>()),
+                true,
             )
 
             assertThat(suppressor).isNull()
@@ -39,6 +41,7 @@ class AnnotationSuppressorSpec {
         fun `Factory returns not null if ignoreAnnotated is set to a not empty list`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Composable")),
+                true,
             )
 
             assertThat(suppressor).isNotNull()
@@ -49,6 +52,7 @@ class AnnotationSuppressorSpec {
     inner class AnnotationSuppressor {
         val suppressor = annotationSuppressorFactory(
             buildRule("ignoreAnnotated" to listOf("Composable")),
+            false,
         )!!
 
         @Test
@@ -305,14 +309,17 @@ class AnnotationSuppressorSpec {
             """.trimIndent()
 
             fun getFile() = listOf(
-                compileContentForTest(code),
-                KotlinAnalysisApiEngine.compile(code, composableFiles)
+                Arguments.of(compileContentForTest(code), false),
+                Arguments.of(KotlinAnalysisApiEngine.compile(code, composableFiles), true),
             )
 
             @ParameterizedTest
             @MethodSource("getFile")
-            fun `Just name`(root: KtFile) {
-                val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("Composable")))!!
+            fun `Just name`(root: KtFile, analysisApi: Boolean) {
+                val suppressor = annotationSuppressorFactory(
+                    buildRule("ignoreAnnotated" to listOf("Composable")),
+                    analysisApi,
+                )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -321,9 +328,10 @@ class AnnotationSuppressorSpec {
 
             @ParameterizedTest
             @MethodSource("getFile")
-            fun `Full qualified name name`(root: KtFile) {
+            fun `Full qualified name name`(root: KtFile, analysisApi: Boolean) {
                 val suppressor = annotationSuppressorFactory(
                     buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
+                    analysisApi,
                 )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -334,8 +342,11 @@ class AnnotationSuppressorSpec {
             @ParameterizedTest
             @MethodSource("getFile")
             @DisplayName("with glob doesn't match because * doesn't match .")
-            fun withGlobDoesntMatch(root: KtFile) {
-                val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("*.Composable")))!!
+            fun withGlobDoesntMatch(root: KtFile, analysisApi: Boolean) {
+                val suppressor = annotationSuppressorFactory(
+                    buildRule("ignoreAnnotated" to listOf("*.Composable")),
+                    analysisApi,
+                )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -344,8 +355,11 @@ class AnnotationSuppressorSpec {
 
             @ParameterizedTest
             @MethodSource("getFile")
-            fun `With glob2`(root: KtFile) {
-                val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("**.Composable")))!!
+            fun `With glob2`(root: KtFile, analysisApi: Boolean) {
+                val suppressor = annotationSuppressorFactory(
+                    buildRule("ignoreAnnotated" to listOf("**.Composable")),
+                    analysisApi,
+                )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -354,8 +368,11 @@ class AnnotationSuppressorSpec {
 
             @ParameterizedTest
             @MethodSource("getFile")
-            fun `With glob3`(root: KtFile) {
-                val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("Compo*")))!!
+            fun `With glob3`(root: KtFile, analysisApi: Boolean) {
+                val suppressor = annotationSuppressorFactory(
+                    buildRule("ignoreAnnotated" to listOf("Compo*")),
+                    analysisApi,
+                )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -364,8 +381,11 @@ class AnnotationSuppressorSpec {
 
             @ParameterizedTest
             @MethodSource("getFile")
-            fun `With glob4`(root: KtFile) {
-                val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("*")))!!
+            fun `With glob4`(root: KtFile, analysisApi: Boolean) {
+                val suppressor = annotationSuppressorFactory(
+                    buildRule("ignoreAnnotated" to listOf("*")),
+                    analysisApi,
+                )!!
 
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -377,6 +397,7 @@ class AnnotationSuppressorSpec {
         fun `Doesn't mix annotations`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
+                true,
             )!!
 
             val root = KotlinAnalysisApiEngine.compile(
@@ -397,6 +418,7 @@ class AnnotationSuppressorSpec {
         fun `Works when no using imports`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
+                true,
             )!!
 
             val root = KotlinAnalysisApiEngine.compile(
@@ -417,6 +439,7 @@ class AnnotationSuppressorSpec {
         fun `Works when using import alias`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
+                true,
             )!!
 
             val root = KotlinAnalysisApiEngine.compile(
@@ -462,7 +485,10 @@ class AnnotationSuppressorSpec {
 
         @Test
         fun `suppress if it has parameters with type solving`() {
-            val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("Preview")))!!
+            val suppressor = annotationSuppressorFactory(
+                buildRule("ignoreAnnotated" to listOf("Preview")),
+                true,
+            )!!
 
             val root = KotlinAnalysisApiEngine.compile(code, composableFiles)
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
@@ -472,7 +498,7 @@ class AnnotationSuppressorSpec {
 
         @Test
         fun `suppress if it has parameters without type solving`() {
-            val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("Preview")))!!
+            val suppressor = annotationSuppressorFactory(buildRule("ignoreAnnotated" to listOf("Preview")), false)!!
 
             val ktFunction = compileContentForTest(code).findChildByClass(KtFunction::class.java)!!
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
@@ -6,6 +6,7 @@ import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.test.TestConfig
 import dev.detekt.test.utils.compileContentForTest
+import dev.detekt.tooling.api.AnalysisMode
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.junit.jupiter.api.Test
@@ -35,7 +36,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, BindingContext.EMPTY, false)
+        val suppress = buildSuppressors(rule, BindingContext.EMPTY, AnalysisMode.light)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableFinding) }
 
         assertThat(suppress).isFalse()
@@ -44,7 +45,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should not be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, BindingContext.EMPTY, false)
+        val suppress = buildSuppressors(rule, BindingContext.EMPTY, AnalysisMode.light)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableFinding) }
 
         assertThat(suppress).isTrue()

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
@@ -35,7 +35,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, BindingContext.EMPTY)
+        val suppress = buildSuppressors(rule, BindingContext.EMPTY, false)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableFinding) }
 
         assertThat(suppress).isFalse()
@@ -44,7 +44,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should not be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, BindingContext.EMPTY)
+        val suppress = buildSuppressors(rule, BindingContext.EMPTY, false)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableFinding) }
 
         assertThat(suppress).isTrue()

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -3,7 +3,7 @@ public final class dev/detekt/psi/AllowedExceptionNamePatternKt {
 }
 
 public final class dev/detekt/psi/AnnotationExcluder {
-	public fun <init> (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;)V
+	public fun <init> (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/util/List;Z)V
 	public final fun shouldExclude (Ljava/util/List;)Z
 }
 

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/AnnotationExcluder.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/AnnotationExcluder.kt
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 class AnnotationExcluder(
     root: KtFile,
     private val excludes: List<Regex>,
-    private val analysisApi: Boolean,
+    private val fullAnalysis: Boolean,
 ) {
 
     private val fullQualifiedNameGuesser = FullQualifiedNameGuesser(root)
@@ -28,7 +28,7 @@ class AnnotationExcluder(
         annotations.any { annotation -> annotation.typeReference?.let { isExcluded(it) } ?: false }
 
     private fun isExcluded(annotation: KtTypeReference): Boolean {
-        val fqName = if (analysisApi) annotation.fqNameOrNull() else null
+        val fqName = if (fullAnalysis) annotation.fqNameOrNull() else null
         val possibleNames = if (fqName == null) {
             fullQualifiedNameGuesser.getFullQualifiedName(annotation.text.toString())
                 .map { it.getPackage() to it }

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
@@ -20,7 +20,7 @@ class AnnotationExcluderSpec {
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation, enableAnalysisApi = false)
-        val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()))
+        val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), false)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
     }
@@ -31,7 +31,7 @@ class AnnotationExcluderSpec {
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases - AnalysisAPI`(exclusion: String, annotation: String, shouldExclude: Boolean) {
         val (file, ktAnnotation) = createKtFile(annotation, enableAnalysisApi = true)
-        val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()))
+        val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), true)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
     }
@@ -41,7 +41,7 @@ class AnnotationExcluderSpec {
         @Test
         fun `should not exclude when the annotation was not found`() {
             val (file, ktAnnotation) = createKtFile("@Component", enableAnalysisApi = false)
-            val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()))
+            val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
         }
@@ -49,7 +49,7 @@ class AnnotationExcluderSpec {
         @Test
         fun `should not exclude when no annotations should be excluded`() {
             val (file, ktAnnotation) = createKtFile("@Component", enableAnalysisApi = false)
-            val excluder = AnnotationExcluder(file, emptyList())
+            val excluder = AnnotationExcluder(file, emptyList(), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
         }
@@ -57,7 +57,7 @@ class AnnotationExcluderSpec {
         @Test
         fun `should also exclude an annotation that is not imported`() {
             val (file, ktAnnotation) = createKtFile("@SinceKotlin", enableAnalysisApi = false)
-            val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()))
+            val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
         }
@@ -72,7 +72,7 @@ class AnnotationExcluderSpec {
             @Test
             fun `incorrect without Analysis API`() {
                 val (file, ktAnnotation) = createKtFile("@Deprecated", enableAnalysisApi = false)
-                val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), false)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
             }
@@ -80,7 +80,7 @@ class AnnotationExcluderSpec {
             @Test
             fun `correct with Analysis API`() {
                 val (file, ktAnnotation) = createKtFile("@Deprecated(\"\")", enableAnalysisApi = true)
-                val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), true)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
             }
@@ -106,7 +106,7 @@ class AnnotationExcluderSpec {
             fun `incorrect without Analysis API`() {
                 val file = compileContentForTest(code)
                 val ktAnnotation = file.annotationEntry()
-                val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), false)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
             }
@@ -116,7 +116,7 @@ class AnnotationExcluderSpec {
             fun `correct with Analysis API`() {
                 val file = KotlinAnalysisApiEngine.compile(code, listOf(helloWorldAnnotationsCode))
                 val ktAnnotation = file.annotationEntry()
-                val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), true)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
             }
@@ -142,11 +142,11 @@ class AnnotationExcluderSpec {
             fun `incorrect without Analysis API`() {
                 val file = compileContentForTest(file)
                 val ktAnnotation = file.annotationEntry()
-                val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), false)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
 
-                val excluder2 = AnnotationExcluder(file, listOf("com\\.hello\\.World".toRegex()))
+                val excluder2 = AnnotationExcluder(file, listOf("com\\.hello\\.World".toRegex()), false)
 
                 assertThat(excluder2.shouldExclude(listOf(ktAnnotation))).isTrue()
             }
@@ -155,11 +155,11 @@ class AnnotationExcluderSpec {
             fun `correct with Analysis API`() {
                 val file = KotlinAnalysisApiEngine.compile(file, listOf(helloWorldAnnotationsKtFile))
                 val ktAnnotation = file.annotationEntry()
-                val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()))
+                val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), true)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
 
-                val excluder2 = AnnotationExcluder(file, listOf("com\\.hello\\.World".toRegex()))
+                val excluder2 = AnnotationExcluder(file, listOf("com\\.hello\\.World".toRegex()), true)
 
                 assertThat(excluder2.shouldExclude(listOf(ktAnnotation))).isTrue()
             }

--- a/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/LongParameterList.kt
+++ b/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/LongParameterList.kt
@@ -57,7 +57,7 @@ class LongParameterList(config: Config) :
     private lateinit var annotationExcluder: AnnotationExcluder
 
     override fun visitKtFile(file: KtFile) {
-        annotationExcluder = AnnotationExcluder(file, ignoreAnnotatedParameter)
+        annotationExcluder = AnnotationExcluder(file, ignoreAnnotatedParameter, true)
         super.visitKtFile(file)
     }
 


### PR DESCRIPTION
Fixes #8458

This will be also needed to finish #8654 because that suppressor doesn't work without AnalysisApi.

cc @marschwar