### PR TITLE
Don't use `isSuppressedBy` from `:detekt-core` on `:detekt-test`

### DIFF
--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressionsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressionsSpec.kt
@@ -284,7 +284,7 @@ class SuppressionsSpec {
     }
 
     @Test
-    fun neverSuppressForbiddenSuppress2() {
+    fun neverSuppressForbiddenSuppress_withSlashId() {
         val file = compileContentForTest("""@file:Suppress("ForbiddenSuppress/foo")""")
         assertThat(file.isSuppressedBy("ForbiddenSuppress", emptySet())).isFalse()
     }


### PR DESCRIPTION
Part of #8681

`lint` and `lintWithContext` filter out the suppressed issues. This is like that for historical reasons: In detekt 1.x the suppression was `BaseRule` work so it had sense to test it in the rules. Now the suppresion is made by the core and the rules know nothing about it. So we could remove the tests that check things related with `@Suppress` in the modules `:detekt-rules-*`.

But there is other thing that is being tested here too. On the rule we need to report a `KtElement`. And we use that `KtElement` to know if the issue is suppressed or not. So if we remove all those tests we will be losing a bit of coverage. For this reason, right now, I don't want to remove those tests and instead I prefer to create a simplified version of `isSuppressedBy` in `:detekt-test`. This way we can still test that the `KtElement` reported is correct but we don't depend on the real implementation of `isSuppressedBy` from core because we shouldn't care about it.