### PR TITLE
Update `getPropertyAccessorSymbol` method to correctly return getter …

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
@@ -16,7 +16,9 @@ import org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall
 import org.jetbrains.kotlin.analysis.api.resolution.KaCompoundAccessCall
 import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaPropertyAccessorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaPropertySymbol
+import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
@@ -25,7 +27,6 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
 import org.jetbrains.kotlin.psi.KtPostfixExpression
 import org.jetbrains.kotlin.psi.KtPrefixExpression
-import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.isDotSelector
 import org.jetbrains.kotlin.resolve.calls.util.asCallableReferenceExpression
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
@@ -154,9 +155,13 @@ class ForbiddenMethodCall(config: Config) :
     internal data class ForbiddenMethod(val value: FunctionMatcher, val reason: String?)
 }
 
-private fun getPropertyAccessorSymbol(appliedSymbol: KaPropertySymbol, expression: KtExpression) =
-    when (expression.parent) {
-        is KtBinaryExpression -> appliedSymbol.setter
-        is KtProperty -> appliedSymbol.getter
-        else -> null
+private fun getPropertyAccessorSymbol(
+    appliedSymbol: KaPropertySymbol,
+    expression: KtExpression,
+): KaPropertyAccessorSymbol? {
+    val parent = expression.parent
+    return when {
+        parent is KtBinaryExpression && parent.operationToken == KtTokens.EQ -> appliedSymbol.setter
+        else -> appliedSymbol.getter
     }
+}

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenMethodCallSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenMethodCallSpec.kt
@@ -662,6 +662,48 @@ class ForbiddenMethodCallSpec(val env: KotlinEnvironmentContainer) {
         }
 
         @Test
+        fun `should report property getters call used without property`() {
+            val code = """
+                fun foo() = run {
+                    val calendar = java.util.Calendar.getInstance()
+                    calendar.firstDayOfWeek
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(
+                TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
+            ).lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `should not report property getters call with binary expression when setter is configured`() {
+            val code = """
+                fun foo() = run {
+                    val calendar = java.util.Calendar.getInstance()
+                    calendar.firstDayOfWeek * 2
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(
+                TestConfig(METHODS to listOf("java.util.Calendar.setFirstDayOfWeek"))
+            ).lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should report property getters call with binary expression`() {
+            val code = """
+                fun foo() = run {
+                    val calendar = java.util.Calendar.getInstance()
+                    calendar.firstDayOfWeek * 2
+                }
+            """.trimIndent()
+            val findings = ForbiddenMethodCall(
+                TestConfig(METHODS to listOf("java.util.Calendar.getFirstDayOfWeek"))
+            ).lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
         fun `should report property getter and setter call`() {
             val code = """
                 import java.util.Calendar


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/8786