### PR TITLE
Pass the correct type to `TestConfig`

### DIFF
--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
@@ -188,7 +188,7 @@ class OutdatedDocumentationSpec {
             """.trimIndent()
             assertThat(
                 OutdatedDocumentation(
-                    TestConfig("allowParamOnConstructorProperties" to "true")
+                    TestConfig("allowParamOnConstructorProperties" to true)
                 ).lint(incorrectDeclarationsOrder)
             ).isEmpty()
         }
@@ -496,7 +496,7 @@ class OutdatedDocumentationSpec {
     @Nested
     inner class `configuration matchTypeParameters` {
         private val configuredSubject =
-            OutdatedDocumentation(TestConfig("matchTypeParameters" to "false"))
+            OutdatedDocumentation(TestConfig("matchTypeParameters" to false))
 
         @Test
         fun `should not report when class type parameters mismatch and configuration is off`() {
@@ -524,7 +524,7 @@ class OutdatedDocumentationSpec {
     @Nested
     inner class `configuration matchDeclarationsOrder` {
         private val configuredSubject =
-            OutdatedDocumentation(TestConfig("matchDeclarationsOrder" to "false"))
+            OutdatedDocumentation(TestConfig("matchDeclarationsOrder" to false))
 
         @Test
         fun `should not report when declarations order mismatch and configuration is off`() {
@@ -556,7 +556,7 @@ class OutdatedDocumentationSpec {
     @Nested
     inner class `configuration allowParamOnConstructorProperties` {
         private val configuredSubject = OutdatedDocumentation(
-            TestConfig("allowParamOnConstructorProperties" to "true")
+            TestConfig("allowParamOnConstructorProperties" to true)
         )
 
         @Test
@@ -600,8 +600,8 @@ class OutdatedDocumentationSpec {
     inner class `configuration matchDeclarationsOrder and allowParamOnConstructorProperties` {
         private val configuredSubject = OutdatedDocumentation(
             TestConfig(
-                "matchDeclarationsOrder" to "false",
-                "allowParamOnConstructorProperties" to "true",
+                "matchDeclarationsOrder" to false,
+                "allowParamOnConstructorProperties" to true,
             )
         )
 

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicClassSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicClassSpec.kt
@@ -105,21 +105,21 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `should not report inner classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_CLASS to "false")).lint(inner)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_CLASS to false)).lint(inner)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner objects when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_OBJECT to "false")).lint(innerObject)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_OBJECT to false)).lint(innerObject)
         assertThat(findings).isEmpty()
     }
 
     @Test
     fun `should not report inner interfaces when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_INTERFACE to "false")).lint(
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_INNER_INTERFACE to false)).lint(
                 innerInterface
             )
         assertThat(findings).isEmpty()
@@ -128,7 +128,7 @@ class UndocumentedPublicClassSpec {
     @Test
     fun `should not report nested classes when turned off`() {
         val findings =
-            UndocumentedPublicClass(TestConfig(SEARCH_IN_NESTED_CLASS to "false")).lint(nested)
+            UndocumentedPublicClass(TestConfig(SEARCH_IN_NESTED_CLASS to false)).lint(nested)
         assertThat(findings).isEmpty()
     }
 
@@ -254,7 +254,7 @@ class UndocumentedPublicClassSpec {
                 protected class ProtectedClass
             }
         """.trimIndent()
-        val subject = UndocumentedPublicClass(TestConfig(SEARCH_IN_PROTECTED_CLASS to "true"))
+        val subject = UndocumentedPublicClass(TestConfig(SEARCH_IN_PROTECTED_CLASS to true))
         assertThat(subject.lint(code)).hasSize(1)
     }
 
@@ -300,7 +300,7 @@ class UndocumentedPublicClassSpec {
         """.trimIndent()
         assertThat(
             UndocumentedPublicClass(
-                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
+                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to true)
             ).lint(code)
         ).isEmpty()
     }
@@ -335,7 +335,7 @@ class UndocumentedPublicClassSpec {
         """.trimIndent()
         assertThat(
             UndocumentedPublicClass(
-                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
+                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to true)
             ).lint(code)
         ).hasSize(4)
     }
@@ -362,7 +362,7 @@ class UndocumentedPublicClassSpec {
         """.trimIndent()
         assertThat(
             UndocumentedPublicClass(
-                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to "true")
+                TestConfig(IGNORE_DEFAULT_COMPANION_OBJECT to true)
             ).lint(code)
         ).hasSize(3)
     }

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicFunctionSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicFunctionSpec.kt
@@ -162,7 +162,7 @@ class UndocumentedPublicFunctionSpec {
                 protected fun noComment1() {}
             }
         """.trimIndent()
-        val subject = UndocumentedPublicFunction(TestConfig(SEARCH_PROTECTED_FUN to "true"))
+        val subject = UndocumentedPublicFunction(TestConfig(SEARCH_PROTECTED_FUN to true))
         assertThat(subject.lint(code)).hasSize(1)
     }
 

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicPropertySpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/UndocumentedPublicPropertySpec.kt
@@ -234,7 +234,7 @@ class UndocumentedPublicPropertySpec {
                 protected val a = 1
             }
         """.trimIndent()
-        val subject = UndocumentedPublicProperty(TestConfig(SEARCH_PROTECTED_PROPERTY to "true"))
+        val subject = UndocumentedPublicProperty(TestConfig(SEARCH_PROTECTED_PROPERTY to true))
         assertThat(subject.lint(code)).hasSize(1)
     }
 

--- a/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/CognitiveComplexMethodSpec.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 
 class CognitiveComplexMethodSpec {
 
-    private val testConfig = TestConfig("allowedComplexity" to "1")
+    private val testConfig = TestConfig("allowedComplexity" to 1)
 
     @Test
     fun `should report complex function exceeding the allowed complexity`() {

--- a/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/CyclomaticComplexMethodSpec.kt
@@ -8,7 +8,7 @@ import dev.detekt.test.lint
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-private val defaultAllowedComplexity = "allowedComplexity" to "1"
+private val defaultAllowedComplexity = "allowedComplexity" to 1
 
 class CyclomaticComplexMethodSpec {
 
@@ -81,13 +81,13 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `counts three with nesting function 'forEach'`() {
-            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to "false")
+            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to false)
             assertExpectedComplexityValue(code, config, expectedValue = 3)
         }
 
         @Test
         fun `can ignore nesting functions like 'forEach'`() {
-            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to "true")
+            val config = TestConfig(defaultAllowedComplexity, "ignoreNestingFunctions" to true)
             assertExpectedComplexityValue(code, config, expectedValue = 2)
         }
 
@@ -161,8 +161,8 @@ class CyclomaticComplexMethodSpec {
         @Test
         fun `does not report complex methods with a single when expression`() {
             val config = TestConfig(
-                "allowedComplexity" to "4",
-                "ignoreSingleWhenExpression" to "true",
+                "allowedComplexity" to 4,
+                "ignoreSingleWhenExpression" to true,
             )
             val subject = CyclomaticComplexMethod(config)
 
@@ -172,7 +172,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `reports all complex methods`() {
-            val config = TestConfig("allowedComplexity" to "4")
+            val config = TestConfig("allowedComplexity" to 4)
             val subject = CyclomaticComplexMethod(config)
 
             val findings = subject.lint(code)
@@ -188,7 +188,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `does not report function that has exactly the allowed complexity`() {
-            val config = TestConfig("allowedComplexity" to "6")
+            val config = TestConfig("allowedComplexity" to 6)
             val subject = CyclomaticComplexMethod(config)
 
             val code = """
