### PR TITLE
Migrate to Kotlin Gradle Plugin's binary compatibility validation

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation(libs.gradleNexus.publish.plugin)
     implementation(libs.semver4j)
     implementation(libs.breadmoirai.githubRelease.plugin)
-    implementation(libs.binaryCompatibilityValidator.plugin)
     implementation(libs.dokka.plugin)
 }
 

--- a/build-logic/src/main/kotlin/public-api.gradle.kts
+++ b/build-logic/src/main/kotlin/public-api.gradle.kts
@@ -1,10 +1,22 @@
 plugins {
-    id("org.jetbrains.kotlinx.binary-compatibility-validator")
     id("org.jetbrains.dokka")
+    kotlin("jvm")
 }
 
 dokka {
     dokkaPublications.configureEach {
         failOnWarning = true
     }
+}
+
+kotlin {
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+        enabled = true
+    }
+}
+
+tasks.check {
+    // Add dependency manually until https://youtrack.jetbrains.com/issue/KT-80614 is fixed
+    dependsOn("checkLegacyAbi")
 }

--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -48,6 +48,13 @@ listOf(configurations.testFixturesApiElements, configurations.testFixturesRuntim
     }
 }
 
-apiValidation {
-    ignoredPackages.add("dev.detekt.api.internal")
+kotlin {
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            excluded {
+                byNames.add("dev.detekt.api.internal.**")
+            }
+        }
+    }
 }

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -15,6 +15,13 @@ dependencies {
     testImplementation(libs.assertj.core)
 }
 
-apiValidation {
-    ignoredPackages.add("dev.detekt.test.utils.internal")
+kotlin {
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            excluded {
+                byNames.add("dev.detekt.test.utils.internal.**")
+            }
+        }
+    }
 }

--- a/detekt-tooling/build.gradle.kts
+++ b/detekt-tooling/build.gradle.kts
@@ -9,6 +9,13 @@ dependencies {
     testImplementation(libs.assertj.core)
 }
 
-apiValidation {
-    ignoredPackages.add("dev.detekt.tooling.internal")
+kotlin {
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation {
+        filters {
+            excluded {
+                byNames.add("dev.detekt.tooling.internal.**")
+            }
+        }
+    }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,6 @@ java-compile-toolchain = "17"
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version = "8.13.2" }
-binaryCompatibilityValidator-plugin = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.18.1" }
 breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
 develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version = "4.3" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.1.0" }


### PR DESCRIPTION
Fixes #8183 