### PR TITLE
 Make code more type-safe - Performance Monitor

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
@@ -11,6 +11,7 @@ import dev.detekt.core.settings.ExtensionFacade
 import dev.detekt.core.settings.LoggingAware
 import dev.detekt.core.settings.LoggingFacade
 import dev.detekt.core.settings.PropertiesFacade
+import dev.detekt.core.util.PerformanceMonitor
 import dev.detekt.tooling.api.spec.ConfigSpec
 import dev.detekt.tooling.api.spec.ProcessingSpec
 import org.jetbrains.kotlin.utils.closeQuietly
@@ -30,6 +31,7 @@ import java.nio.file.Path
 class ProcessingSettings(
     val spec: ProcessingSpec,
     override val config: Config,
+    val monitor: PerformanceMonitor,
 ) : AutoCloseable,
     Closeable,
     LoggingAware by LoggingFacade(spec.loggingSpec),

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -13,7 +13,6 @@ import dev.detekt.core.getRules
 import dev.detekt.core.reporting.OutputFacade
 import dev.detekt.core.rules.createRuleProviders
 import dev.detekt.core.util.PerformanceMonitor.Phase
-import dev.detekt.core.util.getOrCreateMonitor
 import dev.detekt.parser.DetektMessageCollector
 import dev.detekt.parser.GenerateBindingContextOptions
 import dev.detekt.parser.generateBindingContext
@@ -35,7 +34,7 @@ internal interface Lifecycle {
     val processorsProvider: () -> List<FileProcessListener>
     val ruleSetsProvider: () -> List<RuleSetProvider>
 
-    private fun <R> measure(phase: Phase, block: () -> R): R = settings.getOrCreateMonitor().measure(phase, block)
+    private fun <R> measure(phase: Phase, block: () -> R): R = settings.monitor.measure(phase, block)
 
     fun analyze(): Detektion {
         measure(Phase.ValidateConfig) { checkConfiguration(settings, baselineConfig) }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
@@ -10,7 +10,6 @@ import dev.detekt.core.config.DisabledAutoCorrectConfig
 import dev.detekt.core.config.YamlConfig
 import dev.detekt.core.config.validation.DeprecatedRule
 import dev.detekt.core.config.validation.loadDeprecations
-import dev.detekt.core.util.MONITOR_PROPERTY_KEY
 import dev.detekt.core.util.PerformanceMonitor
 import dev.detekt.core.util.PerformanceMonitor.Phase
 import dev.detekt.tooling.api.spec.ProcessingSpec
@@ -22,10 +21,9 @@ internal fun <R> ProcessingSpec.withSettings(execute: ProcessingSettings.() -> R
         workaroundConfiguration(loadConfiguration())
     }
     val settings = monitor.measure(Phase.CreateSettings) {
-        ProcessingSettings(this, configuration).apply {
+        ProcessingSettings(this, configuration, monitor).apply {
             baselineSpec.path?.let { register(DETEKT_BASELINE_PATH_KEY, it) }
             register(DETEKT_BASELINE_CREATION_KEY, baselineSpec.shouldCreateDuringAnalysis)
-            register(MONITOR_PROPERTY_KEY, monitor)
         }
     }
     val result = settings.use { execute(it) }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/util/PerformanceMonitor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/util/PerformanceMonitor.kt
@@ -1,7 +1,5 @@
 package dev.detekt.core.util
 
-import dev.detekt.api.PropertiesAware
-import dev.detekt.api.getOrNull
 import kotlin.time.Duration
 import kotlin.time.measureTimedValue
 
@@ -30,8 +28,3 @@ class PerformanceMonitor {
         return timedBlockExecution.value
     }
 }
-
-internal const val MONITOR_PROPERTY_KEY = "detekt.core.monitor"
-
-internal fun PropertiesAware.getOrCreateMonitor() =
-    getOrNull(MONITOR_PROPERTY_KEY) ?: PerformanceMonitor().also { register(MONITOR_PROPERTY_KEY, it) }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/ProcessingSettingsFactory.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/ProcessingSettingsFactory.kt
@@ -1,6 +1,7 @@
 package dev.detekt.core
 
 import dev.detekt.api.Config
+import dev.detekt.core.util.PerformanceMonitor
 import dev.detekt.test.utils.NullPrintStream
 import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.tooling.api.spec.ProcessingSpec
@@ -45,7 +46,7 @@ fun createProcessingSettings(
         }
         init.invoke(this)
     }
-    return ProcessingSettings(spec, config)
+    return ProcessingSettings(spec, config, PerformanceMonitor())
 }
 
 fun createNullLoggingSpec(


### PR DESCRIPTION
We can pass it as a normal property instead of using a non-type-safe api