@@ -211,7 +211,7 @@ class CyclomaticComplexMethodSpec {
 
         @Test
         fun `does not trip for a reasonable amount of simple when entries when ignoreSimpleWhenEntries is true`() {
-            val config = TestConfig("ignoreSimpleWhenEntries" to "true")
+            val config = TestConfig("ignoreSimpleWhenEntries" to true)
             val subject = CyclomaticComplexMethod(config)
             val code = """
                 fun f() {

--- a/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/LongParameterListSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/LongParameterListSpec.kt
@@ -54,7 +54,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
 
     @Test
     fun `does not report long parameter list if parameters with defaults should be ignored`() {
-        val config = TestConfig("ignoreDefaultParameters" to "true")
+        val config = TestConfig("ignoreDefaultParameters" to true)
         val rule = LongParameterList(config)
         val code = "fun long(a: Int, b: Int, c: Int = 2) {}"
         assertThat(rule.lintWithContext(env, code)).isEmpty()
@@ -90,7 +90,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
 
     @Test
     fun `reports long parameter list if custom threshold is set`() {
-        val config = TestConfig("allowedConstructorParameters" to "1")
+        val config = TestConfig("allowedConstructorParameters" to 1)
         val rule = LongParameterList(config)
         val code = "class LongCtor(a: Int, b: Int)"
         assertThat(rule.lintWithContext(env, code)).hasSize(1)
@@ -108,8 +108,8 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
     @Test
     fun `does not report long parameter list for constructors of data classes if asked`() {
         val config = TestConfig(
-            "ignoreDataClasses" to "true",
-            "constructorThreshold" to "1",
+            "ignoreDataClasses" to true,
+            "constructorThreshold" to 1,
         )
         val rule = LongParameterList(config)
         val code = "data class Data(val a: Int)"
@@ -174,7 +174,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
     inner class Signatures {
         @Test
         fun `does not include the params in primary ctor`() {
-            val config = TestConfig("allowedConstructorParameters" to "1")
+            val config = TestConfig("allowedConstructorParameters" to 1)
             val rule = LongParameterList(config)
             val code = "class LongCtor(a: Int, b: Int)"
             val result = rule.lintWithContext(env, code)
@@ -187,7 +187,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
 
         @Test
         fun `does not include the params in secondary ctor`() {
-            val config = TestConfig("allowedConstructorParameters" to "1")
+            val config = TestConfig("allowedConstructorParameters" to 1)
             val rule = LongParameterList(config)
             val code = """
                 class LongCtor {
@@ -204,7 +204,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
 
         @Test
         fun `does not include the params in class function`() {
-            val config = TestConfig("allowedFunctionParameters" to "1")
+            val config = TestConfig("allowedFunctionParameters" to 1)
             val rule = LongParameterList(config)
             val code = """
                 class LongCtor {
@@ -221,7 +221,7 @@ class LongParameterListSpec(private val env: KotlinEnvironmentContainer) {
 
         @Test
         fun `does not include the params in top level function`() {
-            val config = TestConfig("allowedFunctionParameters" to "1")
+            val config = TestConfig("allowedFunctionParameters" to 1)
             val rule = LongParameterList(config)
             val code = """
                 fun a(a: Int, b: Int) = a + b

--- a/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/StringLiteralDuplicationSpec.kt
@@ -59,7 +59,7 @@ class StringLiteralDuplicationSpec {
 
         @Test
         fun `reports strings in annotations according to config`() {
-            val config = TestConfig(IGNORE_ANNOTATION to "false", "allowedDuplications" to 2)
+            val config = TestConfig(IGNORE_ANNOTATION to false, "allowedDuplications" to 2)
             assertFindingWithConfig(code, config, 1)
         }
     }

--- a/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/TooManyFunctionsSpec.kt
+++ b/detekt-rules-complexity/src/test/kotlin/dev/detekt/rules/complexity/TooManyFunctionsSpec.kt
@@ -20,11 +20,11 @@ private const val IGNORE_ANNOTATED_FUNCTIONS = "ignoreAnnotatedFunctions"
 class TooManyFunctionsSpec {
     val rule = TooManyFunctions(
         TestConfig(
-            ALLOWED_FUNCTIONS_PER_CLASS to "1",
-            ALLOWED_FUNCTIONS_PER_ENUM to "1",
-            ALLOWED_FUNCTIONS_PER_FILE to "1",
-            ALLOWED_FUNCTIONS_PER_INTERFACE to "1",
-            ALLOWED_FUNCTIONS_PER_OBJECT to "1",
+            ALLOWED_FUNCTIONS_PER_CLASS to 1,
+            ALLOWED_FUNCTIONS_PER_ENUM to 1,
+            ALLOWED_FUNCTIONS_PER_FILE to 1,
+            ALLOWED_FUNCTIONS_PER_INTERFACE to 1,
+            ALLOWED_FUNCTIONS_PER_OBJECT to 1,
         )
     )
 
@@ -155,9 +155,9 @@ class TooManyFunctionsSpec {
         fun `finds no deprecated functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    ALLOWED_FUNCTIONS_PER_FILE to "1",
-                    IGNORE_DEPRECATED to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    ALLOWED_FUNCTIONS_PER_FILE to 1,
+                    IGNORE_DEPRECATED to true,
                 )
             )
             assertThat(configuredRule.lint(code)).isEmpty()
@@ -183,9 +183,9 @@ class TooManyFunctionsSpec {
         fun `finds no private functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    ALLOWED_FUNCTIONS_PER_FILE to "1",
-                    IGNORE_PRIVATE to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    ALLOWED_FUNCTIONS_PER_FILE to 1,
+                    IGNORE_PRIVATE to true,
                 )
             )
             assertThat(configuredRule.lint(code)).isEmpty()
@@ -211,8 +211,8 @@ class TooManyFunctionsSpec {
         fun `finds no internal functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    IGNORE_INTERNAL to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    IGNORE_INTERNAL to true,
                 )
             )
             assertThat(configuredRule.lint(code)).isEmpty()
@@ -222,8 +222,8 @@ class TooManyFunctionsSpec {
         fun `finds private functions`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    IGNORE_INTERNAL to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    IGNORE_INTERNAL to true,
                 )
             )
             val code = """
@@ -261,11 +261,11 @@ class TooManyFunctionsSpec {
             """.trimIndent()
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    ALLOWED_FUNCTIONS_PER_FILE to "1",
-                    IGNORE_PRIVATE to "true",
-                    IGNORE_DEPRECATED to "true",
-                    IGNORE_OVERRIDDEN to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    ALLOWED_FUNCTIONS_PER_FILE to 1,
+                    IGNORE_PRIVATE to true,
+                    IGNORE_DEPRECATED to true,
+                    IGNORE_OVERRIDDEN to true,
                 )
             )
             assertThat(configuredRule.lint(code)).isEmpty()
@@ -291,9 +291,9 @@ class TooManyFunctionsSpec {
         fun `should not report class with overridden functions, if ignoreOverridden is enabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    ALLOWED_FUNCTIONS_PER_FILE to "1",
-                    IGNORE_OVERRIDDEN to "true",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    ALLOWED_FUNCTIONS_PER_FILE to 1,
+                    IGNORE_OVERRIDDEN to true,
                 )
             )
             assertThat(configuredRule.lint(code)).isEmpty()
@@ -303,9 +303,9 @@ class TooManyFunctionsSpec {
         fun `should count overridden functions, if ignoreOverridden is disabled`() {
             val configuredRule = TooManyFunctions(
                 TestConfig(
-                    ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                    ALLOWED_FUNCTIONS_PER_FILE to "1",
-                    IGNORE_OVERRIDDEN to "false",
+                    ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                    ALLOWED_FUNCTIONS_PER_FILE to 1,
+                    IGNORE_OVERRIDDEN to false,
                 )
             )
             assertThat(configuredRule.lint(code)).hasSize(1)
@@ -316,11 +316,11 @@ class TooManyFunctionsSpec {
     fun `should not count functions included in ignoreAnnotatedFunctions`() {
         val rule = TooManyFunctions(
             TestConfig(
-                ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                ALLOWED_FUNCTIONS_PER_ENUM to "1",
-                ALLOWED_FUNCTIONS_PER_FILE to "1",
-                ALLOWED_FUNCTIONS_PER_INTERFACE to "1",
-                ALLOWED_FUNCTIONS_PER_OBJECT to "1",
+                ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                ALLOWED_FUNCTIONS_PER_ENUM to 1,
+                ALLOWED_FUNCTIONS_PER_FILE to 1,
+                ALLOWED_FUNCTIONS_PER_INTERFACE to 1,
+                ALLOWED_FUNCTIONS_PER_OBJECT to 1,
                 IGNORE_ANNOTATED_FUNCTIONS to listOf("Preview"),
             )
         )
@@ -345,11 +345,11 @@ class TooManyFunctionsSpec {
     fun `should trigger when there are too many non-annotated functions`() {
         val rule = TooManyFunctions(
             TestConfig(
-                ALLOWED_FUNCTIONS_PER_CLASS to "1",
-                ALLOWED_FUNCTIONS_PER_ENUM to "1",
-                ALLOWED_FUNCTIONS_PER_FILE to "1",
-                ALLOWED_FUNCTIONS_PER_INTERFACE to "1",
-                ALLOWED_FUNCTIONS_PER_OBJECT to "1",
+                ALLOWED_FUNCTIONS_PER_CLASS to 1,
+                ALLOWED_FUNCTIONS_PER_ENUM to 1,
+                ALLOWED_FUNCTIONS_PER_FILE to 1,
+                ALLOWED_FUNCTIONS_PER_INTERFACE to 1,
+                ALLOWED_FUNCTIONS_PER_OBJECT to 1,
                 IGNORE_ANNOTATED_FUNCTIONS to listOf("Preview"),
             )
         )
@@ -373,7 +373,7 @@ class TooManyFunctionsSpec {
 
     @Test
     fun `should suppress TooManyFunctionsRule on class level`() {
-        val rule = TooManyFunctions(TestConfig("thresholdInClasses" to "0"))
+        val rule = TooManyFunctions(TestConfig("thresholdInClasses" to 0))
         val code = """
             @Suppress("TooManyFunctions")
             class OneIsTooMany {

--- a/detekt-rules-empty-blocks/src/test/kotlin/dev/detekt/rules/emptyblocks/EmptyFunctionBlockSpec.kt
+++ b/detekt-rules-empty-blocks/src/test/kotlin/dev/detekt/rules/emptyblocks/EmptyFunctionBlockSpec.kt
@@ -89,7 +89,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions`() {
-            val config = TestConfig(IGNORE_OVERRIDDEN to "true")
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             assertThat(EmptyFunctionBlock(config).lint(code)).singleElement()
                 .hasStartSourceLocation(1, 13)
         }
@@ -123,7 +123,7 @@ class EmptyFunctionBlockSpec {
 
         @Test
         fun `should not flag overridden functions with ignoreOverridden`() {
-            val config = TestConfig(IGNORE_OVERRIDDEN to "true")
+            val config = TestConfig(IGNORE_OVERRIDDEN to true)
             assertThat(EmptyFunctionBlock(config).lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/ReturnFromFinallySpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/ReturnFromFinallySpec.kt
@@ -111,7 +111,7 @@ class ReturnFromFinallySpec(val env: KotlinEnvironmentContainer) {
 
         @Test
         fun `should not report when ignoreLabeled is true`() {
-            val config = TestConfig("ignoreLabeled" to "true")
+            val config = TestConfig("ignoreLabeled" to true)
             val findings = ReturnFromFinally(config).lintWithContext(env, code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/TooGenericExceptionCaughtSpec.kt
@@ -64,7 +64,7 @@ class TooGenericExceptionCaughtSpec {
 
         @Test
         fun `should not report an ignored catch blocks because of its exception type`() {
-            val config = TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to "[MyException]")
+            val config = TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to listOf("MyException"))
             val rule = TooGenericExceptionCaught(config)
 
             val findings = rule.lint(code)
@@ -107,7 +107,7 @@ class TooGenericExceptionCaughtSpec {
 
     @Test
     fun `should not report any`() {
-        val rule = TooGenericExceptionCaught(TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to "[]"))
+        val rule = TooGenericExceptionCaught(TestConfig(CAUGHT_EXCEPTIONS_PROPERTY to emptyList<String>()))
         val code = """
             fun main() {
                 try {

--- a/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/TooGenericExceptionThrownSpec.kt
@@ -14,7 +14,7 @@ class TooGenericExceptionThrownSpec {
     @ParameterizedTest
     @ValueSource(strings = ["Error", "Exception", "Throwable", "RuntimeException"])
     fun `should report $exceptionName`(exceptionName: String) {
-        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "[$exceptionName]"))
+        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to listOf(exceptionName)))
         val code = """
             fun main() {
                 try {
@@ -40,7 +40,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report thrown exceptions`() {
-        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "['MyException', Bar]"))
+        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to listOf("MyException", "Bar")))
         val code = """
             fun main() {
                 try {
@@ -66,7 +66,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report caught exceptions`() {
-        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "['Exception']"))
+        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to listOf("Exception")))
         val code = """
             fun f() {
                 try {
@@ -82,7 +82,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report initialize exceptions`() {
-        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "['Exception']"))
+        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to listOf("Exception")))
         val code = """fun f() { val ex = Exception() }"""
 
         assertThat(rule.lint(code)).isEmpty()
@@ -90,7 +90,7 @@ class TooGenericExceptionThrownSpec {
 
     @Test
     fun `should not report any`() {
-        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to "[]"))
+        val rule = TooGenericExceptionThrown(TestConfig(EXCEPTION_NAMES to emptyList<String>()))
         val code = """
             fun main() {
                 try {

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ArgumentListWrappingSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ArgumentListWrappingSpec.kt
@@ -40,7 +40,7 @@ class ArgumentListWrappingSpec {
              3
             )
         """.trimIndent()
-        val config = TestConfig("indentSize" to "1")
+        val config = TestConfig("indentSize" to 1)
         assertThat(ArgumentListWrapping(config).lint(code)).isEmpty()
     }
 
@@ -49,7 +49,7 @@ class ArgumentListWrappingSpec {
         val code = """
             val x = f(1111, 2222, 3333)
         """.trimIndent()
-        val config = TestConfig("maxLineLength" to "10")
+        val config = TestConfig("maxLineLength" to 10)
         assertThat(ArgumentListWrapping(config).lint(code)).hasSize(4)
     }
 }

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
@@ -30,11 +30,11 @@ class AutoCorrectLevelSpec {
     fun autoCorrect(ruleSet: AutoCorrectConfig, rule: AutoCorrectConfig, wasFormatted: Boolean) {
         val config = TestConfig(
             "ktlint" to mapOfNotNull(
-                "active" to "true",
-                ("autoCorrect" to ruleSet.toString()).takeIf { ruleSet != AutoCorrectConfig.Undefined },
+                "active" to true,
+                ("autoCorrect" to ruleSet.toConfig()).takeIf { ruleSet != AutoCorrectConfig.Undefined },
                 "ChainWrapping" to mapOfNotNull(
-                    "active" to "true",
-                    ("autoCorrect" to rule.toString()).takeIf { rule != AutoCorrectConfig.Undefined }
+                    "active" to true,
+                    ("autoCorrect" to rule.toConfig()).takeIf { rule != AutoCorrectConfig.Undefined }
                 )
             )
         )
@@ -60,11 +60,11 @@ enum class AutoCorrectConfig {
     Undefined,
     ;
 
-    override fun toString(): String =
+    fun toConfig(): Any? =
         when (this) {
-            True -> "true"
-            False -> "false"
-            Undefined -> "Undefined"
+            True -> true
+            False -> false
+            Undefined -> null
         }
 }
 

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/FinalNewlineSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/FinalNewlineSpec.kt
@@ -30,7 +30,7 @@ class FinalNewlineSpec {
 
     @Test
     fun `should report new line when configured`() {
-        val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to "false"))
+        val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to false))
             .lint(
                 """
                     fun main() = Unit
@@ -43,7 +43,7 @@ class FinalNewlineSpec {
 
     @Test
     fun `should not report when no new line is configured and not present`() {
-        val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to "false"))
+        val findings = FinalNewline(TestConfig(INSERT_FINAL_NEWLINE_KEY to false))
             .lint("fun main() = Unit")
 
         assertThat(findings).isEmpty()

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ImportOrderingSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ImportOrderingSpec.kt
@@ -73,12 +73,12 @@ class ImportOrderingSpec {
 
             @Test
             fun `passes for alphabetical order`() {
-                assertThat(ImportOrdering(TestConfig("android" to "true")).lint(negativeCase)).isEmpty()
+                assertThat(ImportOrdering(TestConfig("android" to true)).lint(negativeCase)).isEmpty()
             }
 
             @Test
             fun `fails for non alphabetical order`() {
-                assertThat(ImportOrdering(TestConfig("android" to "true")).lint(positiveCase)).hasSize(1)
+                assertThat(ImportOrdering(TestConfig("android" to true)).lint(positiveCase)).hasSize(1)
             }
         }
     }

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
@@ -41,7 +41,7 @@ class IndentationSpec {
 
         @Test
         fun `does not report when using an indentation level config of 1`() {
-            val config = TestConfig("indentSize" to "1")
+            val config = TestConfig("indentSize" to 1)
             assertThat(Indentation(config).lint(code)).isEmpty()
         }
     }
@@ -68,7 +68,7 @@ class IndentationSpec {
 
         @Test
         fun `does not report when using an indentation level config of 1`() {
-            val config = TestConfig("indentSize" to "1")
+            val config = TestConfig("indentSize" to 1)
             assertThat(Indentation(config).lint(code)).isEmpty()
         }
     }

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/MaximumLineLengthSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/MaximumLineLengthSpec.kt
@@ -15,7 +15,7 @@ class MaximumLineLengthSpec {
 
     @BeforeEach
     fun createSubject() {
-        subject = MaximumLineLength(TestConfig(MAX_LINE_LENGTH to "30"))
+        subject = MaximumLineLength(TestConfig(MAX_LINE_LENGTH to 30))
     }
 
     @Nested
@@ -75,8 +75,8 @@ class MaximumLineLengthSpec {
         """.trimIndent()
         val findings = MaximumLineLength(
             TestConfig(
-                MAX_LINE_LENGTH to "30",
-                "ignoreBackTickedIdentifier" to "true"
+                MAX_LINE_LENGTH to 30,
+                "ignoreBackTickedIdentifier" to true,
             )
         ).lint(code)
         assertThat(findings).isEmpty()

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ParameterListWrappingSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/ParameterListWrappingSpec.kt
@@ -33,7 +33,7 @@ class ParameterListWrappingSpec {
             fun f(a: Int, b: Int, c: Int) {
             }
         """.trimIndent()
-        val config = TestConfig("maxLineLength" to "10")
+        val config = TestConfig("maxLineLength" to 10)
         assertThat(ParameterListWrapping(config).lint(code)).hasSize(4)
     }
 }

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/RuleSetConfigPropertySpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/RuleSetConfigPropertySpec.kt
@@ -14,7 +14,7 @@ class RuleSetConfigPropertySpec {
     inner class `boolean property` {
         @Test
         fun `reads the value in config if present`() {
-            assertThat(TestRuleSetProvider.android.value(TestConfig("android" to "false")))
+            assertThat(TestRuleSetProvider.android.value(TestConfig("android" to false)))
                 .isEqualTo(false)
         }
 
@@ -29,7 +29,7 @@ class RuleSetConfigPropertySpec {
     inner class `int property` {
         @Test
         fun `reads the value in config if present`() {
-            assertThat(TestRuleSetProvider.number.value(TestConfig("number" to "37"))).isEqualTo(37)
+            assertThat(TestRuleSetProvider.number.value(TestConfig("number" to 37))).isEqualTo(37)
         }
 
         @Test

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/MatchingDeclarationNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/MatchingDeclarationNameSpec.kt
@@ -247,7 +247,7 @@ class MatchingDeclarationNameSpec {
                 filename = "Classes.kt"
             )
             val findings = MatchingDeclarationName(
-                TestConfig("mustBeFirst" to "false")
+                TestConfig("mustBeFirst" to false)
             ).lint(ktFile)
             assertThat(findings).singleElement()
                 .hasStartSourceLocation(3, 7)

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/MemberNameEqualsClassNameSpec.kt
@@ -57,7 +57,7 @@ class MemberNameEqualsClassNameSpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `some classes with members which have the same name` {
-        private val noIgnoreOverridden = TestConfig(IGNORE_OVERRIDDEN to "false")
+        private val noIgnoreOverridden = TestConfig(IGNORE_OVERRIDDEN to false)
 
         @Test
         fun `reports a method which is named after the class`() {

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -13,7 +13,7 @@ class VariableMinLengthSpec {
     inner class `VariableMinLength rule with a custom minimum length` {
 
         private val variableMinLength =
-            VariableMinLength(TestConfig(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to "2"))
+            VariableMinLength(TestConfig(VariableMinLength.MINIMUM_VARIABLE_NAME_LENGTH to 2))
 
         @Test
         fun `reports a very short variable name`() {

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnTypeSpec.kt
@@ -38,7 +38,7 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinEnvironmentContainer) {
     fun `reports explicit Unit return type if configured`() {
         val code = """fun safeButStillReported(): Unit = println("Hello Unit")"""
 
-        val findings = ImplicitUnitReturnType(TestConfig("allowExplicitReturnType" to "false"))
+        val findings = ImplicitUnitReturnType(TestConfig("allowExplicitReturnType" to false))
             .lintWithContext(env, code)
 
         assertThat(findings).hasSize(1)

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/DestructuringDeclarationWithTooManyEntriesSpec.kt
@@ -87,7 +87,7 @@ class DestructuringDeclarationWithTooManyEntriesSpec {
 
         val configuredRule =
             DestructuringDeclarationWithTooManyEntries(
-                TestConfig(MAX_DESTRUCTURING_ENTRIES to "2")
+                TestConfig(MAX_DESTRUCTURING_ENTRIES to 2)
             )
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ExpressionBodySyntaxSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ExpressionBodySyntaxSpec.kt
@@ -134,7 +134,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to true)
             assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }
@@ -158,7 +158,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to true)
             assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }
@@ -184,7 +184,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `does not report with includeLineWrapping = true configuration`() {
-            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to true)
             assertThat(ExpressionBodySyntax(config).lint(code)).isEmpty()
         }
     }
@@ -206,7 +206,7 @@ class ExpressionBodySyntaxSpec {
 
         @Test
         fun `reports with includeLineWrapping = true configuration`() {
-            val config = TestConfig(INCLUDE_LINE_WRAPPING to "true")
+            val config = TestConfig(INCLUDE_LINE_WRAPPING to true)
             assertThat(ExpressionBodySyntax(config).lint(code)).hasSize(1)
         }
     }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenVoidSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenVoidSpec.kt
@@ -62,7 +62,7 @@ class ForbiddenVoidSpec(val env: KotlinEnvironmentContainer) {
     @Nested
     inner class `ignoreOverridden is enabled` {
 
-        val config = TestConfig(IGNORE_OVERRIDDEN to "true")
+        val config = TestConfig(IGNORE_OVERRIDDEN to true)
 
         @Test
         fun `should not report Void in overriding function declarations`() {
@@ -138,7 +138,7 @@ class ForbiddenVoidSpec(val env: KotlinEnvironmentContainer) {
     @Nested
     inner class `ignoreUsageInGenerics is enabled` {
 
-        val config = TestConfig(IGNORE_USAGE_IN_GENERICS to "true")
+        val config = TestConfig(IGNORE_USAGE_IN_GENERICS to true)
 
         @Test
         fun `should not report Void in generic type declaration`() {

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstantSpec.kt
@@ -61,7 +61,7 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports overridden functions which return constants`() {
-            val config = TestConfig(IGNORE_OVERRIDABLE_FUNCTION to "false")
+            val config = TestConfig(IGNORE_OVERRIDABLE_FUNCTION to false)
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(code)).hasSize(9)
         }
@@ -73,7 +73,7 @@ class FunctionOnlyReturningConstantSpec {
 
         @Test
         fun `reports actual functions which return constants`() {
-            val config = TestConfig(IGNORE_ACTUAL_FUNCTION to "false")
+            val config = TestConfig(IGNORE_ACTUAL_FUNCTION to false)
             val rule = FunctionOnlyReturningConstant(config)
             assertThat(rule.lint(actualFunctionCode, compile = false)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/LoopWithTooManyJumpStatementsSpec.kt
@@ -66,7 +66,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to 2)).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -79,7 +79,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 }
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to 2)).lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -92,7 +92,7 @@ class LoopWithTooManyJumpStatementsSpec {
                 } while (i < 1)
             }
         """.trimIndent()
-        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to "2")).lint(code)
+        val findings = LoopWithTooManyJumpStatements(TestConfig(MAX_JUMP_COUNT to 2)).lint(code)
         assertThat(findings).isEmpty()
     }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MagicNumberSpec.kt
@@ -475,12 +475,12 @@ class MagicNumberSpec {
         @Test
         fun `should report all without ignore flags`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "false",
-                IGNORE_ANNOTATION to "false",
-                IGNORE_NAMED_ARGUMENT to "false",
-                IGNORE_HASH_CODE to "false",
-                IGNORE_CONSTANT_DECLARATION to "false",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
+                IGNORE_PROPERTY_DECLARATION to false,
+                IGNORE_ANNOTATION to false,
+                IGNORE_NAMED_ARGUMENT to false,
+                IGNORE_HASH_CODE to false,
+                IGNORE_CONSTANT_DECLARATION to false,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to false,
             )
 
             val findings = MagicNumber(config).lint(code, compile = false)
@@ -500,11 +500,11 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues with all ignore flags`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "true",
-                IGNORE_ANNOTATION to "true",
-                IGNORE_HASH_CODE to "true",
-                IGNORE_CONSTANT_DECLARATION to "true",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
+                IGNORE_PROPERTY_DECLARATION to true,
+                IGNORE_ANNOTATION to true,
+                IGNORE_HASH_CODE to true,
+                IGNORE_CONSTANT_DECLARATION to true,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to true,
             )
 
             val findings = MagicNumber(config).lint(code, compile = false)
@@ -533,9 +533,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties but not constants nor companion objects`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "true",
-                IGNORE_CONSTANT_DECLARATION to "false",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
+                IGNORE_PROPERTY_DECLARATION to true,
+                IGNORE_CONSTANT_DECLARATION to false,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to false,
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -545,9 +545,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties and constants but not companion objects`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "true",
-                IGNORE_CONSTANT_DECLARATION to "true",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
+                IGNORE_PROPERTY_DECLARATION to true,
+                IGNORE_CONSTANT_DECLARATION to true,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to false,
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -557,8 +557,8 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring properties, constants and companion objects`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "true",
-                IGNORE_CONSTANT_DECLARATION to "true",
+                IGNORE_PROPERTY_DECLARATION to true,
+                IGNORE_CONSTANT_DECLARATION to true,
                 IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true"
             )
 
@@ -569,9 +569,9 @@ class MagicNumberSpec {
         @Test
         fun `should not report any issues when ignoring companion objects but not properties and constants`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "false",
-                IGNORE_CONSTANT_DECLARATION to "false",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "true",
+                IGNORE_PROPERTY_DECLARATION to false,
+                IGNORE_CONSTANT_DECLARATION to false,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to true,
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -581,9 +581,9 @@ class MagicNumberSpec {
         @Test
         fun `should report property when ignoring constants but not properties and companion objects`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "false",
-                IGNORE_CONSTANT_DECLARATION to "true",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
+                IGNORE_PROPERTY_DECLARATION to false,
+                IGNORE_CONSTANT_DECLARATION to true,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to false,
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -594,9 +594,9 @@ class MagicNumberSpec {
         @Test
         fun `should report property and constant when not ignoring properties, constants nor companion objects`() {
             val config = TestConfig(
-                IGNORE_PROPERTY_DECLARATION to "false",
-                IGNORE_CONSTANT_DECLARATION to "false",
-                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to "false",
+                IGNORE_PROPERTY_DECLARATION to false,
+                IGNORE_CONSTANT_DECLARATION to false,
+                IGNORE_COMPANION_OBJECT_PROPERTY_DECLARATION to false,
             )
 
             val findings = MagicNumber(config).lint(code)
@@ -634,25 +634,25 @@ class MagicNumberSpec {
 
             @Test
             fun `should not ignore int`() {
-                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to false))
                 assertThat(rule.lint(code("53"))).hasSize(1)
             }
 
             @Test
             fun `should not ignore float`() {
-                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to false))
                 assertThat(rule.lint(code("53f"), compile = false)).hasSize(1)
             }
 
             @Test
             fun `should not ignore binary`() {
-                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to false))
                 assertThat(rule.lint(code("0b01001"))).hasSize(1)
             }
 
             @Test
             fun `should ignore integer with underscores`() {
-                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to false))
                 assertThat(rule.lint(code("101_000"))).hasSize(1)
             }
 
@@ -749,7 +749,7 @@ class MagicNumberSpec {
 
             @Test
             fun `numbers when 'ignoreEnums' is set to true`() {
-                val rule = MagicNumber(TestConfig(IGNORE_ENUMS to "true"))
+                val rule = MagicNumber(TestConfig(IGNORE_ENUMS to true))
                 assertThat(rule.lint(code)).isEmpty()
             }
         }
@@ -765,7 +765,7 @@ class MagicNumberSpec {
 
             @Test
             fun `should be reported`() {
-                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "false"))
+                val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to false))
                 assertThat(rule.lint(code)).hasSize(1)
             }
 
