### PR TITLE
Exclude generated sources from default sources

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
@@ -624,7 +624,6 @@ class DetektAndroidSpec {
             addSubmodule(
                 name = "app",
                 numberOfSourceFilesPerSourceDir = 0,
-                numberOfFindings = 0,
                 buildFileContent = """
                     plugins {
                         id("com.android.application")
@@ -648,8 +647,11 @@ class DetektAndroidSpec {
                         compilerOptions {
                             jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
                         }
-                        sourceSets.getByName("debug") {
-                            generatedKotlin.srcDir(project.layout.buildDirectory.dir("generated/custom/debug"))
+                        sourceSets {
+                            debug {
+                                val generatedDir = project.layout.buildDirectory.dir("generated/debug")
+                                generatedKotlin.srcDir(generatedDir)
+                            }
                         }
                     }
                     
@@ -666,7 +668,7 @@ class DetektAndroidSpec {
         val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, dryRun = true).also {
             it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent)
             it.writeProjectFile(
-                filename = "app/build/generated/custom/debug/GeneratedClass.kt",
+                filename = "app/build/generated/debug/GeneratedClass.kt",
                 content = """
                     package generated
                     class GeneratedClass

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -244,7 +244,7 @@ class DetektMultiplatformSpec {
                         "src/androidMain/kotlin",
                     ),
                     baselineFiles = listOf(
-                        "detekt-baseline.xml",
+                        "detekt-baseline-main.xml",
                     )
                 )
             }
