### PR TITLE
Add maven relocation info

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -54,10 +54,32 @@ publishing {
                 url.set("https://github.com/detekt/detekt")
             }
             distributionManagement {
-                relocation {
-                    groupId = "dev.detekt"
-                    version = "2.0.0"
-                    message = "groupId has been changed to match the detekt site"
+                val nameChanges = mapOf(
+                    "detekt-formatting" to "detekt-rules-ktlint-wrapper", // done in https://github.com/detekt/detekt/pull/8474
+                    "detekt-report-xml" to "detekt-report-checkstyle", // https://github.com/detekt/detekt/pull/8656
+                    "detekt-report-md" to "detekt-report-markdown", // https://github.com/detekt/detekt/pull/8735
+                    "detekt-rules-empty" to "detekt-rules-emptyblocks", // https://github.com/detekt/detekt/pull/8888
+                    "detekt-rules-documentation" to "detekt-rules-comments", // https://github.com/detekt/detekt/pull/8889
+                    "detekt-rules-errorprone" to "detekt-rules-potential-bugs", // https://github.com/detekt/detekt/pull/8887
+                )
+                val relocationExclusions = listOf(
+                    "detekt-report-txt", // https://github.com/detekt/detekt/pull/7470
+                    "detekt-sample-extensions",
+                )
+                if (project.name !in relocationExclusions) {
+                    val newArtifactName = if (project.name in nameChanges.keys) {
+                        nameChanges[project.name]
+                    } else {
+                        null
+                    }
+                    relocation {
+                        groupId = "dev.detekt"
+                        version = "2.0.0"
+                        if (newArtifactName != null) {
+                            artifactId = newArtifactName
+                        }
+                        message = "groupId has been changed to match the detekt website"
+                    }
                 }
             }
         }

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -53,6 +53,13 @@ publishing {
             scm {
                 url.set("https://github.com/detekt/detekt")
             }
+            distributionManagement {
+                relocation {
+                    groupId = "dev.detekt"
+                    version = "2.0.0"
+                    message = "groupId has been changed to match the detekt site"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Add relocation info
Fixes https://github.com/detekt/detekt/issues/8912

This PR needs to be updated before the final release to handle the case of the 
1. renamed artifacts
2. removing the relocation info from newly created artifacts
