### PR TITLE
Remove DSL marker annotation that has no effect

### DIFF
--- a/detekt-report-html/src/main/kotlin/dev/detekt/report/html/HtmlOutputReport.kt
+++ b/detekt-report-html/src/main/kotlin/dev/detekt/report/html/HtmlOutputReport.kt
@@ -16,7 +16,6 @@ import kotlinx.html.CommonAttributeGroupFacadeFlowInteractiveContent
 import kotlinx.html.FlowContent
 import kotlinx.html.FlowOrInteractiveContent
 import kotlinx.html.HTMLTag
-import kotlinx.html.HtmlTagMarker
 import kotlinx.html.TagConsumer
 import kotlinx.html.a
 import kotlinx.html.attributesMapOf
@@ -175,7 +174,6 @@ class HtmlOutputReport : OutputReport {
         ComplexityReportGenerator.create(detektion).generate().orEmpty()
 }
 
-@HtmlTagMarker
 private fun FlowOrInteractiveContent.summary(classes: String, block: SUMMARY.() -> Unit = {}): Unit =
     SUMMARY(attributesMapOf("class", classes), consumer).visit(block)
 


### PR DESCRIPTION
This use of the annotation is redundant. Upcoming Kotlin release has a new checker for this, but we can remove it now.

https://youtrack.jetbrains.com/issue/KT-81567

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
