### PR TITLE
Fix Android testFixtures support in Gradle plugin

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -58,14 +58,20 @@ internal object DetektAndroidCompilations {
                     mainBaselineTaskProvider.configure {
                         it.dependsOn(DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize())
                     }
-                    variant.nestedComponents.forEach { testVariant ->
-                        testTaskProvider.configure {
-                            it.dependsOn(DetektPlugin.DETEKT_TASK_NAME + testVariant.name.capitalize())
+                    // Filter out testFixtures components as they may not have corresponding Kotlin compilations.
+                    // TestFixtures support is experimental (android.experimental.enableTestFixturesKotlinSupport)
+                    // and detekt tasks are only registered for compilations available in KotlinAndroidExtension.
+                    // See: https://github.com/detekt/detekt/issues/8835
+                    variant.nestedComponents
+                        .filterNot { it.name.contains("TestFixtures", ignoreCase = true) }
+                        .forEach { testVariant ->
+                            testTaskProvider.configure {
+                                it.dependsOn(DetektPlugin.DETEKT_TASK_NAME + testVariant.name.capitalize())
+                            }
+                            testBaselineTaskProvider.configure {
+                                it.dependsOn(DetektPlugin.BASELINE_TASK_NAME + testVariant.name.capitalize())
+                            }
                         }
-                        testBaselineTaskProvider.configure {
-                            it.dependsOn(DetektPlugin.BASELINE_TASK_NAME + testVariant.name.capitalize())
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #8835

When Android projects enable experimental testFixtures support (`android.experimental.enableTestFixturesKotlinSupport=true`), the build was failing with `Task detektDebugTestFixtures not found` error.

The issue occurred because `variant.nestedComponents` includes testFixtures components when the experimental feature is enabled, but detekt tasks are only registered for Kotlin compilations available in `KotlinAndroidExtension`. TestFixtures may not create corresponding Kotlin compilations, causing the task dependency to reference non-existent tasks.

This change filters out testFixtures components from `nestedComponents` before creating task dependencies, preventing the build failure.

**Changes:**
- Filter testFixtures components in DetektAndroidCompilations.kt
- Add comprehensive functional tests for testFixtures scenarios
- Test with product flavors and baseline tasks