@@ -773,8 +773,8 @@ class MagicNumberSpec {
             fun `numbers when 'ignoreEnums' is set to true`() {
                 val rule = MagicNumber(
                     TestConfig(
-                        IGNORE_NAMED_ARGUMENT to "false",
-                        IGNORE_ENUMS to "true",
+                        IGNORE_NAMED_ARGUMENT to false,
+                        IGNORE_ENUMS to true,
                     )
                 )
                 assertThat(rule.lint(code)).isEmpty()
@@ -783,7 +783,7 @@ class MagicNumberSpec {
 
         @Test
         fun `in constructor invocation with complex expression`() {
-            val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to "true"))
+            val rule = MagicNumber(TestConfig(IGNORE_NAMED_ARGUMENT to true))
             val code = """
                 data class Image(val size: Float)
                 val a = Image(
@@ -909,27 +909,27 @@ class MagicNumberSpec {
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports a finding if ranges are not ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "false")).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to false)).lint(code))
                 .hasSize(1)
         }
 
         @ParameterizedTest
         @MethodSource("cases")
         fun `reports no finding if ranges are ignored`(code: String) {
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code))
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to true)).lint(code))
                 .isEmpty()
         }
 
         @Test
         fun `reports a finding for a parenthesized number if ranges are ignored`() {
             val code = "val foo : Int = (127)"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to true)).lint(code)).hasSize(1)
         }
 
         @Test
         fun `reports a finding for an addition if ranges are ignored`() {
             val code = "val foo : Int = 1 + 27"
-            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to "true")).lint(code)).hasSize(1)
+            assertThat(MagicNumber(TestConfig(IGNORE_RANGES to true)).lint(code)).hasSize(1)
         }
     }
 
@@ -940,13 +940,13 @@ class MagicNumberSpec {
 
         @Test
         fun `reports 3 due to the assignment to a local variable`() {
-            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "false"))
+            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to false))
             assertThat(rule.lint(code)).hasSize(1)
         }
 
         @Test
         fun `should not report 3 due to the ignored local variable config`() {
-            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to "true"))
+            val rule = MagicNumber(TestConfig(IGNORE_LOCAL_VARIABLES to true))
             assertThat(rule.lint(code)).isEmpty()
         }
     }
@@ -956,8 +956,8 @@ class MagicNumberSpec {
 
         private val rule = MagicNumber(
             TestConfig(
-                IGNORE_LOCAL_VARIABLES to "true",
-                IGNORE_NAMED_ARGUMENT to "true",
+                IGNORE_LOCAL_VARIABLES to true,
+                IGNORE_NAMED_ARGUMENT to true,
             )
         )
 
@@ -981,7 +981,7 @@ class MagicNumberSpec {
     inner class `with extension function` {
 
         private val rule = MagicNumber(
-            TestConfig(IGNORE_EXTENSION_FUNCTIONS to "true")
+            TestConfig(IGNORE_EXTENSION_FUNCTIONS to true)
         )
 
         @Test
@@ -1105,7 +1105,7 @@ class MagicNumberSpec {
         @Test
         fun `should not report unsigned literals in property declarations when ignored`() {
             val code = "val myUInt = 65520U"
-            val findings = MagicNumber(TestConfig(IGNORE_PROPERTY_DECLARATION to "true")).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_PROPERTY_DECLARATION to true)).lint(code)
             assertThat(findings).isEmpty()
         }
 
@@ -1239,7 +1239,7 @@ class MagicNumberSpec {
                 val myUInt = 65520u
                 val myULong = 0xFFF0uL
             """.trimIndent()
-            val findings = MagicNumber(TestConfig(IGNORE_PROPERTY_DECLARATION to "true")).lint(code)
+            val findings = MagicNumber(TestConfig(IGNORE_PROPERTY_DECLARATION to true)).lint(code)
             assertThat(findings).isEmpty()
         }
     }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MaxLineLengthSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MaxLineLengthSpec.kt
