### PR TITLE
remove suppression

### DIFF
--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/CheckConfigurationSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/CheckConfigurationSpec.kt
@@ -16,11 +16,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 
-class CheckConfigurationSpec {
+class CheckConfigurationSpec(@param:TempDir private val testDir: Path) {
 
-    @TempDir
-    @Suppress("VarCouldBeVal")
-    private lateinit var testDir: Path
     private val spec = createNullLoggingSpec {}
 
     @Test


### PR DESCRIPTION
As a follow up to [this comment](https://github.com/detekt/detekt/pull/8725#discussion_r2405425555) it replaces the `lateinit var` with a constructor parameter.