### PR TITLE
Remove explicit config used to enable reproducible builds

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -11,11 +11,6 @@ plugins {
     id("jacoco")
 }
 
-tasks.withType<AbstractArchiveTask>().configureEach {
-    isPreserveFileTimestamps = false
-    isReproducibleFileOrder = true
-}
-
 val versionCatalog = versionCatalogs.named("libs")
 
 jacoco.toolVersion = versionCatalog.findVersion("jacoco").get().requiredVersion


### PR DESCRIPTION
This is default in Gradle 9.0.0:
https://docs.gradle.org/9.0.0/release-notes.html#archive-tasks-produce-reproducible-archives-by-default

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