@@ -76,7 +76,7 @@ class MaxLineLengthSpec {
         fun `should report no errors when maxLineLength is set to 200`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "200",
+                    MAX_LINE_LENGTH to 200,
                 )
             )
 
@@ -238,7 +238,7 @@ class MaxLineLengthSpec {
         fun `should not report the package statement and import statements by default`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
+                    MAX_LINE_LENGTH to 40,
                 )
             )
 
@@ -250,9 +250,9 @@ class MaxLineLengthSpec {
         fun `should report the package statement and import statements if they're enabled`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
-                    EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    EXCLUDE_IMPORT_STATEMENTS to "false",
+                    MAX_LINE_LENGTH to 40,
+                    EXCLUDE_PACKAGE_STATEMENTS to false,
+                    EXCLUDE_IMPORT_STATEMENTS to false,
                 )
             )
 
@@ -264,9 +264,9 @@ class MaxLineLengthSpec {
         fun `should not report anything if both package and import statements are disabled`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
-                    EXCLUDE_PACKAGE_STATEMENTS to "true",
-                    EXCLUDE_IMPORT_STATEMENTS to "true",
+                    MAX_LINE_LENGTH to 40,
+                    EXCLUDE_PACKAGE_STATEMENTS to true,
+                    EXCLUDE_IMPORT_STATEMENTS to true,
                 )
             )
 
