### PR TITLE
Change `parentPath` to `key`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -15,13 +15,12 @@ public abstract interface class dev/detekt/api/Config {
 	public static final field ACTIVE_KEY Ljava/lang/String;
 	public static final field ALIASES_KEY Ljava/lang/String;
 	public static final field AUTO_CORRECT_KEY Ljava/lang/String;
-	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field Companion Ldev/detekt/api/Config$Companion;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
+	public abstract fun getKey ()Ljava/lang/String;
 	public abstract fun getParent ()Ldev/detekt/api/Config;
-	public abstract fun getParentPath ()Ljava/lang/String;
 	public abstract fun subConfig (Ljava/lang/String;)Ldev/detekt/api/Config;
 	public abstract fun subConfigKeys ()Ljava/util/Set;
 	public fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
@@ -32,7 +31,6 @@ public final class dev/detekt/api/Config$Companion {
 	public static final field ACTIVE_KEY Ljava/lang/String;
 	public static final field ALIASES_KEY Ljava/lang/String;
 	public static final field AUTO_CORRECT_KEY Ljava/lang/String;
-	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
@@ -6,12 +6,11 @@ package dev.detekt.api
 interface Config {
 
     /**
-     * Keeps track of which key was taken to [subConfig] this configuration.
-     * Sub-sequential calls to [subConfig] are tracked with '>' as a separator.
+     * Keeps track of which key was taken to get this configuration.
      *
      * May be null if this is the top most configuration object.
      */
-    val parentPath: String?
+    val key: String?
 
     /**
      * The reference to a parent [Config] from this configuration, useful when navigating with [subConfig].
@@ -59,7 +58,7 @@ interface Config {
          * Always returns the default value except when 'active' is queried, it returns true.
          */
         val empty: Config = object : Config {
-            override val parentPath: String? = null
+            override val key: String? = null
 
             override val parent: Config = this
 
@@ -78,6 +77,5 @@ interface Config {
         const val SEVERITY_KEY: String = "severity"
         const val EXCLUDES_KEY: String = "excludes"
         const val INCLUDES_KEY: String = "includes"
-        const val CONFIG_SEPARATOR: String = ">"
     }
 }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
@@ -14,8 +14,8 @@ internal data class AllRulesConfig(
 ) : Config,
     ValidatableConfiguration {
 
-    override val parentPath: String?
-        get() = wrapped.parentPath
+    override val key: String?
+        get() = wrapped.key
 
     override fun subConfig(key: String) = AllRulesConfig(wrapped.subConfig(key), deprecatedRules, this)
 
@@ -36,9 +36,7 @@ internal data class AllRulesConfig(
     override fun validate(baseline: Config, excludePatterns: Set<Regex>) =
         validateConfig(wrapped, baseline, excludePatterns)
 
-    private fun isDeprecated(): Boolean = deprecatedRules.any { parentPath == it.toPath() }
-
-    private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleName"
+    private fun isDeprecated(): Boolean = deprecatedRules.any { key == it.ruleName && parent?.key == it.ruleSetId }
 
     @Suppress("MagicNumber")
     override fun toString() =

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
@@ -1,11 +1,21 @@
 package dev.detekt.core.config
 
+import com.intellij.util.containers.addIfNotNull
 import dev.detekt.api.Config
-import dev.detekt.api.Config.Companion.CONFIG_SEPARATOR
 import kotlin.reflect.KClass
 
-private fun Config.keySequence(key: String): String =
-    if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key"
+private fun Config.keySequence(key: String): String {
+    var config: Config? = this
+    return buildList {
+        add(key)
+        while (config != null) {
+            addIfNotNull(config.key)
+            config = config.parent
+        }
+    }
+        .reversed()
+        .joinToString(" > ")
+}
 
 fun Config.valueOrDefaultInternal(
     key: String,

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/CompositeConfig.kt
@@ -16,8 +16,8 @@ class CompositeConfig(
 ) : Config,
     ValidatableConfiguration {
 
-    override val parentPath: String?
-        get() = lookFirst.parentPath ?: lookSecond.parentPath
+    override val key: String?
+        get() = lookFirst.key ?: lookSecond.key
 
     override fun subConfig(key: String): Config =
         CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key), this)

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -11,8 +11,8 @@ class DisabledAutoCorrectConfig(private val wrapped: Config, override val parent
     Config,
     ValidatableConfiguration {
 
-    override val parentPath: String?
-        get() = wrapped.parentPath
+    override val key: String?
+        get() = wrapped.key
 
     override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key), this)
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
@@ -1,7 +1,6 @@
 package dev.detekt.core.config
 
 import dev.detekt.api.Config
-import dev.detekt.api.Config.Companion.CONFIG_SEPARATOR
 import dev.detekt.api.Notification
 import dev.detekt.core.config.validation.ValidatableConfiguration
 import dev.detekt.core.config.validation.validateConfig
@@ -21,7 +20,7 @@ import kotlin.io.path.reader
  */
 class YamlConfig internal constructor(
     val properties: Map<String, Any>,
-    override val parentPath: String?,
+    override val key: String?,
     override val parent: Config?,
 ) : Config,
     ValidatableConfiguration {
@@ -29,11 +28,7 @@ class YamlConfig internal constructor(
     override fun subConfig(key: String): Config {
         @Suppress("UNCHECKED_CAST")
         val subProperties = properties.getOrElse(key) { emptyMap<String, Any>() } as Map<String, Any>
-        return YamlConfig(
-            subProperties,
-            if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key",
-            this,
-        )
+        return YamlConfig(subProperties, key, this)
     }
 
     override fun subConfigKeys(): Set<String> = properties.keys

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/AllRulesConfigSpec.kt
@@ -46,7 +46,7 @@ class AllRulesConfigSpec {
                 wrapped = rulesetConfig,
                 deprecatedRules = emptySet(),
             )
-            val actual = subject.parentPath
+            val actual = subject.key
             assertThat(actual).isEqualTo(rulesetId)
         }
 
@@ -56,7 +56,7 @@ class AllRulesConfigSpec {
                 wrapped = emptyYamlConfig,
                 deprecatedRules = emptySet(),
             )
-            val actual = subject.parentPath
+            val actual = subject.key
             assertThat(actual).isEqualTo(null)
         }
     }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
@@ -67,14 +67,14 @@ class CompositeConfigSpec {
         @Test
         fun `is derived from the _override_ config if available`() {
             val subject = compositeConfig.subConfig("style")
-            val actual = subject.parentPath
+            val actual = subject.key
             assertThat(actual).isEqualTo("style")
         }
 
         @Test
         fun `is derived from the default config if unavailable in original config`() {
             val subject = compositeConfig.subConfig("code-smell")
-            val actual = subject.parentPath
+            val actual = subject.key
             assertThat(actual).isEqualTo("code-smell")
         }
     }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -42,7 +42,7 @@ class DisabledAutoCorrectConfigSpec {
     @Test
     fun `parent path is derived from wrapped config`() {
         val subject = DisabledAutoCorrectConfig(configSingleRuleInStyle.subConfig(rulesetId))
-        val actual = subject.parentPath
+        val actual = subject.key
         assertThat(actual).isEqualTo(rulesetId)
     }
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/YamlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/YamlConfigSpec.kt
@@ -64,7 +64,7 @@ class YamlConfigSpec {
         fun `parent path of ruleset config is ruleset id`() {
             val rulesetId = "style"
             val subject = config.subConfig(rulesetId)
-            val actual = subject.parentPath
+            val actual = subject.key
             assertThat(actual).isEqualTo(rulesetId)
         }
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/tooling/DefaultConfigProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/tooling/DefaultConfigProviderSpec.kt
@@ -18,7 +18,7 @@ class DefaultConfigProviderSpec {
         fun gets() {
             val config = DefaultConfigProvider().apply { init(extensionsSpec) }.get()
 
-            assertThat(config.parentPath).isNull()
+            assertThat(config.key).isNull()
             assertThat(config.valueOrNull<Any>("sample")).isNull()
         }
 
@@ -44,7 +44,7 @@ class DefaultConfigProviderSpec {
         fun gets() {
             val config = DefaultConfigProvider().apply { init(extensionsSpec) }.get()
 
-            assertThat(config.parentPath).isNull()
+            assertThat(config.key).isNull()
             assertThat(config.valueOrNull<Any>("sample")).isNotNull()
         }
 

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -24,8 +24,8 @@ public final class dev/detekt/test/RuleExtensionsKt {
 public final class dev/detekt/test/TestConfig : dev/detekt/api/Config {
 	public fun <init> (Ldev/detekt/api/Config;[Lkotlin/Pair;)V
 	public fun <init> ([Lkotlin/Pair;)V
+	public fun getKey ()Ljava/lang/String;
 	public fun getParent ()Ldev/detekt/api/Config;
-	public fun getParentPath ()Ljava/lang/String;
 	public synthetic fun subConfig (Ljava/lang/String;)Ldev/detekt/api/Config;
 	public fun subConfig (Ljava/lang/String;)Ldev/detekt/test/TestConfig;
 	public fun subConfigKeys ()Ljava/util/Set;

--- a/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
@@ -9,7 +9,7 @@ import dev.detekt.core.config.valueOrDefaultInternal
 class TestConfig private constructor(
     override val parent: Config?,
     override val key: String?,
-    private val values: Map<String, Any>
+    private val values: Map<String, Any>,
 ) : Config {
 
     constructor(parent: Config?, vararg pairs: Pair<String, Any>) : this(parent, null, pairs.toMap())

--- a/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
@@ -6,16 +6,19 @@ import dev.detekt.core.config.tryParseBasedOnDefault
 import dev.detekt.core.config.valueOrDefaultInternal
 
 @Suppress("UNCHECKED_CAST")
-class TestConfig private constructor(override val parent: Config?, private val values: Map<String, Any>) : Config {
-    override val parentPath: String? = null
+class TestConfig private constructor(
+    override val parent: Config?,
+    override val key: String?,
+    private val values: Map<String, Any>
+) : Config {
 
-    constructor(parent: Config?, vararg pairs: Pair<String, Any>) : this(parent, pairs.toMap())
+    constructor(parent: Config?, vararg pairs: Pair<String, Any>) : this(parent, null, pairs.toMap())
 
     constructor(vararg pairs: Pair<String, Any>) : this(Config.empty, *pairs)
 
     override fun subConfig(key: String): TestConfig {
         val value = values.getOrDefault(key, emptyMap<String, Any>()) as Map<String, Any>
-        return TestConfig(this, value)
+        return TestConfig(this, key, value)
     }
 
     override fun subConfigKeys(): Set<String> = values.keys


### PR DESCRIPTION
This should be easier to maintain and implement because some of our `Config` implementations didn't implement `parentPath` correctly.