### PR TITLE
docs: clarify function type handling in ForbiddenMethodCall

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
@@ -70,7 +70,10 @@ class ForbiddenMethodCall(config: Config) :
             "`fun hello(args: Array<Any>)` is referred to as simply `hello(kotlin.Array)`. To forbid calls " +
             "involving varargs for example `fun hello(vararg args: String)` you need to define it like " +
             "`hello(vararg String)`. To forbid methods from the companion object reference the Companion class, for " +
-            "example as `TestClass.Companion.hello()` (even if it is marked `@JvmStatic`)."
+            "example as `TestClass.Companion.hello()` (even if it is marked `@JvmStatic`). " +
+            "To match function type parameters like `initializer` in `fun <T> lazy(initializer: () -> T)`, " +
+            "use `kotlin.Function{N}` where N is the number of parameters the function takes. For example, " +
+            "`kotlin.lazy(kotlin.Function0)` matches calls to `lazy { ... }`."
     )
     private val methods: List<ForbiddenMethod> by config(
         valuesWithReason(


### PR DESCRIPTION
## Summary

This PR adds documentation to the `ForbiddenMethodCall` rule explaining how to match function type parameters using `kotlin.Function{N}` syntax.

### Problem

When users want to forbid specific overloads of higher-order functions (like `lazy`), they need to know that Kotlin internally represents function types like `() -> T` as synthetic classes (`kotlin.Function0`, `kotlin.Function1`, etc.). This information is not visible in source code or IDE, making it difficult for users to configure the rule correctly.

### Solution

Added a clarifying sentence to the `@Configuration` documentation:

> To match function type parameters like `initializer` in `fun <T> lazy(initializer: () -> T)`, use `kotlin.Function{N}` where N is the number of parameters the function takes. For example, `kotlin.lazy(kotlin.Function0)` matches calls to `lazy { ... }`.

### Example Usage

```yaml
ForbiddenMethodCall:
  methods:
    - value: "kotlin.lazy(kotlin.Function0)"
      reason: "Must use lazy(LazyThreadSafetyMode.PUBLICATION) for performance"
```

Fixes #7823