### PR TITLE
Replace `Lifecycle.bindingProvider` by a private function and rename it to `validateClasspath`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -36,7 +36,7 @@ internal class Lifecycle(
         measure(Phase.ValidateConfig) { checkConfiguration(settings, baselineConfig) }
         val filesToAnalyze = measure(Phase.Parsing) { settings.ktFiles }
         if (settings.spec.projectSpec.analysisMode == AnalysisMode.full) {
-            measure(Phase.Binding) { bindingProvider(filesToAnalyze) }
+            measure(Phase.ValidateClasspath) { validateClasspath(filesToAnalyze) }
         }
         val analysisMode = settings.spec.projectSpec.analysisMode
         val (processors, rules) = measure(Phase.LoadingExtensions) {
@@ -64,7 +64,7 @@ internal class Lifecycle(
         }
     }
 
-    private fun bindingProvider(files: List<KtFile>) {
+    private fun validateClasspath(files: List<KtFile>) {
         val collector = DetektMessageCollector(
             minSeverity = CompilerMessageSeverity.ERROR,
             debugPrinter = settings::debug,

--- a/detekt-core/src/main/kotlin/dev/detekt/core/util/PerformanceMonitor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/util/PerformanceMonitor.kt
@@ -10,7 +10,7 @@ class PerformanceMonitor {
         CreateSettings,
         ValidateConfig,
         Parsing,
-        Binding,
+        ValidateClasspath,
         LoadingExtensions,
         Analyzer,
         Reporting,

--- a/detekt-core/src/test/kotlin/dev/detekt/core/util/PerformanceMonitorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/util/PerformanceMonitorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.core.util
 
 import dev.detekt.core.tooling.DefaultDetektProvider
+import dev.detekt.core.util.PerformanceMonitor.Phase.ValidateClasspath
 import dev.detekt.test.utils.StringPrintStream
 import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.tooling.api.AnalysisMode
@@ -48,7 +49,7 @@ class PerformanceMonitorSpec {
         DefaultDetektProvider().get(spec).run()
 
         assertThat(actual.toString())
-            .contains(PerformanceMonitor.Phase.entries.minus(PerformanceMonitor.Phase.Binding).map { it.name })
-            .doesNotContain(PerformanceMonitor.Phase.Binding.name)
+            .contains(PerformanceMonitor.Phase.entries.minus(ValidateClasspath).map { it.name })
+            .doesNotContain(ValidateClasspath.name)
     }
 }


### PR DESCRIPTION
No one passes a value to `bindingProvider` so we are always using the default value. For that reason we can replace it from a parameter to a function making the code a bit easier to read

~Waiting for:~
- ~#9002~