### PR TITLE
Create single function matcher doc

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -9,6 +9,7 @@ public final class dev/detekt/psi/AnnotationExcluder {
 
 public abstract class dev/detekt/psi/FunctionMatcher {
 	public static final field Companion Ldev/detekt/psi/FunctionMatcher$Companion;
+	public static final field FUNCTION_MATCHER_DOC Ljava/lang/String;
 	public abstract fun match (Lorg/jetbrains/kotlin/analysis/api/symbols/KaCallableSymbol;)Z
 	public abstract fun match (Lorg/jetbrains/kotlin/analysis/api/symbols/KaPropertySymbol;Lorg/jetbrains/kotlin/analysis/api/symbols/KaCallableSymbol;)Z
 	public abstract fun match (Lorg/jetbrains/kotlin/psi/KtNamedFunction;Z)Z
@@ -16,7 +17,6 @@ public abstract class dev/detekt/psi/FunctionMatcher {
 
 public final class dev/detekt/psi/FunctionMatcher$Companion {
 	public final fun fromFunctionSignature (Ljava/lang/String;)Ldev/detekt/psi/FunctionMatcher;
-	public final fun getNameForGetterOrSetter (Lorg/jetbrains/kotlin/analysis/api/symbols/KaPropertySymbol;Lorg/jetbrains/kotlin/analysis/api/symbols/KaCallableSymbol;)Ljava/lang/String;
 }
 
 public final class dev/detekt/psi/IsPartOfUtilsKt {

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/FunctionMatcher.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/FunctionMatcher.kt
@@ -101,6 +101,22 @@ sealed class FunctionMatcher {
     }
 
     companion object {
+        const val FUNCTION_MATCHER_DOC = "Methods can be defined without full signature " +
+            "(i.e. `java.time.LocalDate.now`) which will match " +
+            "calls of all methods with this name or with full signature " +
+            "(i.e. `java.time.LocalDate(java.time.Clock)`) which would match only call " +
+            "with this concrete signature. If you want to match an extension function like " +
+            "`fun String.hello(a: Int)` you should add the receiver parameter as the first parameter like this: " +
+            "`hello(kotlin.String, kotlin.Int)`. To match constructor calls you need to define them with `<init>`, " +
+            "for example `java.util.Date.<init>`. To match calls involving type parameters, omit them, for example " +
+            "`fun hello(args: Array<Any>)` is referred to as simply `hello(kotlin.Array)`. To match calls " +
+            "involving varargs for example `fun hello(vararg args: String)` you need to define it like " +
+            "`hello(vararg String)`. To forbid methods from the companion object reference the Companion class, for " +
+            "example as `TestClass.Companion.hello()` (even if it is marked `@JvmStatic`). " +
+            "To match function type parameters like `initializer` in `fun <T> lazy(initializer: () -> T)`, " +
+            "use `kotlin.Function{N}` where N is the number of parameters the function takes. For example, " +
+            "`kotlin.lazy(kotlin.Function0)` matches calls to `lazy { ... }`."
+
         fun fromFunctionSignature(methodSignature: String): FunctionMatcher {
             @Suppress("TooGenericExceptionCaught", "UnsafeCallOnNullableType")
             try {
@@ -120,7 +136,7 @@ sealed class FunctionMatcher {
             }
         }
 
-        fun getNameForGetterOrSetter(propertySymbol: KaPropertySymbol, symbol: KaCallableSymbol): String? {
+        private fun getNameForGetterOrSetter(propertySymbol: KaPropertySymbol, symbol: KaCallableSymbol): String? {
             return if (symbol.callableId != null) {
                 // in case it is Java getter or setter then callableId id will be not null and can be used
                 symbol.asFqNameString()

--- a/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NamedArguments.kt
+++ b/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NamedArguments.kt
@@ -44,17 +44,7 @@ class NamedArguments(config: Config) :
 
     @Configuration(
         "List of fully qualified method signatures where this rule is ignored. " +
-            "Methods can be defined without full signatures (i.e. `java.time.LocalDate.now`), which will report " +
-            "calls of all methods with this name or with the full signature " +
-            "(i.e. `java.time.LocalDate(java.time.Clock)`), which reports only calls" +
-            "with the specific signature given. If you want to add an extension function like " +
-            "`fun String.hello(a: Int)` you should add the receiver parameter as the first parameter like this: " +
-            "`hello(kotlin.String, kotlin.Int)`. To add constructor calls you need to define them with `<init>`, " +
-            "for example `java.util.Date.<init>`. To add calls involving type parameters, omit them, for example " +
-            "`fun hello(args: Array<Any>)` is referred to as simply `hello(kotlin.Array)`. To add calls " +
-            "involving varargs, for example `fun hello(vararg args: String)`, you need to define it like " +
-            "`hello(vararg String)`. To add methods from the companion object reference the companion class, for " +
-            "example with `TestClass.Companion.hello()`, even if it is marked `@JvmStatic`."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val ignoreMethods: List<ForbiddenMethod> by config(
         valuesWithReason()

--- a/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -53,7 +53,7 @@ class NestedScopeFunctions(config: Config) :
 
     @Configuration(
         "Set of scope function names which add complexity. " +
-            "Function names have to be fully qualified. For example 'kotlin.apply'."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val functions: List<FunctionMatcher> by config(DEFAULT_FUNCTIONS) {
         it.toSet().map(FunctionMatcher::fromFunctionSignature)

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -102,10 +102,7 @@ class IgnoredReturnValue(config: Config) :
 
     @Configuration(
         "List of function signatures which should be ignored by this rule. " +
-            "Specifying fully-qualified function signature with name only (i.e. `java.time.LocalDate.now`) will " +
-            "ignore all function calls matching the name. Specifying fully-qualified function signature with " +
-            "parameters (i.e. `java.time.LocalDate.now(java.time.Clock)`) will ignore only function calls matching " +
-            "the name and parameters exactly."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val ignoreFunctionCall: List<FunctionMatcher> by config(emptyList<String>()) {
         it.map(FunctionMatcher::fromFunctionSignature)

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/UnnamedParameterUse.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/UnnamedParameterUse.kt
@@ -99,10 +99,7 @@ class UnnamedParameterUse(config: Config) :
 
     @Configuration(
         "List of function signatures which should be ignored by this rule. " +
-            "Specifying fully-qualified function signature with name only (i.e. `kotlin.collections.maxOf`) will " +
-            "ignore all function calls matching the name. Specifying fully-qualified function signature with " +
-            "parameters (i.e. `kotlin.collections.maxOf(kotlin.Long, kotlin.Long)`) will ignore only " +
-            "function calls matching the name and parameters exactly."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val ignoreFunctionCall: List<FunctionMatcher> by config(emptyList<String>()) {
         it.map(FunctionMatcher::fromFunctionSignature)

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenMethodCall.kt
@@ -60,20 +60,7 @@ class ForbiddenMethodCall(config: Config) :
 
     @Configuration(
         "List of fully qualified method signatures which are forbidden. " +
-            "Methods can be defined without full signature (i.e. `java.time.LocalDate.now`) which will report " +
-            "calls of all methods with this name or with full signature " +
-            "(i.e. `java.time.LocalDate(java.time.Clock)`) which would report only call " +
-            "with this concrete signature. If you want to forbid an extension function like " +
-            "`fun String.hello(a: Int)` you should add the receiver parameter as the first parameter like this: " +
-            "`hello(kotlin.String, kotlin.Int)`. To forbid constructor calls you need to define them with `<init>`, " +
-            "for example `java.util.Date.<init>`. To forbid calls involving type parameters, omit them, for example " +
-            "`fun hello(args: Array<Any>)` is referred to as simply `hello(kotlin.Array)`. To forbid calls " +
-            "involving varargs for example `fun hello(vararg args: String)` you need to define it like " +
-            "`hello(vararg String)`. To forbid methods from the companion object reference the Companion class, for " +
-            "example as `TestClass.Companion.hello()` (even if it is marked `@JvmStatic`). " +
-            "To match function type parameters like `initializer` in `fun <T> lazy(initializer: () -> T)`, " +
-            "use `kotlin.Function{N}` where N is the number of parameters the function takes. For example, " +
-            "`kotlin.lazy(kotlin.Function0)` matches calls to `lazy { ... }`."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val methods: List<ForbiddenMethod> by config(
         valuesWithReason(

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenNamedParam.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenNamedParam.kt
@@ -8,6 +8,7 @@ import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.api.valuesWithReason
+import dev.detekt.psi.FunctionMatcher
 import dev.detekt.psi.FunctionMatcher.Companion.fromFunctionSignature
 import dev.detekt.rules.style.ForbiddenMethodCall.ForbiddenMethod
 import org.jetbrains.kotlin.analysis.api.analyze
@@ -45,17 +46,7 @@ class ForbiddenNamedParam(config: Config) :
 
     @Configuration(
         "List of fully qualified method signatures for which are named param is forbidden. " +
-            "Methods can be defined without full signature (i.e. `java.time.LocalDate.now`) which will report " +
-            "calls of all methods with this name or with full signature " +
-            "(i.e. `java.time.LocalDate(java.time.Clock)`) which would report only call " +
-            "with this concrete signature. If you want to add an extension function like " +
-            "`fun String.hello(a: Int)` you should add the receiver parameter as the first parameter like this: " +
-            "`hello(kotlin.String, kotlin.Int)`. To add constructor calls you need to define them with `<init>`, " +
-            "for example `java.util.Date.<init>`. To add calls involving type parameters, omit them, for example " +
-            "`fun hello(args: Array<Any>)` is referred to as simply `hello(kotlin.Array)`. To add calls " +
-            "involving varargs for example `fun hello(vararg args: String)` you need to define it like " +
-            "`hello(vararg String)`. To add methods from the companion object reference the Companion class, for " +
-            "example as `TestClass.Companion.hello()` (even if it is marked `@JvmStatic`)."
+            FunctionMatcher.FUNCTION_MATCHER_DOC
     )
     private val methods: List<ForbiddenMethod> by config(
         valuesWithReason()


### PR DESCRIPTION
Make the doc generic and replace the use of word `forbid` to `match`

Fixes: https://github.com/detekt/detekt/issues/8783
