### PR TITLE
fix(ImplicitDefaultLocale): don't flag locale-independent format specifiers

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
@@ -14,7 +14,9 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 
 /**
@@ -59,6 +61,11 @@ class ImplicitDefaultLocale(config: Config) :
             val symbol = expression.resolveToCall()?.singleFunctionCallOrNull()?.symbol ?: return
             if (symbol.callableId != formatCallId) return
             if (symbol.valueParameters.firstOrNull()?.returnType?.symbol?.classId == localeClassId) return
+
+            // Don't flag if the format string only contains locale-independent specifiers
+            val formatString = getFormatString(expression)
+            if (formatString != null && hasOnlyLocaleIndependentSpecifiers(formatString)) return
+
             report(
                 Finding(
                     Entity.from(expression),
@@ -68,11 +75,65 @@ class ImplicitDefaultLocale(config: Config) :
         }
     }
 
+    private fun getFormatString(expression: KtQualifiedExpression): String? {
+        val receiver = expression.receiverExpression
+
+        // Case 1: "format".format(args) - receiver is the format string
+        if (receiver is KtStringTemplateExpression && !receiver.hasInterpolation()) {
+            return receiver.entries.joinToString("") { it.text }
+        }
+
+        // Case 2: String.format("format", args) - format string is the first argument
+        val callExpression = expression.selectorExpression as? KtCallExpression ?: return null
+        val firstArg = callExpression.valueArguments.firstOrNull()?.getArgumentExpression()
+        if (firstArg is KtStringTemplateExpression && !firstArg.hasInterpolation()) {
+            return firstArg.entries.joinToString("") { it.text }
+        }
+
+        return null
+    }
+
+    private fun hasOnlyLocaleIndependentSpecifiers(formatString: String): Boolean {
+        // Java format specifier pattern: %[argument_index$][flags][width][.precision]conversion
+        // or %[argument_index$][flags][width][.precision]t/T<date/time conversion>
+        val specifierPattern = Regex("""%(\d+\$)?[-#+ 0,(]*\d*(\.\d+)?([tT][a-zA-Z]|[a-zA-Z%])""")
+        val conversions = specifierPattern.findAll(formatString).map { it.groupValues[3] }.toList()
+
+        // If no format specifiers found, no locale dependency
+        if (conversions.isEmpty()) return true
+
+        // Locale-independent conversions according to Java Formatter documentation:
+        // - x, X: hexadecimal integer (no localization applied)
+        // - o: octal integer (no localization applied)
+        // - a, A: hexadecimal floating-point (no localization applied)
+        // - b, B: boolean
+        // - h, H: hash code (hexadecimal)
+        // - s: string (just toString())
+        // - c: character
+        // - n: platform line separator
+        // - %: literal percent
+        // Note: Uppercase S and C perform locale-dependent case conversion, so they're excluded
+        return conversions.all { it in localeIndependentConversions }
+    }
+
     companion object {
         private val formatCallIds = listOf(
             CallableId(FqName("kotlin.text"), Name.identifier("format")),
         ).associateBy { it.callableName.asString() }
 
         private val localeClassId = ClassId(FqName("java.util"), Name.identifier("Locale"))
+
+        // Locale-independent format conversions
+        private val localeIndependentConversions = setOf(
+            "x", "X",   // hexadecimal integer
+            "o",        // octal integer
+            "a", "A",   // hexadecimal floating-point
+            "b", "B",   // boolean
+            "h", "H",   // hash code
+            "s",        // string (lowercase only - uppercase S is locale-dependent)
+            "c",        // character (lowercase only - uppercase C is locale-dependent)
+            "n",        // line separator
+            "%",        // literal percent
+        )
     }
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
@@ -77,4 +77,195 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `does not report for locale-independent hexadecimal format specifier %x`() {
+        val code = """
+            fun x() {
+                "0x%08x".format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent hexadecimal format specifier %X`() {
+        val code = """
+            fun x() {
+                "0x%08X".format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent octal format specifier %o`() {
+        val code = """
+            fun x() {
+                "%o".format(64)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent hexadecimal floating-point %a`() {
+        val code = """
+            fun x() {
+                "%a".format(1.0)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent boolean format specifier %b`() {
+        val code = """
+            fun x() {
+                "%b".format(true)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent hash code format specifier %h`() {
+        val code = """
+            fun x() {
+                "%h".format("test")
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent string format specifier %s`() {
+        val code = """
+            fun x() {
+                "%s".format("test")
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent character format specifier %c`() {
+        val code = """
+            fun x() {
+                "%c".format('A')
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for locale-independent line separator %n`() {
+        val code = """
+            fun x() {
+                "line1%nline2".format()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for literal percent %%`() {
+        val code = """
+            fun x() {
+                "100%%".format()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for combined locale-independent specifiers`() {
+        val code = """
+            fun x() {
+                "hex: 0x%08X, octal: %o, bool: %b".format(255, 64, true)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report String_format with locale-independent specifiers`() {
+        val code = """
+            fun x() {
+                String.format("0x%08X", 255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports for locale-dependent decimal format specifier %d`() {
+        val code = """
+            fun x() {
+                "%d".format(1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for locale-dependent floating-point format specifier %f`() {
+        val code = """
+            fun x() {
+                "%f".format(1.5)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for locale-dependent scientific notation %e`() {
+        val code = """
+            fun x() {
+                "%e".format(1000.0)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for locale-dependent uppercase string %S`() {
+        val code = """
+            fun x() {
+                "%S".format("test")
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for locale-dependent uppercase character %C`() {
+        val code = """
+            fun x() {
+                "%C".format('a')
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for mixed locale-independent and locale-dependent specifiers`() {
+        val code = """
+            fun x() {
+                "hex: 0x%X, decimal: %d".format(255, 100)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for date-time format specifiers`() {
+        val code = """
+            import java.util.Date
+            fun x() {
+                "%tY".format(Date())
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
@@ -268,4 +268,64 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).hasSize(1)
     }
+
+    @Test
+    fun `does not report for format string without any specifiers`() {
+        val code = """
+            fun x() {
+                "no specifiers here".format()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports for dynamic format string that cannot be analyzed`() {
+        val code = """
+            fun x(template: String) {
+                template.format(1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for String_format with dynamic format string`() {
+        val code = """
+            fun x(template: String) {
+                String.format(template, 1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report for format string with interpolation`() {
+        val code = """
+            fun x(prefix: String) {
+                "${'$'}prefix: %s".format("test")
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report for non-format method calls`() {
+        val code = """
+            fun x() {
+                "test".toString()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report for uppercase hexadecimal with argument index %1$X`() {
+        val code = """
+            fun x() {
+                "hex: %1${'$'}08X".format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
@@ -328,4 +328,44 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `reports for String_format with interpolated format string as first argument`() {
+        val code = """
+            fun x(prefix: String) {
+                String.format("${'$'}prefix: %d", 1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports for format extension with receiver that has interpolation`() {
+        val code = """
+            fun x(prefix: String) {
+                "${'$'}prefix: %d".format(1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report for String_format with locale-independent specifier as first string arg`() {
+        val code = """
+            fun x() {
+                String.format("%x", 255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports when format string has no interpolation but locale-dependent specifier`() {
+        val code = """
+            fun x() {
+                String.format("%g", 1.5)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes false positive in ImplicitDefaultLocale rule for locale-independent format specifiers
- Adds logic to identify format specifiers that don't require explicit locale
- Includes extensive test coverage for various format specifier types

## Changes
- Enhanced `ImplicitDefaultLocale.kt` with locale-independent format specifier detection
- Added comprehensive test cases in `ImplicitDefaultLocaleSpec.kt`

## Test plan
- [x] Added test cases for locale-independent format specifiers
- [x] Verified existing tests still pass
- [x] Confirmed rule correctly handles both locale-dependent and locale-independent cases

Fixes #3821

🤖 Generated with [Claude Code](https://claude.com/claude-code)