### PR TITLE
Fix invalid Maven POM metadata for ktlint-repackage

### DIFF
--- a/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
@@ -17,11 +17,3 @@ tasks.shadowJar {
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
-
-val javaComponent = components["java"] as AdhocComponentWithVariants
-javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
-    skip()
-}
-javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) {
-    skip()
-}


### PR DESCRIPTION
Change added in #8292. 

Remove skip() configurations for apiElements and runtimeElements variants to allow proper dependency publishing. Without this, the published POM was empty, causing Maven consumers to miss ktlint transitive dependencies.

The skip() configurations prevented the module's dependencies from being included in the generated POM file, breaking Maven-based projects that depend on detekt-rules-ktlint-wrapper.

Fixes #8626.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
