### PR TITLE
Disable `ImplicitUnitReturnType` by default for test cases

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -18,6 +18,7 @@ public abstract interface class dev/detekt/api/Config {
 	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field Companion Ldev/detekt/api/Config$Companion;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
+	public static final field IGNORE_ANNOTATED_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
 	public abstract fun getParent ()Ldev/detekt/api/Config;
@@ -34,6 +35,7 @@ public final class dev/detekt/api/Config$Companion {
 	public static final field AUTO_CORRECT_KEY Ljava/lang/String;
 	public static final field CONFIG_SEPARATOR Ljava/lang/String;
 	public static final field EXCLUDES_KEY Ljava/lang/String;
+	public static final field IGNORE_ANNOTATED_KEY Ljava/lang/String;
 	public static final field INCLUDES_KEY Ljava/lang/String;
 	public static final field SEVERITY_KEY Ljava/lang/String;
 	public final fun getEmpty ()Ldev/detekt/api/Config;

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Config.kt
@@ -65,6 +65,7 @@ interface Config {
         const val ACTIVE_KEY: String = "active"
         const val ALIASES_KEY: String = "aliases"
         const val AUTO_CORRECT_KEY: String = "autoCorrect"
+        const val IGNORE_ANNOTATED_KEY: String = "ignoreAnnotated"
         const val SEVERITY_KEY: String = "severity"
         const val EXCLUDES_KEY: String = "excludes"
         const val INCLUDES_KEY: String = "includes"

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -481,7 +481,7 @@ potential-bugs:
     active: true
   ImplicitUnitReturnType:
     active: false
-    excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']
+    ignoreAnnotated: ['Test']
     allowExplicitReturnType: true
   InvalidRange:
     active: true

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/Exclusion.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/Exclusion.kt
@@ -52,7 +52,6 @@ private object TestExclusions : Exclusions() {
         "UndocumentedPublicProperty",
         "UnsafeCallOnNullableType",
         "KDocReferencesNonPublicProperty",
-        "ImplicitUnitReturnType",
     )
 }
 

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/IgnoreAnnotated.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/IgnoreAnnotated.kt
@@ -1,0 +1,23 @@
+package dev.detekt.generator.printer.defaultconfig
+
+import dev.detekt.generator.collection.Rule
+
+/**
+ * Holds a list of default `ignoreAnnotated` values for rules.
+ */
+val ignoreAnnotatedDefaults: Array<IgnoreAnnotated> = arrayOf(TestIgnoreAnnotated)
+
+/**
+ * Tracks rules which need an extra `ignoreAnnotated` property when printing the default detekt config yaml file.
+ */
+abstract class IgnoreAnnotated {
+    abstract val annotations: List<String>
+    abstract val rules: Set<String>
+
+    fun getAnnotations(rule: Rule): List<String>? = if (rule.name in rules) annotations else null
+}
+
+private object TestIgnoreAnnotated : IgnoreAnnotated() {
+    override val annotations = listOf("Test")
+    override val rules = setOf("ImplicitUnitReturnType")
+}

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
@@ -45,6 +45,12 @@ internal fun YamlNode.printRule(rule: Rule) {
         if (ruleExclusion != null) {
             keyValue { Config.EXCLUDES_KEY to ruleExclusion.pattern }
         }
+        val ignoreAnnotated = ignoreAnnotatedDefaults.firstNotNullOfOrNull { it.getAnnotations(rule) }
+        if (ignoreAnnotated != null) {
+            keyValue {
+                Config.IGNORE_ANNOTATED_KEY to ignoreAnnotated.joinToString(prefix = "[", postfix = "]") { "'$it'" }
+            }
+        }
         rule.configurations.forEach(::printConfiguration)
     }
 }

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
@@ -140,6 +140,28 @@ internal class RuleSetConfigPrinterTest {
                 assertThat(actual).doesNotContain(Config.EXCLUDES_KEY)
             }
         }
+
+        @Nested
+        inner class IgnoreAnnotated {
+            @Test
+            fun `rule has ignoreAnnotated`() {
+                val anIgnoreAnnotated = ignoreAnnotatedDefaults[0]
+                val anIgnoreAnnotatedRuleName = anIgnoreAnnotated.rules.first()
+                val rule = ruleTemplate.copy(name = anIgnoreAnnotatedRuleName)
+                val actual = yaml { printRule(rule) }
+                assertThat(actual).contains(Config.IGNORE_ANNOTATED_KEY)
+                anIgnoreAnnotated.annotations.forEach { annotation ->
+                    assertThat(actual).contains("'$annotation'")
+                }
+            }
+
+            @Test
+            fun `omits ignoreAnnotated property if rule has no default`() {
+                val rule = ruleTemplate.copy(name = "ARuleNameThatHasNoIgnoreAnnotated")
+                val actual = yaml { printRule(rule) }
+                assertThat(actual).doesNotContain(Config.IGNORE_ANNOTATED_KEY)
+            }
+        }
     }
 
     @Nested

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnType.kt
@@ -56,7 +56,7 @@ class ImplicitUnitReturnType(config: Config) :
 
         if (function.hasImplicitUnitReturnType()) {
             val message = buildString {
-                append("'${function.name}'  has the implicit return type `Unit`.")
+                append("'${function.name}' has the implicit return type `Unit`.")
                 append(" Prefer using a block statement")
                 if (allowExplicitReturnType) {
                     append(" or specify the return type explicitly")


### PR DESCRIPTION
It's a pretty common pattern for test cases (especially coroutine tests, but also some other frameworks too) to use a pattern like:

```kotlin
@Test 
fun myTest() = runTest {
  // whatever
}
```

As it stands, if I enable this rule it'll flag an issue due to the implicit Unit return type. IMO that's unnecessary.

Two(?) solutions:
1. Exclude the rule for test source sets. Could be considered overkill, since it'll also disable for utility functions in test source sets, not just the test cases themselves
1. Check in the `visitNamedFunction` block of the rule logic for any annotations, and skip if it's a junit4/junit5/kotlin-test `@Test` annotation.
1. Any other suggestions?