### PR TITLE
Only enable compiler's progressive mode in non-DGP modules

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -63,7 +63,6 @@ val jvmMajorVersion = jvmTargetVersion.toIntOrNull() ?: 8
 kotlin {
     compilerOptions {
         jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
-        progressiveMode = true
         extraWarnings = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
         freeCompilerArgs.add("-Xcontext-parameters")
@@ -71,6 +70,10 @@ kotlin {
             // DGP compiles with Kotlin 2.1.21. Support for the stable version of this flag was only added in 2.2.0.
             // See KT-73007 & KT-74590
             jvmDefault = JvmDefaultMode.NO_COMPATIBILITY
+
+            // Only enable progressive mode in non-DGP modules. DGP doesn't compile with latest language version so
+            // progressive mode is not appropriate.
+            progressiveMode = true
         } else {
             freeCompilerArgs.add("-Xjvm-default=all")
         }


### PR DESCRIPTION
Stops compiler warning that progressive mode is enabled on an older compiler version. Warning stated that compiler behaviour in that case is undefined.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
