### PR TITLE
`AnalysisMode` shouldn't depend on how we define the `cli`

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -52,8 +52,8 @@ class ClasspathResourceConverter : IStringConverter<URL> {
 class AnalysisModeConverter : IStringConverter<AnalysisMode> {
     override fun convert(value: String): AnalysisMode =
         when (value) {
-            "light" -> AnalysisMode.light
-            "full" -> AnalysisMode.full
+            "light" -> AnalysisMode.Light
+            "full" -> AnalysisMode.Full
             else -> throw ParameterException("Invald value $value")
         }
 }

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -1,9 +1,11 @@
 package dev.detekt.cli
 
+import com.beust.jcommander.IParameterValidator
 import com.beust.jcommander.IStringConverter
 import com.beust.jcommander.IValueValidator
 import com.beust.jcommander.ParameterException
 import com.beust.jcommander.converters.IParameterSplitter
+import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.config.ApiVersion
 import org.jetbrains.kotlin.config.JvmTarget
 import org.jetbrains.kotlin.config.LanguageVersion
@@ -44,6 +46,23 @@ class ClasspathResourceConverter : IStringConverter<URL> {
         val relativeResource = if (resource.startsWith("/")) resource else "/$resource"
         return javaClass.getResource(relativeResource)
             ?: throw ParameterException("Classpath resource '$resource' does not exist!")
+    }
+}
+
+class AnalysisModeConverter : IStringConverter<AnalysisMode> {
+    override fun convert(value: String): AnalysisMode =
+        when (value) {
+            "light" -> AnalysisMode.light
+            "full" -> AnalysisMode.full
+            else -> throw ParameterException("Invald value $value")
+        }
+}
+
+class AnalysisModeValidator : IParameterValidator {
+    override fun validate(name: String, value: String) {
+        if (value !in setOf("light", "full")) {
+            throw ParameterException("Invalid value for $name parameter. Allowed values:[full, light]")
+        }
     }
 }
 

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -27,6 +27,8 @@ class CliArgs {
 
     @Parameter(
         names = ["--analysis-mode"],
+        validateWith = [AnalysisModeValidator::class],
+        converter = AnalysisModeConverter::class,
         description = "Analysis mode used by detekt. " +
             "'full' analysis mode is comprehensive but requires the correct compiler options to be provided. " +
             "'light' analysis cannot utilise compiler information and some rules cannot be run in this mode."

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -33,7 +33,7 @@ class CliArgs {
             "'full' analysis mode is comprehensive but requires the correct compiler options to be provided. " +
             "'light' analysis cannot utilise compiler information and some rules cannot be run in this mode."
     )
-    var analysisMode: AnalysisMode = AnalysisMode.light
+    var analysisMode: AnalysisMode = AnalysisMode.Light
 
     @Parameter(
         names = ["--includes", "-in"],

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -295,13 +295,13 @@ internal class CliArgsSpec {
             @Test
             fun `--analysis-mode light is accepted`() {
                 val spec = parseArguments(arrayOf("--analysis-mode", "light")).toSpec()
-                assertThat(spec.projectSpec.analysisMode).isEqualTo(AnalysisMode.light)
+                assertThat(spec.projectSpec.analysisMode).isEqualTo(AnalysisMode.Light)
             }
 
             @Test
             fun `--analysis-mode full is accepted`() {
                 val spec = parseArguments(arrayOf("--analysis-mode", "full")).toSpec()
-                assertThat(spec.projectSpec.analysisMode).isEqualTo(AnalysisMode.full)
+                assertThat(spec.projectSpec.analysisMode).isEqualTo(AnalysisMode.Full)
             }
 
             @Test

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -308,6 +308,7 @@ internal class CliArgsSpec {
             fun `throws exception on invalid analysis mode`() {
                 assertThatExceptionOfType(HandledArgumentViolation::class.java)
                     .isThrownBy { parseArguments(arrayOf("--analysis-mode", "invalid")) }
+                    .withMessage("Invalid value for --analysis-mode parameter. Allowed values:[full, light]")
             }
         }
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/RuleDescriptor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/RuleDescriptor.kt
@@ -55,8 +55,8 @@ private fun RuleSet.getRules(
                 val ruleConfig = config.subConfig(ruleId)
                 val active = config.isActiveOrDefault(true) && ruleConfig.isActiveOrDefault(false)
                 val executable = when (analysisMode) {
-                    AnalysisMode.full -> true
-                    AnalysisMode.light -> rule !is RequiresAnalysisApi
+                    AnalysisMode.Full -> true
+                    AnalysisMode.Light -> rule !is RequiresAnalysisApi
                 }
                 if (active && !executable) {
                     log { "The rule '$ruleId' requires type resolution but it was run without it." }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -22,7 +22,7 @@ internal fun annotationSuppressorFactory(rule: Rule, analysisMode: AnalysisMode)
         Suppressor { finding ->
             val element = finding.entity.ktElement
             element.isAnnotatedWith(
-                AnnotationExcluder(element.containingKtFile, annotations, analysisMode == AnalysisMode.full),
+                AnnotationExcluder(element.containingKtFile, annotations, analysisMode == AnalysisMode.Full),
             )
         }
     } else {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/FunctionSuppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/FunctionSuppressor.kt
@@ -36,7 +36,7 @@ private fun functionSuppressor(
     element: KtElement,
     functionMatchers: List<FunctionMatcher>,
     analysisMode: AnalysisMode,
-): Boolean = element.isInFunctionNamed(functionMatchers, analysisMode == AnalysisMode.full)
+): Boolean = element.isInFunctionNamed(functionMatchers, analysisMode == AnalysisMode.Full)
 
 private fun KtElement.isInFunctionNamed(functionMatchers: List<FunctionMatcher>, fullAnalysis: Boolean): Boolean =
     if (this is KtNamedFunction && functionMatchers.any { it.match(this, fullAnalysis) }) {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -35,7 +35,7 @@ internal class Lifecycle(
     fun analyze(): Detektion {
         measure(Phase.ValidateConfig) { checkConfiguration(settings, baselineConfig) }
         val filesToAnalyze = measure(Phase.Parsing) { settings.ktFiles }
-        if (settings.spec.projectSpec.analysisMode == AnalysisMode.full) {
+        if (settings.spec.projectSpec.analysisMode == AnalysisMode.Full) {
             measure(Phase.ValidateClasspath) { validateClasspath(filesToAnalyze) }
         }
         val analysisMode = settings.spec.projectSpec.analysisMode

--- a/detekt-core/src/test/kotlin/dev/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/AnalyzerSpec.kt
@@ -461,7 +461,7 @@ internal fun Analyzer(
     settings: ProcessingSettings,
     vararg ruleDescriptors: RuleDescriptor,
     processors: List<FileProcessListener> = emptyList(),
-    analysisMode: AnalysisMode = AnalysisMode.light,
+    analysisMode: AnalysisMode = AnalysisMode.Light,
 ): Analyzer =
     Analyzer(
         settings,

--- a/detekt-core/src/test/kotlin/dev/detekt/core/RuleDescriptorKtTest.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/RuleDescriptorKtTest.kt
@@ -49,7 +49,7 @@ class RuleDescriptorKtTest {
     @Test
     fun returns4RulesAndIgnoreUnknownRule() {
         val rules = getRules(
-            AnalysisMode.full,
+            AnalysisMode.Full,
             listOf(TestDefaultRuleSetProvider()),
             yamlConfigFromContent(
                 """
@@ -82,7 +82,7 @@ class RuleDescriptorKtTest {
     @Test
     fun doesntCrashWhenConfigHasWrongType() {
         val rules = getRules(
-            AnalysisMode.full,
+            AnalysisMode.Full,
             listOf(TestDefaultRuleSetProvider()),
             yamlConfigFromContent(
                 """
@@ -116,7 +116,7 @@ class RuleDescriptorKtTest {
     @Test
     fun `when fullAnalysis is disabled the rules that require full analysis are inactive`() {
         val rules = getRules(
-            AnalysisMode.light,
+            AnalysisMode.Light,
             listOf(TestDefaultRuleSetProvider()),
             yamlConfigFromContent(
                 """
@@ -150,7 +150,7 @@ class RuleDescriptorKtTest {
     @Test
     fun `when fullAnalysis is disabled but the rule is disabled we log nothing`() {
         val rules = getRules(
-            AnalysisMode.light,
+            AnalysisMode.Light,
             listOf(TestDefaultRuleSetProvider()),
             yamlConfigFromContent(
                 """
@@ -172,7 +172,7 @@ class RuleDescriptorKtTest {
     @Test
     fun whenRuleSetIsInactiveReturnsAllRuleAreDisabled() {
         val rules = getRules(
-            AnalysisMode.light,
+            AnalysisMode.Light,
             listOf(TestDefaultRuleSetProvider()),
             yamlConfigFromContent(
                 """
@@ -208,7 +208,7 @@ class RuleDescriptorKtTest {
         @Test
         fun whenRuleSetIsInactiveReturnsAllRuleAreDisabled() {
             val rules = getRules(
-                AnalysisMode.light,
+                AnalysisMode.Light,
                 listOf(TestCustomRuleSetProvider()),
                 yamlConfigFromContent(
                     """
@@ -241,7 +241,7 @@ class RuleDescriptorKtTest {
         @ValueSource(strings = ["warning", "WARNING", "wArNiNg"])
         fun ignoreCase(candidate: String) {
             val rules = getRules(
-                AnalysisMode.light,
+                AnalysisMode.Light,
                 listOf(TestDefaultRuleSetProvider()),
                 yamlConfigFromContent(
                     """
@@ -271,7 +271,7 @@ class RuleDescriptorKtTest {
         @EnumSource(Severity::class)
         fun supportsAll(severity: Severity) {
             val rules = getRules(
-                AnalysisMode.light,
+                AnalysisMode.Light,
                 listOf(TestDefaultRuleSetProvider()),
                 yamlConfigFromContent(
                     """
@@ -301,7 +301,7 @@ class RuleDescriptorKtTest {
         fun unknownSeverityThrows() {
             assertThatThrownBy {
                 getRules(
-                    AnalysisMode.light,
+                    AnalysisMode.Light,
                     listOf(TestDefaultRuleSetProvider()),
                     yamlConfigFromContent(
                         """
@@ -324,7 +324,7 @@ class RuleDescriptorKtTest {
         @Test
         fun severityOnRuleSet() {
             val rules = getRules(
-                AnalysisMode.light,
+                AnalysisMode.Light,
                 listOf(TestDefaultRuleSetProvider()),
                 yamlConfigFromContent(
                     """

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -24,7 +24,7 @@ class AnnotationSuppressorSpec {
     inner class AnnotationSuppressorFactory {
         @Test
         fun `Factory returns null if ignoreAnnotated is not set`() {
-            val suppressor = annotationSuppressorFactory(buildRule(), AnalysisMode.full)
+            val suppressor = annotationSuppressorFactory(buildRule(), AnalysisMode.Full)
 
             assertThat(suppressor).isNull()
         }
@@ -33,7 +33,7 @@ class AnnotationSuppressorSpec {
         fun `Factory returns null if ignoreAnnotated is set to empty`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to emptyList<String>()),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )
 
             assertThat(suppressor).isNull()
@@ -43,7 +43,7 @@ class AnnotationSuppressorSpec {
         fun `Factory returns not null if ignoreAnnotated is set to a not empty list`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Composable")),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )
 
             assertThat(suppressor).isNotNull()
@@ -54,7 +54,7 @@ class AnnotationSuppressorSpec {
     inner class AnnotationSuppressor {
         val suppressor = annotationSuppressorFactory(
             buildRule("ignoreAnnotated" to listOf("Composable")),
-            AnalysisMode.light,
+            AnalysisMode.Light,
         )!!
 
         @Test
@@ -313,8 +313,8 @@ class AnnotationSuppressorSpec {
 
             fun getFile() =
                 listOf(
-                    Arguments.of(compileContentForTest(code), AnalysisMode.light),
-                    Arguments.of(analysisApiEngine.compile(code, composableFiles), AnalysisMode.full),
+                    Arguments.of(compileContentForTest(code), AnalysisMode.Light),
+                    Arguments.of(analysisApiEngine.compile(code, composableFiles), AnalysisMode.Full),
                 )
 
             @ParameterizedTest
@@ -401,7 +401,7 @@ class AnnotationSuppressorSpec {
         fun `Doesn't mix annotations`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )!!
 
             val root = analysisApiEngine.compile(
@@ -422,7 +422,7 @@ class AnnotationSuppressorSpec {
         fun `Works when no using imports`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )!!
 
             val root = analysisApiEngine.compile(
@@ -443,7 +443,7 @@ class AnnotationSuppressorSpec {
         fun `Works when using import alias`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("androidx.compose.runtime.Composable")),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )!!
 
             val root = analysisApiEngine.compile(
@@ -492,7 +492,7 @@ class AnnotationSuppressorSpec {
         fun `suppress if it has parameters with type solving`(analysisApiEngine: KotlinAnalysisApiEngine) {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Preview")),
-                AnalysisMode.full,
+                AnalysisMode.Full,
             )!!
 
             val root = analysisApiEngine.compile(code, composableFiles)
@@ -505,7 +505,7 @@ class AnnotationSuppressorSpec {
         fun `suppress if it has parameters without type solving`() {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Preview")),
-                AnalysisMode.light,
+                AnalysisMode.Light,
             )!!
 
             val ktFunction = compileContentForTest(code).findChildByClass(KtFunction::class.java)!!

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/FunctionSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/FunctionSuppressorSpec.kt
@@ -19,7 +19,7 @@ class FunctionSuppressorSpec {
         fun `Factory returns null if ignoreFunction is not set`() {
             val suppressor = functionSuppressorFactory(
                 buildRule(),
-                AnalysisMode.light,
+                AnalysisMode.Light,
             )
 
             assertThat(suppressor).isNull()
@@ -29,7 +29,7 @@ class FunctionSuppressorSpec {
         fun `Factory returns null if ignoreFunction is set to empty`() {
             val suppressor = functionSuppressorFactory(
                 buildRule("ignoreFunction" to emptyList<String>()),
-                AnalysisMode.light,
+                AnalysisMode.Light,
             )
 
             assertThat(suppressor).isNull()
@@ -39,7 +39,7 @@ class FunctionSuppressorSpec {
         fun `Factory returns not null if ignoreFunction is set to a not empty list`() {
             val suppressor = functionSuppressorFactory(
                 buildRule("ignoreFunction" to listOf("toString")),
-                AnalysisMode.light,
+                AnalysisMode.Light,
             )
 
             assertThat(suppressor).isNotNull()
@@ -50,7 +50,7 @@ class FunctionSuppressorSpec {
     inner class FunctionSuppressor {
         @Test
         fun `If KtElement is null it returns false`() {
-            val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+            val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
 
             assertThat(suppressor.shouldSuppress(buildFinding(element = null))).isFalse()
         }
@@ -75,14 +75,14 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports root it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
             @Test
             fun `If reports class it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
@@ -90,7 +90,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports function in class it returns true`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
 
@@ -99,7 +99,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports parameter in function in class it returns true`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -109,7 +109,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports function in function it returns true`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
                     .children
@@ -120,7 +120,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports parameter function in function it returns true`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
                     .children
@@ -132,7 +132,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports parameter function in function it returns true 2`() {
-                val suppressor = buildFunctionSuppressor(listOf("hello"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("hello"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("toString")!!
                     .children
@@ -144,7 +144,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports top level function it returns true`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isTrue()
@@ -167,13 +167,13 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports root it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 assertThat(suppressor.shouldSuppress(buildFinding(element = root))).isFalse()
             }
 
             @Test
             fun `If reports class it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktClass = root.findChildByClass(KtClass::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktClass))).isFalse()
@@ -181,7 +181,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports function in class it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("compare")!!
 
@@ -190,7 +190,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports parameter in function in class it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktParameter = root.findChildByClass(KtClass::class.java)!!
                     .findFunctionByName("compare")!!
                     .findDescendantOfType<KtParameter>()!!
@@ -200,7 +200,7 @@ class FunctionSuppressorSpec {
 
             @Test
             fun `If reports top level function it returns false`() {
-                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.light)
+                val suppressor = buildFunctionSuppressor(listOf("toString"), AnalysisMode.Light)
                 val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
                 assertThat(suppressor.shouldSuppress(buildFinding(element = ktFunction))).isFalse()

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/SuppressorsSpec.kt
@@ -35,7 +35,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, AnalysisMode.light)
+        val suppress = buildSuppressors(rule, AnalysisMode.Light)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(noIgnorableFinding) }
 
         assertThat(suppress).isFalse()
@@ -44,7 +44,7 @@ class SuppressorsSpec {
     @Test
     fun `A finding that should not be suppressed`() {
         val rule = ARule(TestConfig("ignoreAnnotated" to listOf("Composable")))
-        val suppress = buildSuppressors(rule, AnalysisMode.light)
+        val suppress = buildSuppressors(rule, AnalysisMode.Light)
             .fold(false) { acc, suppressor -> acc || suppressor.shouldSuppress(ignorableFinding) }
 
         assertThat(suppress).isTrue()

--- a/detekt-core/src/test/kotlin/dev/detekt/core/util/PerformanceMonitorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/util/PerformanceMonitorSpec.kt
@@ -18,7 +18,7 @@ class PerformanceMonitorSpec {
             project {
                 basePath = resourceAsPath("")
                 inputPaths = listOf(resourceAsPath("cases/Test.kt"))
-                analysisMode = AnalysisMode.full
+                analysisMode = AnalysisMode.Full
             }
             logging {
                 debug = true
@@ -38,7 +38,7 @@ class PerformanceMonitorSpec {
             project {
                 basePath = resourceAsPath("")
                 inputPaths = listOf(resourceAsPath("cases/Test.kt"))
-                analysisMode = AnalysisMode.light
+                analysisMode = AnalysisMode.Light
             }
             logging {
                 debug = true

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -1,6 +1,6 @@
 public final class dev/detekt/tooling/api/AnalysisMode : java/lang/Enum {
-	public static final field full Ldev/detekt/tooling/api/AnalysisMode;
-	public static final field light Ldev/detekt/tooling/api/AnalysisMode;
+	public static final field Full Ldev/detekt/tooling/api/AnalysisMode;
+	public static final field Light Ldev/detekt/tooling/api/AnalysisMode;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ldev/detekt/tooling/api/AnalysisMode;
 	public static fun values ()[Ldev/detekt/tooling/api/AnalysisMode;

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/AnalysisMode.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/AnalysisMode.kt
@@ -1,16 +1,15 @@
 package dev.detekt.tooling.api
 
-@Suppress("EnumEntryName") // we use lower case enum names as the enum values are exposed in CLI --help
 enum class AnalysisMode {
     /**
      * Allows rules to analyse the PSI & AST of files and also use additional information from the compiler like types,
-     * symbols and smart casts. [light] mode is faster but rules that use additional compiler information will not run.
+     * symbols and smart casts. [Light] mode is faster but rules that use additional compiler information will not run.
      */
-    full,
+    Full,
 
     /**
-     * Allows rules to analyse the PSI & AST of files only. Use [full] mode to allow rules to use additional information
+     * Allows rules to analyse the PSI & AST of files only. Use [Full] mode to allow rules to use additional information
      * from the compiler like types, symbols and smart casts.
      */
-    light,
+    Light,
 }

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/ProjectSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/ProjectSpecBuilder.kt
@@ -15,7 +15,7 @@ class ProjectSpecBuilder : Builder<ProjectSpec> {
             field = value
         }
     var inputPaths: Collection<Path> = emptyList()
-    var analysisMode: AnalysisMode = AnalysisMode.light
+    var analysisMode: AnalysisMode = AnalysisMode.Light
 
     override fun build(): ProjectSpec = ProjectModel(basePath, inputPaths, analysisMode)
 }


### PR DESCRIPTION
This PR removes this `@Suppress`:

```kotlin
@Suppress("EnumEntryName") // we use lower case enum names as the enum values are exposed in CLI --help
enum class AnalysisMode
```

Our tooling API shouldn't depend on how is our cli.