@@ -312,7 +312,7 @@ class MaxLineLengthSpec {
         fun `should report the package statement, import statements, line and comments by default`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 
@@ -324,10 +324,10 @@ class MaxLineLengthSpec {
         fun `should report the package statement, import statements, line and comments if they're enabled`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
-                    EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    EXCLUDE_IMPORT_STATEMENTS to "false",
-                    EXCLUDE_COMMENT_STATEMENTS to "false",
+                    MAX_LINE_LENGTH to 60,
+                    EXCLUDE_PACKAGE_STATEMENTS to false,
+                    EXCLUDE_IMPORT_STATEMENTS to false,
+                    EXCLUDE_COMMENT_STATEMENTS to false,
                 )
             )
 
@@ -339,8 +339,8 @@ class MaxLineLengthSpec {
         fun `should not report comments if they're disabled`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
-                    EXCLUDE_COMMENT_STATEMENTS to "true",
+                    MAX_LINE_LENGTH to 60,
+                    EXCLUDE_COMMENT_STATEMENTS to true,
                 )
             )
 
@@ -365,7 +365,7 @@ class MaxLineLengthSpec {
         fun `should only the function line by default`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
+                    MAX_LINE_LENGTH to 40,
                 )
             )
 
@@ -377,9 +377,9 @@ class MaxLineLengthSpec {
         fun `should report the package statement, import statements and line if they're not excluded`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
-                    EXCLUDE_PACKAGE_STATEMENTS to "false",
-                    EXCLUDE_IMPORT_STATEMENTS to "false",
+                    MAX_LINE_LENGTH to 40,
+                    EXCLUDE_PACKAGE_STATEMENTS to false,
+                    EXCLUDE_IMPORT_STATEMENTS to false,
                 )
             )
 
