### PR TITLE
Remove `InvalidConfigurationError` from our public API

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -39,10 +39,6 @@ public final class dev/detekt/api/Config$Companion {
 	public final fun getEmpty ()Ldev/detekt/api/Config;
 }
 
-public final class dev/detekt/api/Config$InvalidConfigurationError : java/lang/RuntimeException {
-	public fun <init> (Ljava/lang/Throwable;)V
-}
-
 public final class dev/detekt/api/ConfigPropertyKt {
 	public static final fun config (Ljava/lang/Object;)Lkotlin/properties/ReadOnlyProperty;
 	public static final fun config (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lkotlin/properties/ReadOnlyProperty;

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
@@ -41,19 +41,6 @@ interface Config {
      */
     fun <T : Any> valueOrNull(key: String): T?
 
-    /**
-     * Is thrown when loading a configuration results in errors.
-     */
-    class InvalidConfigurationError(throwable: Throwable) :
-        RuntimeException(
-            """
-                Provided configuration file is invalid: Structure must be from type Map<String,Any>!
-                ${throwable.message}
-            """.trimIndent(),
-            throwable,
-        )
-
-
     companion object {
 
         /**

--- a/detekt-api/src/main/kotlin/dev/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/ConfigProperty.kt
@@ -109,9 +109,9 @@ private fun Config.getValuesWithReasonOrDefault(
                             reason = it["reason"] as String?
                         )
                     } catch (e: ClassCastException) {
-                        throw Config.InvalidConfigurationError(e)
+                        throw InvalidConfigurationError(e)
                     } catch (@Suppress("TooGenericExceptionCaught") e: NullPointerException) {
-                        throw Config.InvalidConfigurationError(e)
+                        throw InvalidConfigurationError(e)
                     }
                 }
 
@@ -123,6 +123,15 @@ private fun Config.getValuesWithReasonOrDefault(
         }
     )
 }
+
+internal class InvalidConfigurationError(throwable: Throwable) :
+    RuntimeException(
+        """
+            Provided configuration file is invalid: Structure must be from type Map<String,Any>!
+            ${throwable.message}
+        """.trimIndent(),
+        throwable,
+    )
 
 private abstract class MemoizedConfigProperty<U : Any> : ReadOnlyProperty<Rule, U> {
     private var value: U? = null

--- a/detekt-api/src/test/kotlin/dev/detekt/api/ConfigPropertySpec.kt
+++ b/detekt-api/src/test/kotlin/dev/detekt/api/ConfigPropertySpec.kt
@@ -149,7 +149,7 @@ class ConfigPropertySpec {
                             ) {
                                 val present: ValuesWithReason by config(defaultValue)
                             }.present
-                        }.isInstanceOf(Config.InvalidConfigurationError::class.java)
+                        }.isInstanceOf(InvalidConfigurationError::class.java)
                     }
 
                     @Test
@@ -162,7 +162,7 @@ class ConfigPropertySpec {
                             ) {
                                 val present: ValuesWithReason by config(defaultValue)
                             }.present
-                        }.isInstanceOf(Config.InvalidConfigurationError::class.java)
+                        }.isInstanceOf(InvalidConfigurationError::class.java)
                     }
 
                     @Test
@@ -175,7 +175,7 @@ class ConfigPropertySpec {
                             ) {
                                 val present: ValuesWithReason by config(defaultValue)
                             }.present
-                        }.isInstanceOf(Config.InvalidConfigurationError::class.java)
+                        }.isInstanceOf(InvalidConfigurationError::class.java)
                     }
                 }
             }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
@@ -87,7 +87,7 @@ class YamlConfig internal constructor(
                 val map: Map<*, *>? = runCatching {
                     @Suppress("UNCHECKED_CAST")
                     createYamlLoad().loadFromReader(bufferedReader) as Map<String, *>?
-                }.getOrElse { throw Config.InvalidConfigurationError(it) }
+                }.getOrElse { throw InvalidConfigurationError(it) }
                 @Suppress("UNCHECKED_CAST")
                 YamlConfig(map.orEmpty() as Map<String, Any>, null, null)
             }
@@ -103,6 +103,15 @@ class YamlConfig internal constructor(
             )
     }
 }
+
+internal class InvalidConfigurationError(throwable: Throwable) :
+    RuntimeException(
+        """
+            Provided configuration file is invalid: Structure must be from type Map<String,Any>!
+            ${throwable.message}
+        """.trimIndent(),
+        throwable,
+    )
 
 @Suppress("MagicNumber")
 private fun Map<*, *>.toPrettyString(recursive: Int): String =

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/YamlConfigSpec.kt
@@ -1,6 +1,5 @@
 package dev.detekt.core.config
 
-import dev.detekt.api.Config
 import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.test.yamlConfig
 import dev.detekt.test.yamlConfigFromContent
@@ -266,7 +265,7 @@ class YamlConfigSpec {
                               {}map
                     """.trimIndent()
                 )
-            }.isInstanceOf(Config.InvalidConfigurationError::class.java)
+            }.isInstanceOf(InvalidConfigurationError::class.java)
                 .hasMessageContaining("Provided configuration file is invalid")
                 .hasCauseInstanceOf(ParserException::class.java)
         }


### PR DESCRIPTION
This exception should only be used by `YamlConfig`. But it is also used in `ConfigProperty` 🤷‍♂️ so I'm copying it in both places to remove it from inside `Config`. The one from `ConfigProperty` should be reworked. At least to improve the error message.