### PR TITLE
Rename report id `xml` to `checkstyle`

### DIFF
--- a/config/detekt/argsfile
+++ b/config/detekt/argsfile
@@ -10,7 +10,7 @@
 -r
 html:./build/detekt-report.html
 -r
-xml:./build/detekt-report.xml
+checkstyle:./build/detekt-report.xml
 -r
 sarif:./build/detekt-report.sarif
 -bp


### PR DESCRIPTION
Fixes: https://github.com/detekt/detekt/issues/8779
