### PR TITLE
Remove `Config.parentPath`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -15,14 +15,12 @@ public abstract interface class dev/detekt/api/Config {
 	public static final field ACTIVE_KEY Ljava/lang/String;
 	public static final field ALIASES_KEY Ljava/lang/String;
 	public static final field AUTO_CORRECT_KEY Ljava/lang/String;
-	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field Companion Ldev/detekt/api/Config$Companion;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field IGNORE_ANNOTATED_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
 	public abstract fun getParent ()Ldev/detekt/api/Config;
-	public abstract fun getParentPath ()Ljava/lang/String;
 	public abstract fun subConfig (Ljava/lang/String;)Ldev/detekt/api/Config;
 	public abstract fun subConfigKeys ()Ljava/util/Set;
 	public fun valueOrDefault (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
@@ -33,7 +31,6 @@ public final class dev/detekt/api/Config$Companion {
 	public static final field ACTIVE_KEY Ljava/lang/String;
 	public static final field ALIASES_KEY Ljava/lang/String;
 	public static final field AUTO_CORRECT_KEY Ljava/lang/String;
-	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
 	public static final field IGNORE_ANNOTATED_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
@@ -4,15 +4,6 @@ package dev.detekt.api
  * A configuration holds information about how to configure specific rules.
  */
 interface Config {
-
-    /**
-     * Keeps track of which key was taken to [subConfig] this configuration.
-     * Sub-sequential calls to [subConfig] are tracked with '>' as a separator.
-     *
-     * May be null if this is the top most configuration object.
-     */
-    val parentPath: String?
-
     /**
      * The reference to a parent [Config] from this configuration, useful when navigating with [subConfig].
      * It's `null` if this is the top most configuration object.
@@ -49,8 +40,6 @@ interface Config {
          * Always returns the default value except when 'active' is queried, it returns true.
          */
         val empty: Config = object : Config {
-            override val parentPath: String? = null
-
             override val parent: Config = this
 
             override fun subConfig(key: String): Config = this
@@ -69,6 +58,5 @@ interface Config {
         const val SEVERITY_KEY: String = "severity"
         const val EXCLUDES_KEY: String = "excludes"
         const val INCLUDES_KEY: String = "includes"
-        const val CONFIG_SEPARATOR: String = ">"
     }
 }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
@@ -11,13 +11,10 @@ internal data class AllRulesConfig(
     private val wrapped: Config,
     private val deprecatedRules: Set<DeprecatedRule>,
     override val parent: Config? = null,
+    private val key: String? = null,
 ) : Config,
     ValidatableConfiguration {
-
-    override val parentPath: String?
-        get() = wrapped.parentPath
-
-    override fun subConfig(key: String) = AllRulesConfig(wrapped.subConfig(key), deprecatedRules, this)
+    override fun subConfig(key: String) = AllRulesConfig(wrapped.subConfig(key), deprecatedRules, this, key)
 
     override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()
 
@@ -36,9 +33,8 @@ internal data class AllRulesConfig(
     override fun validate(baseline: Config, excludePatterns: Set<Regex>) =
         validateConfig(wrapped, baseline, excludePatterns)
 
-    private fun isDeprecated(): Boolean = deprecatedRules.any { parentPath == it.toPath() }
-
-    private fun DeprecatedRule.toPath() = "$ruleSetId > $ruleName"
+    private fun isDeprecated(): Boolean =
+        deprecatedRules.any { key == it.ruleName && (parent as? AllRulesConfig)?.key == it.ruleSetId }
 
     @Suppress("MagicNumber")
     override fun toString() =

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
@@ -1,13 +1,12 @@
 package dev.detekt.core.config
 
-import dev.detekt.api.Config
-import dev.detekt.api.Config.Companion.CONFIG_SEPARATOR
+import dev.detekt.core.config.YamlConfig.Companion.CONFIG_SEPARATOR
 import kotlin.reflect.KClass
 
-private fun Config.keySequence(key: String): String =
+private fun YamlConfig.keySequence(key: String): String =
     if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key"
 
-fun Config.valueOrDefaultInternal(
+fun YamlConfig.valueOrDefaultInternal(
     key: String,
     result: Any?,
     default: Any,

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/CompositeConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/CompositeConfig.kt
@@ -16,9 +16,6 @@ class CompositeConfig(
 ) : Config,
     ValidatableConfiguration {
 
-    override val parentPath: String?
-        get() = lookFirst.parentPath ?: lookSecond.parentPath
-
     override fun subConfig(key: String): Config =
         CompositeConfig(lookFirst.subConfig(key), lookSecond.subConfig(key), this)
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -11,9 +11,6 @@ class DisabledAutoCorrectConfig(private val wrapped: Config, override val parent
     Config,
     ValidatableConfiguration {
 
-    override val parentPath: String?
-        get() = wrapped.parentPath
-
     override fun subConfig(key: String): Config = DisabledAutoCorrectConfig(wrapped.subConfig(key), this)
 
     override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
@@ -1,7 +1,6 @@
 package dev.detekt.core.config
 
 import dev.detekt.api.Config
-import dev.detekt.api.Config.Companion.CONFIG_SEPARATOR
 import dev.detekt.api.Notification
 import dev.detekt.core.config.validation.ValidatableConfiguration
 import dev.detekt.core.config.validation.validateConfig
@@ -16,7 +15,7 @@ import java.io.Reader
  */
 class YamlConfig internal constructor(
     val properties: Map<String, Any>,
-    override val parentPath: String?,
+    val parentPath: String?,
     override val parent: Config?,
 ) : Config,
     ValidatableConfiguration {
@@ -56,6 +55,7 @@ class YamlConfig internal constructor(
         validateConfig(this, baseline, excludePatterns)
 
     companion object {
+        const val CONFIG_SEPARATOR: String = ">"
         private const val YAML_DOC_LIMIT = 102_400 // limit the YAML size to 100 kB
 
         // limit the anchors/aliases for collections to prevent attacks from for untrusted sources

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/AllRulesConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/AllRulesConfigSpec.kt
@@ -30,38 +30,6 @@ class AllRulesConfigSpec {
     }
 
     @Nested
-    inner class ParentPath {
-        private val rulesetId = "style"
-        private val rulesetConfig = yamlConfigFromContent(
-            """
-                style:
-                  MaxLineLength:
-                    maxLineLength: 100
-            """.trimIndent()
-        ).subConfig(rulesetId)
-
-        @Test
-        fun `is derived from the original config`() {
-            val subject = AllRulesConfig(
-                wrapped = rulesetConfig,
-                deprecatedRules = emptySet(),
-            )
-            val actual = subject.parentPath
-            assertThat(actual).isEqualTo(rulesetId)
-        }
-
-        @Test
-        fun `is derived from the default config if unavailable in original config`() {
-            val subject = AllRulesConfig(
-                wrapped = emptyYamlConfig,
-                deprecatedRules = emptySet(),
-            )
-            val actual = subject.parentPath
-            assertThat(actual).isEqualTo(null)
-        }
-    }
-
-    @Nested
     inner class Parent {
         private val rulesetConfig = yamlConfigFromContent(
             """

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
@@ -3,7 +3,6 @@ package dev.detekt.core.config
 import dev.detekt.core.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CompositeConfigSpec {
@@ -101,24 +100,6 @@ class CompositeConfigSpec {
         assertThatThrownBy { config.valueOrDefault("active", true) }
             .isInstanceOf(IllegalArgumentException::class.java)
             .hasMessageContaining("The string doesn't represent a boolean value: truuu")
-    }
-
-    @Nested
-    inner class ParentPath {
-
-        @Test
-        fun `is derived from the _override_ config if available`() {
-            val subject = compositeConfig.subConfig("style")
-            val actual = subject.parentPath
-            assertThat(actual).isEqualTo("style")
-        }
-
-        @Test
-        fun `is derived from the default config if unavailable in original config`() {
-            val subject = compositeConfig.subConfig("code-smell")
-            val actual = subject.parentPath
-            assertThat(actual).isEqualTo("code-smell")
-        }
     }
 
     @Test

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfigSpec.kt
@@ -40,13 +40,6 @@ class DisabledAutoCorrectConfigSpec {
     }
 
     @Test
-    fun `parent path is derived from wrapped config`() {
-        val subject = DisabledAutoCorrectConfig(configSingleRuleInStyle.subConfig(rulesetId))
-        val actual = subject.parentPath
-        assertThat(actual).isEqualTo(rulesetId)
-    }
-
-    @Test
     fun `verify the autocorrect field false in case the autoCorrect not present into yaml config`() {
         val config = yamlConfigFromContent(
             """

--- a/detekt-core/src/test/kotlin/dev/detekt/core/tooling/DefaultConfigProviderSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/tooling/DefaultConfigProviderSpec.kt
@@ -18,7 +18,6 @@ class DefaultConfigProviderSpec {
         fun gets() {
             val config = DefaultConfigProvider().apply { init(extensionsSpec) }.get()
 
-            assertThat(config.parentPath).isNull()
             assertThat(config.valueOrNull<Any>("sample")).isNull()
         }
 
@@ -44,7 +43,6 @@ class DefaultConfigProviderSpec {
         fun gets() {
             val config = DefaultConfigProvider().apply { init(extensionsSpec) }.get()
 
-            assertThat(config.parentPath).isNull()
             assertThat(config.valueOrNull<Any>("sample")).isNotNull()
         }
 

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -20,7 +20,6 @@ public final class dev/detekt/test/TestConfig : dev/detekt/api/Config {
 	public fun <init> (Ldev/detekt/api/Config;[Lkotlin/Pair;)V
 	public fun <init> ([Lkotlin/Pair;)V
 	public fun getParent ()Ldev/detekt/api/Config;
-	public fun getParentPath ()Ljava/lang/String;
 	public synthetic fun subConfig (Ljava/lang/String;)Ldev/detekt/api/Config;
 	public fun subConfig (Ljava/lang/String;)Ldev/detekt/test/TestConfig;
 	public fun subConfigKeys ()Ljava/util/Set;

--- a/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
@@ -5,8 +5,6 @@ import dev.detekt.api.ValueWithReason
 
 @Suppress("UNCHECKED_CAST")
 class TestConfig private constructor(override val parent: Config?, private val values: Map<String, Any>) : Config {
-    override val parentPath: String? = null
-
     constructor(parent: Config?, vararg pairs: Pair<String, Any>) : this(parent, pairs.toMap())
 
     constructor(vararg pairs: Pair<String, Any>) : this(Config.empty, *pairs)


### PR DESCRIPTION
As explained at #9035 we don't need to have `parentPath` as public api. It can be just an implementation detail in some configs.

~Waiting for:~
- ~#8976~
- ~#8986~