### PR TITLE
Fix duplication strategy for shadow jar

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -57,7 +57,11 @@ publishing {
 
 tasks {
     shadowJar {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
         mergeServiceFiles()
+        filesMatching("META-INF/services/**") {
+            duplicatesStrategy = DuplicatesStrategy.INCLUDE
+        }
     }
 
     shadowDistZip {


### PR DESCRIPTION
Fixes #8667 

### Context
When using a resource transformer like `mergeServiceFiles()`, the duplication strategy takes precedence and has to be configured explicitly. With shadow 9.0.1 the default exclusion strategy was changed to EXCLUDE which means, that essentially no merge was happening.

see https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy

### How to test

Run these commands on main branch and on pr branch:

```bash
rm -rf detekt-cli/build/libs && ./gradlew publishToMavenLocal --info --no-build-cache
cd detekt-cli/build
jar -xf libs/detekt-cli-2.0.0-alpha.0-all.jar && cat META-INF/services/dev.detekt.api.RuleSetProvider
```

I do not have an idea how we could check the packaging as part of the pipeline.