### PR TITLE
Remove dependecy of `:detekt-test` with `:detekt-core`

### DIFF
--- a/detekt-rules-comments/build.gradle.kts
+++ b/detekt-rules-comments/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     compileOnly(libs.jetbrains.annotations)
 
     testImplementation(libs.kotlin.compiler)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestUtils)

--- a/detekt-rules-complexity/build.gradle.kts
+++ b/detekt-rules-complexity/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektMetrics)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-empty-blocks/build.gradle.kts
+++ b/detekt-rules-empty-blocks/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(libs.assertj.core)

--- a/detekt-rules-exceptions/build.gradle.kts
+++ b/detekt-rules-exceptions/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestUtils)

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-naming/build.gradle.kts
+++ b/detekt-rules-naming/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-performance/build.gradle.kts
+++ b/detekt-rules-performance/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-potential-bugs/build.gradle.kts
+++ b/detekt-rules-potential-bugs/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-ruleauthors/build.gradle.kts
+++ b/detekt-rules-ruleauthors/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(libs.assertj.core)

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -9,6 +9,8 @@ dependencies {
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
+    testRuntimeOnly(projects.detektMetrics)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -8,5 +8,4 @@ dependencies {
     api(projects.detektTestUtils)
     api(libs.kotlin.compiler)
     implementation(libs.kotlin.reflect)
-    implementation(projects.detektCore)
 }


### PR DESCRIPTION
Close #8681

I'm not sure if we want those dependencies as `testRuntimeOnly` or `testImplementaion`. I set them to `restRuntimeOnly` because we don't need them at compilation time.

~Waiting for:~
- ~#8976~
- ~#8986~