### PR TITLE
docs: update built-in rules count from 40+ to 200+ in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This document provides guidance for AI coding agents (Claude, Codex, Copilot, et
 ## Project Overview
 
 **detekt** is a static code analysis tool for Kotlin. It provides:
-- Code smell analysis with 40+ built-in rules
+- Code smell analysis with 200+ built-in rules
 - Highly configurable rule sets
 - Multiple report formats (HTML, Markdown, SARIF, Checkstyle XML)
 - Extensibility through custom rules, processors, and reports


### PR DESCRIPTION
Address post-merge review comments from cortinico and schalkms on #9027
noting the rules count "feels too low". Actual count across all native
rule set providers is 230 rules, making "200+" a more accurate figure.

Co-authored-by: Claude <claude@anthropic.com>

https://claude.ai/code/session_01RWfAjPFFu3cRpiGp2gZgKQ