@@ -391,9 +391,9 @@ class MaxLineLengthSpec {
         fun `should report only method if both package and import statements are disabled`() {
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "40",
-                    EXCLUDE_PACKAGE_STATEMENTS to "true",
-                    EXCLUDE_IMPORT_STATEMENTS to "true",
+                    MAX_LINE_LENGTH to 40,
+                    EXCLUDE_PACKAGE_STATEMENTS to true,
+                    EXCLUDE_IMPORT_STATEMENTS to true,
                 )
             )
 
@@ -408,8 +408,8 @@ class MaxLineLengthSpec {
     fun `report the correct lines on raw strings with backslash on it - issue #5314`() {
         val rule = MaxLineLength(
             TestConfig(
-                MAX_LINE_LENGTH to "30",
-                "excludeRawStrings" to "false",
+                MAX_LINE_LENGTH to 30,
+                "excludeRawStrings" to false,
             )
         )
 
@@ -433,8 +433,8 @@ class MaxLineLengthSpec {
     fun `report the correct lines on raw strings with backslash on it 2 - issue #5314`() {
         val rule = MaxLineLength(
             TestConfig(
-                MAX_LINE_LENGTH to "30",
-                "excludeRawStrings" to "false",
+                MAX_LINE_LENGTH to 30,
+                "excludeRawStrings" to false,
             )
         )
 
@@ -453,7 +453,7 @@ class MaxLineLengthSpec {
     fun `report the correct lines on interpolated strings - issue #5314`() {
         val rule = MaxLineLength(
             TestConfig(
-                MAX_LINE_LENGTH to "65",
+                MAX_LINE_LENGTH to 65,
             )
         )
 
@@ -511,7 +511,7 @@ class MaxLineLengthSpec {
             """.trimIndent()
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 
@@ -528,7 +528,7 @@ class MaxLineLengthSpec {
             """.trimIndent()
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 
@@ -547,7 +547,7 @@ class MaxLineLengthSpec {
             """.trimIndent()
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 
@@ -573,7 +573,7 @@ class MaxLineLengthSpec {
             """.trimIndent()
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 
@@ -595,7 +595,7 @@ class MaxLineLengthSpec {
             """.trimIndent()
             val rule = MaxLineLength(
                 TestConfig(
-                    MAX_LINE_LENGTH to "60",
+                    MAX_LINE_LENGTH to 60,
                 )
             )
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
@@ -54,7 +54,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).isEmpty()
         }
@@ -78,14 +78,14 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for if condition guard clauses`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged without guard clauses`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "false"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to false))
                 .lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -113,7 +113,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should report a too-complicated if statement for being a guard clause, with EXCLUDE_GUARD_CLAUSES on`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -134,7 +134,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged for ELVIS operator guard clauses`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).isEmpty()
         }
@@ -155,7 +155,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged for an if condition guard clause which is not the first statement`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -176,7 +176,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged for an ELVIS guard clause which is not the first statement`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to "true"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
                 .lint(code)
             assertThat(findings).hasSize(1)
         }
@@ -204,7 +204,7 @@ class ReturnCountSpec {
         fun `should not count all four guard clauses`() {
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_GUARD_CLAUSES to "true"
+                    EXCLUDE_GUARD_CLAUSES to true
                 )
             ).lint(code)
             assertThat(findings).isEmpty()
@@ -214,7 +214,7 @@ class ReturnCountSpec {
         fun `should count all four guard clauses`() {
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_GUARD_CLAUSES to "false"
+                    EXCLUDE_GUARD_CLAUSES to false
                 )
             ).lint(code)
             assertThat(findings).hasSize(1)
@@ -244,7 +244,7 @@ class ReturnCountSpec {
                 """.trimIndent()
                 val findings = ReturnCount(
                     TestConfig(
-                        EXCLUDE_GUARD_CLAUSES to "true",
+                        EXCLUDE_GUARD_CLAUSES to true,
                         MAX to 0,
                     )
                 ).lint(code)
@@ -272,7 +272,7 @@ class ReturnCountSpec {
                 """.trimIndent()
                 val findings = ReturnCount(
                     TestConfig(
-                        EXCLUDE_GUARD_CLAUSES to "true",
+                        EXCLUDE_GUARD_CLAUSES to true,
                         MAX to 0,
                     )
                 ).lint(code)
@@ -301,7 +301,7 @@ class ReturnCountSpec {
                 """.trimIndent()
                 val findings = ReturnCount(
                     TestConfig(
-                        EXCLUDE_GUARD_CLAUSES to "true",
+                        EXCLUDE_GUARD_CLAUSES to true,
                         MAX to 0,
                     )
                 ).lint(code)
@@ -330,7 +330,7 @@ class ReturnCountSpec {
                 """.trimIndent()
                 val findings = ReturnCount(
                     TestConfig(
-                        EXCLUDE_GUARD_CLAUSES to "false",
+                        EXCLUDE_GUARD_CLAUSES to false,
                         MAX to 3,
                     )
                 ).lint(code)
@@ -360,13 +360,13 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged when max value is 3`() {
-            val findings = ReturnCount(TestConfig(MAX to "3")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 3)).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(MAX to "1")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 1)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -391,13 +391,13 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flagged when max value is 2`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 2)).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should get flagged when max value is 1`() {
-            val findings = ReturnCount(TestConfig(MAX to "1")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 1)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -419,7 +419,7 @@ class ReturnCountSpec {
         fun `should not get flagged`() {
             val findings = ReturnCount(
                 TestConfig(
-                    MAX to "2",
+                    MAX to 2,
                     EXCLUDED_FUNCTIONS to listOf("test"),
                 )
             ).lint(code)
@@ -462,7 +462,7 @@ class ReturnCountSpec {
         fun `should flag none of the ignored functions`() {
             val findings = ReturnCount(
                 TestConfig(
-                    MAX to "2",
+                    MAX to 2,
                     EXCLUDED_FUNCTIONS to listOf("factorial", "fac"),
                 )
             ).lint(code)
@@ -473,7 +473,7 @@ class ReturnCountSpec {
         fun `should flag none of the ignored functions using globbing`() {
             val findings = ReturnCount(
                 TestConfig(
-                    MAX to "2",
+                    MAX to 2,
                     EXCLUDED_FUNCTIONS to listOf("fa*ctorial"),
                 )
             ).lint(code)
@@ -504,7 +504,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 2)).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -541,7 +541,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should not get flag when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 2)).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -580,7 +580,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should get flagged when returns is in inner object`() {
-            val findings = ReturnCount(TestConfig(MAX to "2")).lint(code)
+            val findings = ReturnCount(TestConfig(MAX to 2)).lint(code)
             assertThat(findings).hasSize(1)
         }
     }
@@ -605,14 +605,14 @@ class ReturnCountSpec {
 
         @Test
         fun `should count labeled returns from lambda when activated`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false"))
+            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to false))
                 .lint(code, compile = false)
             assertThat(findings).hasSize(1)
         }
 
         @Test
         fun `should be empty when labeled returns are de-activated`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_LABELED to "true", EXCLUDE_RETURN_FROM_LAMBDA to "false",))
+            val findings = ReturnCount(TestConfig(EXCLUDE_LABELED to true, EXCLUDE_RETURN_FROM_LAMBDA to false))
                 .lint(code, compile = false)
             assertThat(findings).isEmpty()
         }
@@ -632,7 +632,7 @@ class ReturnCountSpec {
 
         @Test
         fun `should count labeled return of lambda with explicit label`() {
-            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to "false")).lint(code)
+            val findings = ReturnCount(TestConfig(EXCLUDE_RETURN_FROM_LAMBDA to false)).lint(code)
             assertThat(findings).hasSize(1)
         }
 
@@ -646,8 +646,8 @@ class ReturnCountSpec {
         fun `excludeReturnFromLambda should take precedence over excludeLabeled`() {
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_RETURN_FROM_LAMBDA to "true",
-                    EXCLUDE_LABELED to "false",
+                    EXCLUDE_RETURN_FROM_LAMBDA to true,
+                    EXCLUDE_LABELED to false,
                 )
             ).lint(code)
             assertThat(findings).isEmpty()
@@ -677,7 +677,7 @@ class ReturnCountSpec {
             """.trimIndent()
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_GUARD_CLAUSES to "true",
+                    EXCLUDE_GUARD_CLAUSES to true,
                     MAX to 1,
                 )
             ).lint(code)
@@ -717,7 +717,7 @@ class ReturnCountSpec {
             """.trimIndent()
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_GUARD_CLAUSES to "true",
+                    EXCLUDE_GUARD_CLAUSES to true,
                     MAX to 1,
                 )
             ).lint(code)
@@ -745,7 +745,7 @@ class ReturnCountSpec {
             """.trimIndent()
             val findings = ReturnCount(
                 TestConfig(
-                    EXCLUDE_GUARD_CLAUSES to "true",
+                    EXCLUDE_GUARD_CLAUSES to true,
                     MAX to 1,
                 )
             ).lint(code)

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
@@ -138,14 +138,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `does not report when max parameter is 3`() {
-            val config = TestConfig(MAX to "3")
+            val config = TestConfig(MAX to 3)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
         fun `reports violation when max parameter is 2`() {
-            val config = TestConfig(MAX to "2")
+            val config = TestConfig(MAX to 2)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(code)).hasSize(1)
         }
@@ -166,14 +166,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to false)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
@@ -194,14 +194,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to false)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
         }
@@ -229,7 +229,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -250,7 +250,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -271,7 +271,7 @@ class ThrowsCountSpec {
 
         @Test
         fun `should report the violation even with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithIfCondition)).hasSize(1)
         }
@@ -295,14 +295,14 @@ class ThrowsCountSpec {
 
         @Test
         fun `should not report violation with EXCLUDE_GUARD_CLAUSES as true`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "true")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithMultipleGuardClauses)).isEmpty()
         }
 
         @Test
         fun `should report violation with EXCLUDE_GUARD_CLAUSES as false`() {
-            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to "false")
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to false)
             val subject = ThrowsCount(config)
             assertThat(subject.lint(codeWithMultipleGuardClauses)).hasSize(1)
         }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnderscoresInNumericLiteralsSpec.kt
@@ -26,7 +26,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "3")
+                TestConfig(ACCEPTABLE_LENGTH to 3)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -56,7 +56,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "7")
+                TestConfig(ACCEPTABLE_LENGTH to 7)
             ).lint(code)
             assertThat(findings).isEmpty()
         }
@@ -75,7 +75,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "3")
+                TestConfig(ACCEPTABLE_LENGTH to 3)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -94,7 +94,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "3")
+                TestConfig(ACCEPTABLE_LENGTH to 3)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -124,7 +124,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if ignored acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "7")
+                TestConfig(ACCEPTABLE_LENGTH to 7)
             ).lint(code)
             assertThat(findings).isEmpty()
         }
@@ -155,7 +155,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "3")
+                TestConfig(ACCEPTABLE_LENGTH to 3)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -198,7 +198,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should still be reported even if acceptableLength is 99`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "99")
+                TestConfig(ACCEPTABLE_LENGTH to 99)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -369,7 +369,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 5`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "5")
+                TestConfig(ACCEPTABLE_LENGTH to 5)
             ).lint(code)
             assertThat(findings).isEmpty()
         }
@@ -407,7 +407,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should be reported if acceptableLength is 3`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "3")
+                TestConfig(ACCEPTABLE_LENGTH to 3)
             ).lint(code)
             assertThat(findings).isNotEmpty
         }
@@ -427,7 +427,7 @@ class UnderscoresInNumericLiteralsSpec {
         @Test
         fun `should not be reported if acceptableLength is 7`() {
             val findings = UnderscoresInNumericLiterals(
-                TestConfig(ACCEPTABLE_LENGTH to "7")
+                TestConfig(ACCEPTABLE_LENGTH to 7)
             ).lint(code)
             assertThat(findings).isEmpty()
         }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UseDataClassSpec.kt
@@ -325,7 +325,7 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
         @Test
         fun `does not report class with mutable constructor parameter`() {
             val code = """class DataClassCandidateWithVar(var i: Int)"""
-            val config = TestConfig(ALLOW_VARS to "true")
+            val config = TestConfig(ALLOW_VARS to true)
             assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
@@ -336,7 +336,7 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
                     var i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(ALLOW_VARS to "true")
+            val config = TestConfig(ALLOW_VARS to true)
             assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
@@ -347,7 +347,7 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
                     var i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(ALLOW_VARS to "true")
+            val config = TestConfig(ALLOW_VARS to true)
             assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
 
@@ -358,7 +358,7 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
                     val i2: Int = 0
                 }
             """.trimIndent()
-            val config = TestConfig(ALLOW_VARS to "true")
+            val config = TestConfig(ALLOW_VARS to true)
             assertThat(UseDataClass(config).lintWithContext(env, code)).isEmpty()
         }
     }


### PR DESCRIPTION
`YamlConfig` had a lot of casting to support things like:

```yaml
active: "true"
```

I'm not sure if we should support that on `YamlConfig` but for sure we don't need to support that on `TestConfig`. That only makes the code more difficult and `TestConfig` way more complex. This PR changes all the cases where we were using `TestConfig` on our rule tests without using the correct type.

Basically we were using String to enconde `Int`, `Boolean` and `List` instead of passing that value directly.

This helps with #8681 because `TestConfig` was using the complex casting code from `YamlConfig`. After this PR we can remove that dependency.