### PR TITLE
Simplify KotlinEnvironmentContainer

### DIFF
--- a/detekt-test-junit/src/main/kotlin/dev/detekt/test/junit/KotlinEnvironmentTestSetup.kt
+++ b/detekt-test-junit/src/main/kotlin/dev/detekt/test/junit/KotlinEnvironmentTestSetup.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
-import java.io.File
+import java.nio.file.Path
 
 /**
  * This annotation must be applied to a test class to make use of type analysis APIs when testing Detekt rules, e.g.
@@ -44,10 +44,10 @@ internal class KotlinEnvironmentResolver : ParameterResolver {
     companion object {
         private val NAMESPACE = ExtensionContext.Namespace.create("KotlinCoreEnvironment")
         private const val ENV_KEY = "env"
-        private fun ExtensionContext.additionalJavaSourcePaths(): List<File> {
+        private fun ExtensionContext.additionalJavaSourcePaths(): List<Path> {
             val annotation = requiredTestClass.annotations
                 .find { it is KotlinCoreEnvironmentTest } as? KotlinCoreEnvironmentTest ?: return emptyList()
-            return annotation.additionalJavaSourcePaths.map { resourceAsPath(it).toFile() }
+            return annotation.additionalJavaSourcePaths.map { resourceAsPath(it) }
         }
     }
 }

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -14,8 +14,9 @@ public final class dev/detekt/test/utils/KotlinAnalysisApiEngine {
 }
 
 public final class dev/detekt/test/utils/KotlinEnvironmentContainer {
-	public fun <init> (Lorg/jetbrains/kotlin/config/CompilerConfiguration;)V
-	public final fun getConfiguration ()Lorg/jetbrains/kotlin/config/CompilerConfiguration;
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun getJavaSourceRoots ()Ljava/util/List;
+	public final fun getJvmClasspathRoots ()Ljava/util/List;
 }
 
 public final class dev/detekt/test/utils/KotlinEnvironmentContainerKt {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
@@ -1,10 +1,7 @@
 package dev.detekt.test.utils
 
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
-import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
 import org.jetbrains.kotlin.psi.KtFile
-import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
@@ -33,8 +30,8 @@ fun compileContentForTest(
 
     return KotlinAnalysisApiEngine.compile(
         code = content,
-        javaSourceRoots = environment.configuration.javaSourceRoots.map(::Path),
-        jvmClasspathRoots = environment.configuration.jvmClasspathRoots.map(File::toPath)
+        javaSourceRoots = environment.javaSourceRoots,
+        jvmClasspathRoots = environment.jvmClasspathRoots,
     )
 }
 

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinEnvironmentContainer.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinEnvironmentContainer.kt
@@ -1,37 +1,20 @@
 package dev.detekt.test.utils
 
-import org.jetbrains.kotlin.cli.common.messages.MessageCollector
-import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
-import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
-import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
-import org.jetbrains.kotlin.config.CommonConfigurationKeys
-import org.jetbrains.kotlin.config.CompilerConfiguration
-import org.jetbrains.kotlin.config.JVMConfigurationKeys
-import java.io.File
+import java.nio.file.Path
 import kotlin.script.experimental.jvm.util.classpathFromClassloader
 
-class KotlinEnvironmentContainer(val configuration: CompilerConfiguration)
+class KotlinEnvironmentContainer(val javaSourceRoots: List<Path>, val jvmClasspathRoots: List<Path>)
 
 /**
- * Create a {@link KotlinEnvironmentContainer} used for test.
+ * Create a [KotlinEnvironmentContainer] used for test.
  *
  * @param additionalJavaSourceRootPaths the optional Java source roots list.
  */
-fun createEnvironment(additionalJavaSourceRootPaths: List<File> = emptyList()): KotlinEnvironmentContainer {
-    val configuration = CompilerConfiguration()
-    configuration.put(CommonConfigurationKeys.MODULE_NAME, "test_module")
-    configuration.put(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
-
-    // Get the runtime locations of both the stdlib and kotlinx coroutines core jars and pass
-    // to the compiler so it's available to generate the BindingContext for rules under test.
-    configuration.apply {
-        val classLoader = Thread.currentThread().contextClassLoader
-        val classpath = checkNotNull(classpathFromClassloader(classLoader)) { "We should always have a classpath" }
-        addJvmClasspathRoots(classpath)
-        addJavaSourceRoots(additionalJavaSourceRootPaths)
-        put(JVMConfigurationKeys.JDK_HOME, File(System.getProperty("java.home")))
-        configureJdkClasspathRoots()
-    }
-
-    return KotlinEnvironmentContainer(configuration)
+fun createEnvironment(additionalJavaSourceRootPaths: List<Path> = emptyList()): KotlinEnvironmentContainer {
+    val classLoader = Thread.currentThread().contextClassLoader
+    val classpath = checkNotNull(classpathFromClassloader(classLoader)) { "We should always have a classpath" }
+    return KotlinEnvironmentContainer(
+        javaSourceRoots = additionalJavaSourceRootPaths,
+        jvmClasspathRoots = classpath.map { it.toPath() },
+    )
 }

--- a/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
@@ -9,17 +9,13 @@ import dev.detekt.test.utils.KotlinEnvironmentContainer
 import dev.detekt.test.utils.compileContentForTest
 import dev.detekt.test.utils.createEnvironment
 import org.intellij.lang.annotations.Language
-import org.jetbrains.kotlin.cli.jvm.config.javaSourceRoots
-import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
 import org.jetbrains.kotlin.config.LanguageVersionSettings
-import org.jetbrains.kotlin.config.languageVersionSettings
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
-import java.io.File
-import kotlin.io.path.Path
 
 private val shouldCompileTestSnippets: Boolean =
     System.getProperty("compile-test-snippets", "false")!!.toBoolean()
@@ -34,10 +30,7 @@ fun Rule.lint(
     }
     if (compile && shouldCompileTestSnippets) {
         try {
-            KotlinAnalysisApiEngine.compile(
-                content,
-                jvmClasspathRoots = createEnvironment().configuration.jvmClasspathRoots.map(File::toPath),
-            )
+            KotlinAnalysisApiEngine.compile(content, jvmClasspathRoots = createEnvironment().jvmClasspathRoots)
         } catch (ex: RuntimeException) {
             if (!ex.isNoMatchingOutputFiles()) throw ex
         }
@@ -51,13 +44,13 @@ fun <T> T.lintWithContext(
     @Language("kotlin") content: String,
     @Language("kotlin") vararg dependencyContents: String,
     allowCompilationErrors: Boolean = false,
-    languageVersionSettings: LanguageVersionSettings = environment.configuration.languageVersionSettings,
+    languageVersionSettings: LanguageVersionSettings = LanguageVersionSettingsImpl.DEFAULT,
 ): List<Finding> where T : Rule, T : RequiresAnalysisApi {
     val ktFile = KotlinAnalysisApiEngine.compile(
         code = content,
         dependencyCodes = dependencyContents.toList(),
-        javaSourceRoots = environment.configuration.javaSourceRoots.map(::Path),
-        jvmClasspathRoots = environment.configuration.jvmClasspathRoots.map(File::toPath),
+        javaSourceRoots = environment.javaSourceRoots,
+        jvmClasspathRoots = environment.jvmClasspathRoots,
         allowCompilationErrors = allowCompilationErrors
     )
     return visitFile(ktFile, languageVersionSettings).filterSuppressed(this)


### PR DESCRIPTION
We didn't need `CompilerConfiguration`. It seems like something that we needed at 1.0.