### PR TITLE
Add missing configureEach when configuring detekt task defaults

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/SharedTasks.kt
@@ -11,7 +11,7 @@ import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.jvm.toolchain.JavaToolchainService
 
 internal fun Project.setDetektTaskDefaults(extension: DetektExtension) {
-    tasks.withType(Detekt::class.java) {
+    tasks.withType(Detekt::class.java).configureEach {
         project.plugins.withType(JavaBasePlugin::class.java) { _ ->
             val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
 
@@ -42,7 +42,7 @@ internal fun Project.setDetektTaskDefaults(extension: DetektExtension) {
 }
 
 internal fun Project.setCreateBaselineTaskDefaults(extension: DetektExtension) {
-    tasks.withType(DetektCreateBaselineTask::class.java) {
+    tasks.withType(DetektCreateBaselineTask::class.java).configureEach {
         project.plugins.withType(JavaBasePlugin::class.java) { _ ->
             val toolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
 


### PR DESCRIPTION
Avoids creation of ~400 tasks during Gradle's configuration phase in the detekt build.