### PR TITLE
[Fix `main`] Add missing dependency

### DIFF
--- a/detekt-test-assertj/build.gradle.kts
+++ b/detekt-test-assertj/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     compileOnly(libs.assertj.core)
 
     testImplementation(testFixtures(projects.detektApi))
+    testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
     testImplementation(libs.opentest4j)
 }


### PR DESCRIPTION
#8515 broke `main`. This PR solves that.