### PR TITLE
Make code more type-safe - Report paths

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -3,18 +3,13 @@ package dev.detekt.core.reporting
 import dev.detekt.api.Detektion
 import dev.detekt.api.Notification
 import dev.detekt.api.Notification.Level
-import dev.detekt.api.getOrNull
 import dev.detekt.core.ProcessingSettings
 import dev.detekt.tooling.api.spec.ReportsSpec
 
 class OutputFacade(
     private val settings: ProcessingSettings,
 ) {
-
-    private val reports: Map<String, ReportsSpec.Report> =
-        settings.getOrNull<Collection<ReportsSpec.Report>>(DETEKT_OUTPUT_REPORT_PATHS_KEY)
-            ?.associateBy { it.type }
-            .orEmpty()
+    private val reports: Map<String, ReportsSpec.Report> = settings.spec.reportsSpec.reports.associateBy { it.type }
 
     fun run(result: Detektion) {
         // Always run output reports first.

--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/Reporting.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/Reporting.kt
@@ -21,8 +21,6 @@ internal fun printIssues(issues: Map<String, List<Issue>>, basePath: Path): Stri
         }
     }
 
-const val DETEKT_OUTPUT_REPORT_PATHS_KEY = "detekt.output.report.paths.key"
-
 private const val REPORT_MESSAGE_SIZE_LIMIT = 80
 private val messageReplacementRegex = Regex("\\s+")
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
@@ -10,7 +10,6 @@ import dev.detekt.core.config.DisabledAutoCorrectConfig
 import dev.detekt.core.config.YamlConfig
 import dev.detekt.core.config.validation.DeprecatedRule
 import dev.detekt.core.config.validation.loadDeprecations
-import dev.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
 import dev.detekt.core.util.MONITOR_PROPERTY_KEY
 import dev.detekt.core.util.PerformanceMonitor
 import dev.detekt.core.util.PerformanceMonitor.Phase
@@ -27,7 +26,6 @@ internal fun <R> ProcessingSpec.withSettings(execute: ProcessingSettings.() -> R
             baselineSpec.path?.let { register(DETEKT_BASELINE_PATH_KEY, it) }
             register(DETEKT_BASELINE_CREATION_KEY, baselineSpec.shouldCreateDuringAnalysis)
             register(MONITOR_PROPERTY_KEY, monitor)
-            register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportsSpec.reports)
         }
     }
     val result = settings.use { execute(it) }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/ProcessingSettingsFactory.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/ProcessingSettingsFactory.kt
@@ -1,7 +1,6 @@
 package dev.detekt.core
 
 import dev.detekt.api.Config
-import dev.detekt.core.reporting.DETEKT_OUTPUT_REPORT_PATHS_KEY
 import dev.detekt.test.utils.NullPrintStream
 import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.tooling.api.spec.ProcessingSpec
@@ -41,11 +40,12 @@ fun createProcessingSettings(
         execution {
             executorService = DirectExecutor() // run in the same thread
         }
+        reports {
+            reports.addAll(reportPaths)
+        }
         init.invoke(this)
     }
-    return ProcessingSettings(spec, config).apply {
-        register(DETEKT_OUTPUT_REPORT_PATHS_KEY, reportPaths)
-    }
+    return ProcessingSettings(spec, config)
 }
 
 fun createNullLoggingSpec(


### PR DESCRIPTION
We were registering the report paths as a property when we have direct access to the variable itself.