### PR TITLE
Remove incorrect comments from KtlintWrapperProvider

### DIFF
--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
@@ -214,8 +214,8 @@ class KtlintWrapperProvider : RuleSetProvider {
             ::StringTemplate,
             ::StringTemplateIndent,
             ::ThenSpacing,
-            ::TrailingCommaOnCallSite, // standard rule but not enabled by default
-            ::TrailingCommaOnDeclarationSite, // standard rule but not enabled by default
+            ::TrailingCommaOnCallSite,
+            ::TrailingCommaOnDeclarationSite,
             ::TryCatchFinallySpacing,
             ::TypeArgumentComment,
             ::TypeArgumentListSpacing,


### PR DESCRIPTION
Remove a comment saying both trailing comma rules are disabled by default - they are in fact enabled by default.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