@@ -263,7 +263,7 @@ class DetektMultiplatformSpec {
         @Test
         fun `configures detekt task with type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektMainAndroid") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
                 assertThat(it.output).containsPattern("""--report checkstyle:\S*[/\\]mainAndroid.xml""")
                 assertDetektWithClasspath(it)
             }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -426,8 +426,8 @@ class DetektMultiplatformSpec {
                 it.writeProjectFile(
                     "shared/build/generated/jvmMain/GeneratedClass.kt",
                     """
-                    package generated
-                    class GeneratedClass
+                        package generated
+                        class GeneratedClass
                     """.trimIndent()
                 )
             }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -6,7 +6,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import java.io.File
-import java.util.Locale
 
 private const val DEBUG_PARAMETER = "--debug"
 private const val INPUT_PARAMETER = "--input"
@@ -134,7 +133,7 @@ internal data class FailOnSeverityArgument(val ignoreFailures: Boolean, val minS
     CliArgument {
     override fun toArgument(): List<String> {
         val effectiveSeverity = if (ignoreFailures) FailOnSeverity.Never else minSeverity
-        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.toLowerCase(Locale.ROOT))
+        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.lowercase())
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -6,6 +6,7 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import java.io.File
+import java.util.Locale
 
 private const val DEBUG_PARAMETER = "--debug"
 private const val INPUT_PARAMETER = "--input"
@@ -133,7 +134,7 @@ internal data class FailOnSeverityArgument(val ignoreFailures: Boolean, val minS
     CliArgument {
     override fun toArgument(): List<String> {
         val effectiveSeverity = if (ignoreFailures) FailOnSeverity.Never else minSeverity
-        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.lowercase())
+        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.toLowerCase(Locale.ROOT))
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -81,7 +81,7 @@ class DetektBasePlugin : Plugin<Project> {
 
             project.extensions.getByType(KotlinSourceSetContainer::class.java)
                 .sourceSets
-                .all { sourceSet ->
+                .configureEach { sourceSet ->
                     val taskName = "${DetektPlugin.DETEKT_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
                     tasks.register(taskName, Detekt::class.java) { detektTask ->
                         detektTask.source = sourceSet.kotlin

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -9,7 +9,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidExtension
 
 internal object DetektAndroidCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
-        project.extensions.getByType(KotlinAndroidExtension::class.java).target.compilations.all { compilation ->
+        project.extensions.getByType(
+            KotlinAndroidExtension::class.java
+        ).target.compilations.configureEach { compilation ->
             project.registerJvmCompilationDetektTask(extension, compilation)
             project.registerJvmCompilationCreateBaselineTask(extension, compilation)
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektJvmCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektJvmCompilations.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
 
 internal object DetektJvmCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
-        project.extensions.getByType(KotlinJvmExtension::class.java).target.compilations.all { compilation ->
+        project.extensions.getByType(KotlinJvmExtension::class.java).target.compilations.configureEach { compilation ->
             project.registerJvmCompilationDetektTask(extension, compilation)
             project.registerJvmCompilationCreateBaselineTask(extension, compilation)
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektKmpJvmCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektKmpJvmCompilations.kt
@@ -10,8 +10,8 @@ internal object DetektKmpJvmCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
         val kotlinExtension = project.extensions.getByType(KotlinTargetsContainer::class.java)
 
-        kotlinExtension.targets.matching { it.platformType in setOf(jvm, androidJvm) }.all { target ->
-            target.compilations.all { compilation ->
+        kotlinExtension.targets.matching { it.platformType in setOf(jvm, androidJvm) }.configureEach { target ->
+            target.compilations.configureEach { compilation ->
                 project.registerJvmCompilationDetektTask(extension, compilation, target)
                 project.registerJvmCompilationCreateBaselineTask(extension, compilation, target)
             }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -23,7 +23,7 @@ internal fun Project.registerJvmCompilationDetektTask(
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        detektTask.setSource(siblingTask.sources)
+        detektTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.srcDirs })
         detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
@@ -67,7 +67,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        createBaselineTask.setSource(siblingTask.sources)
+        createBaselineTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.srcDirs })
         createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -21,20 +21,32 @@ internal fun Project.registerJvmCompilationDetektTask(
 ) {
     val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
-        val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
+        val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         detektTask.setSource(compilation.allKotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
-        detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
-        detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
-        detektTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
+        detektTask.classpath.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.libraries }
+        )
+        detektTask.friendPaths.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.friendPaths }
+        )
+        detektTask.apiVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.apiVersion.map { it.version } }
+        )
+        detektTask.languageVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.languageVersion.map { it.version } }
+        )
         /* Note: jvmTarget convention is also set in setDetektTaskDefaults. There may be a race between setting it here
            as well, but they should both set the same value. This should possibly be revisited in the future. */
-        detektTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
-        detektTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
-        detektTask.optIn.convention(siblingTask.compilerOptions.optIn)
-        detektTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
-        detektTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
+        detektTask.jvmTarget.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.jvmTarget.map { it.target } }
+        )
+        detektTask.freeCompilerArgs.convention(siblingTask.flatMap { it.compilerOptions.freeCompilerArgs })
+        detektTask.optIn.convention(siblingTask.flatMap { it.compilerOptions.optIn })
+        detektTask.noJdk.convention(siblingTask.flatMap { it.compilerOptions.noJdk })
+        detektTask.multiPlatformEnabled.convention(siblingTask.flatMap { it.multiPlatformEnabled })
         if (compilation.name == "main") {
             detektTask.explicitApi.convention(mapExplicitArgMode())
         }
@@ -65,20 +77,32 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         DetektPlugin.BASELINE_TASK_NAME + taskSuffix.capitalize(),
         DetektCreateBaselineTask::class.java,
     ) { createBaselineTask ->
-        val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
+        val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         createBaselineTask.setSource(compilation.allKotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
-        createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
-        createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
-        createBaselineTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
+        createBaselineTask.classpath.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.libraries }
+        )
+        createBaselineTask.friendPaths.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.friendPaths }
+        )
+        createBaselineTask.apiVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.apiVersion.map { it.version } }
+        )
+        createBaselineTask.languageVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.languageVersion.map { it.version } }
+        )
         /* Note: jvmTarget convention is also set in setCreateBaselineTaskDefaults. There may be a race between setting
            it here as well, but they should both set the same value. This should possibly be revisited in the future. */
-        createBaselineTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
-        createBaselineTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
-        createBaselineTask.optIn.convention(siblingTask.compilerOptions.optIn)
-        createBaselineTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
-        createBaselineTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
+        createBaselineTask.jvmTarget.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.jvmTarget.map { it.target } }
+        )
+        createBaselineTask.freeCompilerArgs.convention(siblingTask.flatMap { it.compilerOptions.freeCompilerArgs })
+        createBaselineTask.optIn.convention(siblingTask.flatMap { it.compilerOptions.optIn })
+        createBaselineTask.noJdk.convention(siblingTask.flatMap { it.compilerOptions.noJdk })
+        createBaselineTask.multiPlatformEnabled.convention(siblingTask.flatMap { it.multiPlatformEnabled })
         if (compilation.name == "main") {
             createBaselineTask.explicitApi.convention(mapExplicitArgMode())
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -23,7 +23,7 @@ internal fun Project.registerJvmCompilationDetektTask(
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        detektTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.srcDirs })
+        detektTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
         detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
@@ -67,7 +67,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        createBaselineTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.srcDirs })
+        createBaselineTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
         createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -23,7 +23,7 @@ internal fun Project.registerJvmCompilationDetektTask(
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        detektTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
+        detektTask.setSource(compilation.allKotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
         detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
@@ -67,7 +67,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
 
-        createBaselineTask.setSource(compilation.kotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
+        createBaselineTask.setSource(compilation.allKotlinSourceSets.flatMap { it.kotlin.sourceDirectories })
         createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
         createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
         createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })


### PR DESCRIPTION
Fixes issue #8933

- Using `siblingTask.sources` was what was causing generated sources to be mapped as source files.
- The CliArgument change can be reverted as it isn't related, but `toLowerCase` is an error in Kotlin 2.1.
- Added the test cases to DetektAndroidSpec but maybe there's a more appropriate place as the fix isn't really specific to Android. Open to suggestions on a better test setup, this was the simplest way I could figure out getting generated directories without having to add another plugin to testKitRuntimeOnly.

