### PR TITLE
Extend `AbstractClassCanBeInterface` for sealed classes

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/FailurePolicies.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/FailurePolicies.kt
@@ -11,9 +11,9 @@ internal fun RulesSpec.FailurePolicy.check(result: Detektion): FailurePolicyResu
         is RulesSpec.FailurePolicy.FailOnSeverity -> result.checkForIssuesWithSeverity(minSeverity)
     }
 
-sealed class FailurePolicyResult {
-    data object Ok : FailurePolicyResult()
-    data class Fail(val message: String) : FailurePolicyResult()
+sealed interface FailurePolicyResult {
+    data object Ok : FailurePolicyResult
+    data class Fail(val message: String) : FailurePolicyResult
 }
 
 private fun Detektion.checkForIssuesWithSeverity(minSeverity: Severity): FailurePolicyResult {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/validation/Deprecations.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/validation/Deprecations.kt
@@ -3,15 +3,16 @@ package dev.detekt.core.config.validation
 import dev.detekt.utils.openSafeStream
 import java.util.Properties
 
-internal sealed class Deprecation
-internal data class DeprecatedRule(val ruleSetId: String, val ruleName: String, val description: String) : Deprecation()
+internal sealed interface Deprecation
+
+internal data class DeprecatedRule(val ruleSetId: String, val ruleName: String, val description: String) : Deprecation
 
 internal data class DeprecatedProperty(
     val ruleSetId: String,
     val ruleName: String,
     val propertyName: String,
     val description: String,
-) : Deprecation()
+) : Deprecation
 
 internal fun loadDeprecations(): Set<Deprecation> =
     ValidationSettings::class.java.classLoader

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/DefaultActivationStatus.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/DefaultActivationStatus.kt
@@ -2,15 +2,15 @@ package dev.detekt.generator.collection
 
 import dev.detekt.generator.collection.exception.InvalidDocumentationException
 
-sealed class DefaultActivationStatus {
-    abstract val active: Boolean
+sealed interface DefaultActivationStatus {
+    val active: Boolean
 }
 
-data object Inactive : DefaultActivationStatus() {
+data object Inactive : DefaultActivationStatus {
     override val active = false
 }
 
-data class Active(val since: String) : DefaultActivationStatus() {
+data class Active(val since: String) : DefaultActivationStatus {
     override val active = true
 
     init {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -38,23 +38,23 @@ private const val EXPLICIT_API_MODE = "-Xexplicit-api"
  */
 private const val FRIEND_PATHS_PARAMETER = "-Xfriend-paths"
 
-internal sealed class CliArgument {
-    abstract fun toArgument(): List<String>
+internal sealed interface CliArgument {
+    fun toArgument(): List<String>
 }
 
-internal object CreateBaselineArgument : CliArgument() {
+internal object CreateBaselineArgument : CliArgument {
     override fun toArgument() = listOf(CREATE_BASELINE_PARAMETER)
 }
 
-internal data class GenerateConfigArgument(val file: RegularFile) : CliArgument() {
+internal data class GenerateConfigArgument(val file: RegularFile) : CliArgument {
     override fun toArgument() = listOf(GENERATE_CONFIG_PARAMETER, file.asFile.absolutePath)
 }
 
-internal data class InputArgument(val fileCollection: FileCollection) : CliArgument() {
+internal data class InputArgument(val fileCollection: FileCollection) : CliArgument {
     override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
 }
 
-internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument() {
+internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument {
     override fun toArgument() =
         if (!fileCollection.isEmpty) {
             listOf(
@@ -68,27 +68,27 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
         }
 }
 
-internal data class ApiVersionArgument(val apiVersion: String?) : CliArgument() {
+internal data class ApiVersionArgument(val apiVersion: String?) : CliArgument {
     override fun toArgument() = apiVersion?.let { listOf(API_VERSION_PARAMETER, it) }.orEmpty()
 }
 
-internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument() {
+internal data class LanguageVersionArgument(val languageVersion: String?) : CliArgument {
     override fun toArgument() = languageVersion?.let { listOf(LANGUAGE_VERSION_PARAMETER, it) }.orEmpty()
 }
 
-internal data class JvmTargetArgument(val jvmTarget: String?) : CliArgument() {
+internal data class JvmTargetArgument(val jvmTarget: String?) : CliArgument {
     override fun toArgument() = jvmTarget?.let { listOf(JVM_TARGET_PARAMETER, it) }.orEmpty()
 }
 
-internal data class JdkHomeArgument(val jdkHome: DirectoryProperty) : CliArgument() {
+internal data class JdkHomeArgument(val jdkHome: DirectoryProperty) : CliArgument {
     override fun toArgument() = jdkHome.orNull?.let { listOf(JDK_HOME_PARAMETER, it.toString()) }.orEmpty()
 }
 
-internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument() {
+internal data class BaselineArgument(val baseline: RegularFile?) : CliArgument {
     override fun toArgument() = baseline?.let { listOf(BASELINE_PARAMETER, it.asFile.absolutePath) }.orEmpty()
 }
 
-internal data class BaselineArgumentOrEmpty(val baseline: RegularFile?) : CliArgument() {
+internal data class BaselineArgumentOrEmpty(val baseline: RegularFile?) : CliArgument {
     override fun toArgument(): List<String> =
         if (baseline?.asFile?.exists() == true) {
             listOf(BASELINE_PARAMETER, baseline.asFile.absolutePath)
@@ -97,7 +97,7 @@ internal data class BaselineArgumentOrEmpty(val baseline: RegularFile?) : CliArg
         }
 }
 
-internal data class DefaultReportArgument(val report: DetektReport) : CliArgument() {
+internal data class DefaultReportArgument(val report: DetektReport) : CliArgument {
     override fun toArgument(): List<String> =
         if (report.required.get()) {
             listOf(REPORT_PARAMETER, "${report.type.reportId}:${report.outputLocation.get().asFile.absoluteFile}")
@@ -106,15 +106,15 @@ internal data class DefaultReportArgument(val report: DetektReport) : CliArgumen
         }
 }
 
-internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument() {
+internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument {
     override fun toArgument() = listOf(REPORT_PARAMETER, "$reportId:${file.asFile.absolutePath}")
 }
 
-internal data class FreeArgs(val args: List<String>) : CliArgument() {
+internal data class FreeArgs(val args: List<String>) : CliArgument {
     override fun toArgument(): List<String> = args
 }
 
-internal data class FriendPathArgs(val fileCollection: FileCollection) : CliArgument() {
+internal data class FriendPathArgs(val fileCollection: FileCollection) : CliArgument {
     override fun toArgument() =
         if (!fileCollection.isEmpty) {
             listOf(
@@ -126,19 +126,19 @@ internal data class FriendPathArgs(val fileCollection: FileCollection) : CliArgu
         }
 }
 
-internal data class BasePathArgument(val basePath: String?) : CliArgument() {
+internal data class BasePathArgument(val basePath: String?) : CliArgument {
     override fun toArgument() = basePath?.let { listOf(BASE_PATH_PARAMETER, it) }.orEmpty()
 }
 
 internal data class FailOnSeverityArgument(val ignoreFailures: Boolean, val minSeverity: FailOnSeverity) :
-    CliArgument() {
+    CliArgument {
     override fun toArgument(): List<String> {
         val effectiveSeverity = if (ignoreFailures) FailOnSeverity.Never else minSeverity
         return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.toLowerCase(Locale.ROOT))
     }
 }
 
-internal data class ConfigArgument(val files: FileCollection) : CliArgument() {
+internal data class ConfigArgument(val files: FileCollection) : CliArgument {
 
     override fun toArgument() =
         if (files.isEmpty) {
@@ -148,7 +148,7 @@ internal data class ConfigArgument(val files: FileCollection) : CliArgument() {
         }
 }
 
-internal sealed class BoolCliArgument(open val value: Boolean, val configSwitch: String) : CliArgument() {
+internal sealed class BoolCliArgument(open val value: Boolean, val configSwitch: String) : CliArgument {
     override fun toArgument() = if (value) listOf(configSwitch) else emptyList()
 }
 
@@ -166,7 +166,7 @@ internal data class AllRulesArgument(override val value: Boolean) : BoolCliArgum
 
 internal data class AutoCorrectArgument(override val value: Boolean) : BoolCliArgument(value, AUTO_CORRECT_PARAMETER)
 
-internal data class OptInArguments(val list: List<String>) : CliArgument() {
+internal data class OptInArguments(val list: List<String>) : CliArgument {
     override fun toArgument() =
         if (list.isNotEmpty()) {
             listOf(
@@ -180,7 +180,7 @@ internal data class OptInArguments(val list: List<String>) : CliArgument() {
 
 internal data class NoJdkArgument(override val value: Boolean) : BoolCliArgument(value, NO_JDK_PARAMETER)
 
-internal data class ExplicitApiArgument(val mode: String?) : CliArgument() {
+internal data class ExplicitApiArgument(val mode: String?) : CliArgument {
     override fun toArgument() = mode?.let { listOf("$EXPLICIT_API_MODE=$it") }.orEmpty()
 }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -1,6 +1,8 @@
 package dev.detekt.rules.style
 
 import dev.detekt.api.Config
+import dev.detekt.rules.style.AbstractClassCanBeInterface.Companion.NO_CONCRETE_MEMBER
+import dev.detekt.rules.style.AbstractClassCanBeInterface.Companion.SEALED_NO_CONCRETE_MEMBER
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
@@ -14,8 +16,6 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `abstract classes with no concrete members` {
-        val message = "An abstract class without a concrete member can be refactored to an interface."
-
         @Test
         fun `reports an abstract class with no concrete member`() {
             val code = """
@@ -27,7 +27,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)
             assertThat(findings).singleElement()
-                .hasMessage(message)
+                .hasMessage(NO_CONCRETE_MEMBER)
                 .hasStartSourceLocation(1, 16)
         }
 
@@ -38,7 +38,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 val code = "abstract class A"
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
-                    .hasMessage(message)
+                    .hasMessage(NO_CONCRETE_MEMBER)
                     .hasStartSourceLocation(1, 16)
             }
 
@@ -47,7 +47,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 val code = "abstract class A()"
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
-                    .hasMessage(message)
+                    .hasMessage(NO_CONCRETE_MEMBER)
             }
 
             @Test
@@ -55,7 +55,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 val code = "abstract class A {}"
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
-                    .hasMessage(message)
+                    .hasMessage(NO_CONCRETE_MEMBER)
             }
 
             @Test
@@ -63,7 +63,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 val code = "abstract class A() {}"
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
-                    .hasMessage(message)
+                    .hasMessage(NO_CONCRETE_MEMBER)
             }
 
             @Test
@@ -76,7 +76,7 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 """.trimIndent()
                 val findings = subject.lintWithContext(env, code)
                 assertThat(findings).singleElement()
-                    .hasMessage(message)
+                    .hasMessage(NO_CONCRETE_MEMBER)
             }
 
             @Test
@@ -162,13 +162,23 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
+
+        @Test
+        fun `does not report an abstract class containing an internal nested class`() {
+            val code = """
+                abstract class A {
+                    abstract val x: Int
+                    internal class InternalImpl {
+                        val data: Int = 42
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Nested
     inner class `abstract classes with no abstract members` {
-
-        val message = "An abstract class without an abstract member can be refactored to a concrete class."
-
         @Test
         fun `does not report no abstract members in abstract class`() {
             val code = """
@@ -306,6 +316,194 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 abstract class Test(val x: Int) : I
             """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class SealedClasses {
+        @Test
+        fun `report a sealed class with no abstract members`() {
+            val code = """
+                sealed class Result {
+                    data class Success(val data: Int) : Result()
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasMessage(SEALED_NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `don't report a sealed class with constructor params`() {
+            val code = """
+                sealed class Result(val value: Int) {
+                    data class Success(val data: Int) : Result(123)
+                    data class Failure(val reason: String) : Result(456)
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `report a sealed class with only abstract methods`() {
+            val code = """
+                sealed class Result {
+                    abstract fun x()
+                    data class Success(val data: Int) : Result() {
+                        override fun x() = println("success!")
+                    }
+                    data class Failure(val reason: String) : Result() {
+                        override fun x() = println("failure...")
+                    }
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasMessage(SEALED_NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `don't report a sealed class with open methods`() {
+            val code = """
+                sealed class Result {
+                    open fun x() = println("default") 
+                    data class Success(val data: Int) : Result() {
+                        override fun x() = println("success!")
+                    }
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `don't report a sealed class with final methods`() {
+            val code = """
+                sealed class Result {
+                    fun x() = println("final!") 
+                    data class Success(val data: Int) : Result()
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `report a sealed class with only abstract properties`() {
+            val code = """
+                sealed class Result {
+                    abstract val x: Int
+                    data class Success(val data: Int, override val x: Int) : Result()
+                    data class Failure(val reason: String) : Result() {
+                        override val x = 789
+                    }
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasMessage(SEALED_NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `don't report a sealed class with open properties`() {
+            val code = """
+                sealed class Result {
+                    open val x: Int = 123
+                    data class Success(val data: Int, override val x: Int) : Result()
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `don't report a sealed class with only final properties`() {
+            val code = """
+                sealed class Result {
+                    val x: Int = 123
+                    data class Success(val data: Int) : Result()
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `don't report a sealed interface`() {
+            val code = """
+                sealed interface Result {
+                    val x: Int
+                    data class Success(val data: Int, override val x: Int) : Result
+                    data class Failure(val reason: String) : Result {
+                        override val x = 789
+                    }
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        // This would otherwise be flagged by this rule, but Kotlin doesn't allow internal classes declared within an
+        // interface
+        @Test
+        fun `don't report a sealed class containing an internal implementation class`() {
+            val code = """
+                sealed class Result {
+                    internal data class Success(val data: Int) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `don't report a sealed class with abstract properties and an internal nested class`() {
+            val code = """
+                sealed class Result {
+                    abstract val x: Int
+                    internal data class Success(val data: Int, override val x: Int) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `don't report a sealed class with multiple nested classes including an internal one`() {
+            val code = """
+                sealed class Result {
+                    abstract val x: Int
+                    data class Success(val data: Int, override val x: Int) : Result()
+                    internal data class Loading(override val x: Int) : Result()
+                    data class Failure(val reason: String, override val x: Int) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `report a sealed class with only public nested classes`() {
+            val code = """
+                sealed class Result {
+                    abstract val x: Int
+                    data class Success(val data: Int, override val x: Int) : Result()
+                    data class Failure(val reason: String, override val x: Int) : Result()
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings)
+                .singleElement()
+                .hasMessage(SEALED_NO_CONCRETE_MEMBER)
         }
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -178,7 +178,7 @@ public abstract interface class dev/detekt/tooling/api/spec/RulesSpec {
 	public abstract fun getRunPolicy ()Ldev/detekt/tooling/api/spec/RulesSpec$RunPolicy;
 }
 
-public abstract class dev/detekt/tooling/api/spec/RulesSpec$FailurePolicy {
+public abstract interface class dev/detekt/tooling/api/spec/RulesSpec$FailurePolicy {
 }
 
 public final class dev/detekt/tooling/api/spec/RulesSpec$FailurePolicy$FailOnSeverity : dev/detekt/tooling/api/spec/RulesSpec$FailurePolicy {
@@ -199,7 +199,7 @@ public final class dev/detekt/tooling/api/spec/RulesSpec$FailurePolicy$NeverFail
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class dev/detekt/tooling/api/spec/RulesSpec$RunPolicy {
+public abstract interface class dev/detekt/tooling/api/spec/RulesSpec$RunPolicy {
 }
 
 public final class dev/detekt/tooling/api/spec/RulesSpec$RunPolicy$DisableDefaultRuleSets : dev/detekt/tooling/api/spec/RulesSpec$RunPolicy {

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/RulesSpec.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/RulesSpec.kt
@@ -18,17 +18,17 @@ interface RulesSpec {
     /**
      * Policy to decide if detekt throws an error.
      */
-    sealed class FailurePolicy {
+    sealed interface FailurePolicy {
 
         /**
          * Any number of issues is allowed. The build never fails due to detekt issues.
          */
-        data object NeverFail : FailurePolicy()
+        data object NeverFail : FailurePolicy
 
         /**
          * No issue at or above the specified severity is allowed.
          */
-        data class FailOnSeverity(val minSeverity: Severity) : FailurePolicy()
+        data class FailOnSeverity(val minSeverity: Severity) : FailurePolicy
     }
 
     /**
@@ -46,21 +46,21 @@ interface RulesSpec {
     /**
      * Restrict rules to use for current analysis.
      */
-    sealed class RunPolicy {
+    sealed interface RunPolicy {
 
         /**
          * Run all loaded rules provided by [dev.detekt.api.RuleSetProvider]
          */
-        data object NoRestrictions : RunPolicy()
+        data object NoRestrictions : RunPolicy
 
         /**
          * Exclude all default rule sets provided by detekt.
          */
-        data object DisableDefaultRuleSets : RunPolicy()
+        data object DisableDefaultRuleSets : RunPolicy
 
         /**
          * Run a single rule.
          */
-        class RestrictToSingleRule(val ruleSetId: RuleSetId, val ruleId: String) : RunPolicy()
+        class RestrictToSingleRule(val ruleSetId: RuleSetId, val ruleId: String) : RunPolicy
     }
 }


### PR DESCRIPTION
I've been pushing this shift in my day job for a while now, thought I'd see what your opinions are. 

Basically just adding an extra check to `AbstractClassCanBeInterface` for sealed classes with a slightly different error message, plus a few test cases to validate. 

Closes #7675, but merged into the existing rule instead of a new one (as mentioned in the discussion).