### PR TITLE
Remove special case for active at `TestConfig`

### DIFF
--- a/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
@@ -21,27 +21,9 @@ class TestConfig private constructor(override val parent: Config?, private val v
     override fun subConfigKeys(): Set<String> = values.keys
 
     override fun <T : Any> valueOrDefault(key: String, default: T) =
-        if (key == Config.ACTIVE_KEY) {
-            getActiveValue(default) as T
-        } else {
-            valueOrDefaultInternal(key, values[key], default, ::tryParseBasedOnDefaultRespectingCollections) as T
-        }
+        valueOrDefaultInternal(key, values[key], default, ::tryParseBasedOnDefaultRespectingCollections) as T
 
-    private fun <T : Any> getActiveValue(default: T): Any {
-        val active = values[Config.ACTIVE_KEY]
-        return if (active != null) {
-            valueOrDefaultInternal("active", active, default, ::tryParseBasedOnDefaultRespectingCollections)
-        } else {
-            true
-        }
-    }
-
-    override fun <T : Any> valueOrNull(key: String): T? =
-        if (key == Config.ACTIVE_KEY) {
-            (values[Config.ACTIVE_KEY] ?: true) as T?
-        } else {
-            values[key] as? T
-        }
+    override fun <T : Any> valueOrNull(key: String): T? = values[key] as? T
 
     private fun tryParseBasedOnDefaultRespectingCollections(result: String, defaultResult: Any): Any =
         when (defaultResult) {


### PR DESCRIPTION
in detekt 1.x the rules decided by themselves if they should be run or not by checking the value `active` at the config. So, to avoid to set `active to true` in ALL the configs for all the tests of our suite `TestConfig` had this behavior. If someone asked the `config` for `active` and it wasn't set then it would return `true`.

In detekt 2.0 the rules doesn't check this anymore so there is not reason to keep this strange/not expected behavior at `TestConfig`. This also simplifies `TestConfig` and helps with #8681