### PR TITLE
Remove `compile = false` from test cases that do not need it

### DIFF
--- a/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/ThrowingExceptionsWithoutMessageOrCauseSpec.kt
@@ -42,7 +42,7 @@ class ThrowingExceptionsWithoutMessageOrCauseSpec {
                 org.assertj.core.api.Assertions.assertThatIllegalArgumentException().isThrownBy { println() }
             }
         """.trimIndent()
-        assertThat(subject.lint(code, compile = false)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/TopLevelPropertyNamingSpec.kt
@@ -17,7 +17,7 @@ class TopLevelPropertyNamingSpec {
             const val lowerCaseConst = ""
         """.trimIndent()
         val subject = TopLevelPropertyNaming(TestConfig(TopLevelPropertyNaming.CONSTANT_PATTERN to "^lowerCaseConst$"))
-        assertThat(subject.lint(code, compile = false)).isEmpty()
+        assertThat(subject.lint(code)).isEmpty()
     }
 
     @Nested
@@ -29,7 +29,7 @@ class TopLevelPropertyNamingSpec {
                 const val MY_NAME_8 = "Artur"
                 const val MYNAME = "Artur"
             """.trimIndent()
-            assertThat(subject.lint(code, compile = false)).isEmpty()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -41,7 +41,7 @@ class TopLevelPropertyNamingSpec {
                 private const val _nAme = "Artur"
                 const val serialVersionUID = 42L
             """.trimIndent()
-            assertThat(subject.lint(code, compile = false)).hasSize(5)
+            assertThat(subject.lint(code)).hasSize(5)
         }
     }
 

--- a/detekt-rules-ruleauthors/src/test/kotlin/dev/detekt/rules/ruleauthors/UseEntityAtNameSpec.kt
+++ b/detekt-rules-ruleauthors/src/test/kotlin/dev/detekt/rules/ruleauthors/UseEntityAtNameSpec.kt
@@ -21,7 +21,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -37,7 +37,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.atName(element), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 
@@ -53,7 +53,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.nameIdentifier!!), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element) instead.")
             .hasTextLocation("from")
@@ -71,7 +71,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.nameIdentifier!!!!), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element) instead.")
             .hasTextLocation("from")
@@ -89,7 +89,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.nameIdentifier ?: element), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element) instead.")
             .hasTextLocation("from")
@@ -110,7 +110,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.getStrictParentOfType<KtClass>()?.nameIdentifier ?: element), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element.getStrictParentOfType<KtClass>()) instead.")
             .hasTextLocation("from")
@@ -129,7 +129,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.nameIdentifier ?: element2), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).singleElement()
             .hasMessage("Recommended to use Entity.atName(element) instead.")
             .hasTextLocation("from")
@@ -148,7 +148,7 @@ internal class UseEntityAtNameSpec {
                 report(Finding(Entity.from(element.nameIdentifier ?: element2, 0), "message"))
             }
         """.trimIndent()
-        val findings = rule.lint(code, compile = false)
+        val findings = rule.lint(code)
         assertThat(findings).isEmpty()
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MagicNumberSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/MagicNumberSpec.kt
@@ -49,13 +49,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code, compile = false)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -84,13 +84,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code, compile = false)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -169,13 +169,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code, compile = false)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -204,13 +204,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code, compile = false)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }
@@ -239,13 +239,13 @@ class MagicNumberSpec {
 
         @Test
         fun `should not be reported by default`() {
-            val findings = MagicNumber(Config.empty).lint(code, compile = false)
+            val findings = MagicNumber(Config.empty).lint(code)
             assertThat(findings).isEmpty()
         }
 
         @Test
         fun `should not be reported when ignoredNumbers is empty`() {
-            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code, compile = false)
+            val findings = MagicNumber(TestConfig(IGNORE_NUMBERS to emptyList<String>())).lint(code)
             assertThat(findings).isEmpty()
         }
     }


### PR DESCRIPTION
This snippets compile so we shouldn't set `compile = false`