### PR TITLE
Remove unnecessary interface

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/AnalysisFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/AnalysisFacade.kt
@@ -16,15 +16,10 @@ import org.jetbrains.kotlin.psi.KtFile
 
 class AnalysisFacade(private val spec: ProcessingSpec) : Detekt {
 
-    override fun run(): AnalysisResult =
-        runAnalysis {
-            DefaultLifecycle(spec.getDefaultConfiguration(), it)
-        }
+    override fun run(): AnalysisResult = runAnalysis { Lifecycle(spec.getDefaultConfiguration(), it) }
 
     override fun run(files: Collection<KtFile>): AnalysisResult =
-        runAnalysis {
-            DefaultLifecycle(spec.getDefaultConfiguration(), it)
-        }
+        runAnalysis { Lifecycle(spec.getDefaultConfiguration(), it) }
 
     internal fun runAnalysis(createLifecycle: (ProcessingSettings) -> Lifecycle): AnalysisResult =
         spec.withSettings {

--- a/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -8,7 +8,7 @@ import dev.detekt.api.RuleSet
 import dev.detekt.api.RuleSetId
 import dev.detekt.api.RuleSetProvider
 import dev.detekt.core.tooling.AnalysisFacade
-import dev.detekt.core.tooling.DefaultLifecycle
+import dev.detekt.core.tooling.Lifecycle
 import dev.detekt.test.utils.NullPrintStream
 import dev.detekt.test.utils.readResourceContent
 import dev.detekt.test.utils.resourceAsPath
@@ -52,7 +52,7 @@ class TopLevelAutoCorrectSpec {
         }
 
         AnalysisFacade(spec).runAnalysis { settings ->
-            DefaultLifecycle(
+            Lifecycle(
                 settings.config,
                 settings,
                 processorsProvider = { listOf(contentChangedListener) },


### PR DESCRIPTION
`Lifecycle` interface is `internal` and only has one implementation. We can use a class directly.