### PR TITLE
Add direct testImplementation dependency on Kotlin compiler in detekt-test-assertj

### DIFF
--- a/detekt-test-assertj/build.gradle.kts
+++ b/detekt-test-assertj/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     compileOnly(projects.detektApi)
     api(libs.assertj.coreMinimum)
 
+    testImplementation(libs.kotlin.compiler)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.opentest4j)


### PR DESCRIPTION
Addresses this advice from Dependency Analysis Gradle Plugin:

```
Advice for :detekt-test-assertj
These transitive dependencies should be declared directly:
  testImplementation(libs.kotlin.compiler)
```