### PR TITLE
Don't use `dev.detekt.test.yamlConfig` on `:detekt-rules-comments`

### DIFF
--- a/detekt-rules-comments/build.gradle.kts
+++ b/detekt-rules-comments/build.gradle.kts
@@ -8,9 +8,11 @@ dependencies {
     compileOnly(libs.jetbrains.annotations)
 
     testImplementation(libs.kotlin.compiler)
+    testImplementation(projects.detektCore)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestUtils)
+    testImplementation(projects.detektUtils)
     testImplementation(libs.assertj.core)
     testImplementation(testFixtures(projects.detektApi))
 }

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/AbsentOrWrongFileLicenseSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/AbsentOrWrongFileLicenseSpec.kt
@@ -3,11 +3,12 @@ package dev.detekt.rules.comments
 import dev.detekt.api.Config
 import dev.detekt.api.Finding
 import dev.detekt.api.testfixtures.TestSetupContext
+import dev.detekt.core.config.YamlConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.lint
 import dev.detekt.test.utils.compileContentForTest
 import dev.detekt.test.utils.resource
-import dev.detekt.test.yamlConfig
+import dev.detekt.utils.openSafeStream
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -194,3 +195,5 @@ private fun checkLicence(@Language("kotlin") content: String, isRegexLicense: Bo
 
     return AbsentOrWrongFileLicense(Config.empty).lint(file)
 }
+
+private fun yamlConfig(name: String): Config = resource(name).toURL().openSafeStream().reader().use(YamlConfig::load)


### PR DESCRIPTION
Part of #8681

This solution isn't elegant but we don't want `:detekt-test` to depend on `:detekt-core` so we need to move that dependency to `:detekt-rules-comments`. This isn't perfect, a change on core will relaunch the tests on `:detekt-rules-comments`. But this is a win for now, because right now we are relaunching ALL the `:detekt-rules-*` tests.

A proper solution is #8969 but that PR changes the rule behavior so I'm opening this to unblock #8681