### PR TITLE
Use `file.path` to extract the version from doc present in `versioned…

### DIFF
--- a/website/src/remark/detektVersionReplace.js
+++ b/website/src/remark/detektVersionReplace.js
@@ -5,11 +5,19 @@ import { visit } from "unist-util-visit";
 // by the `applyDocVersion` task.
 const detektVersion = "2.0.0-alpha.1";
 
+const getVersionToUse = filePath => {
+  if (!filePath.includes("versioned_docs/")) return detektVersion;
+
+  const match = filePath.match(/version-(.*?)\//);
+  if (!match) throw new Error(`Could not extract version from path: ${filePath}`);
+  return match[1];
+};
+
 const detektVersionReplacePlugin = (options) => {
-  const transformer = async (ast) => {
+  const transformer = async (ast, file) => {
     visit(ast, "code", (node) => {
       if (node.value.includes("[detekt_version]")) {
-        node.value = node.value.replaceAll("[detekt_version]", detektVersion);
+        node.value = node.value.replaceAll("[detekt_version]", getVersionToUse(file.path));
       }
     });
   };


### PR DESCRIPTION
…_docs`

Fixes https://github.com/detekt/detekt/issues/7724
