### PR TITLE
Updated to using Gradle's lazy APIs

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -244,7 +244,7 @@ class DetektMultiplatformSpec {
                         "src/androidMain/kotlin",
                     ),
                     baselineFiles = listOf(
-                        "detekt-baseline.xml",
+                        "detekt-baseline-main.xml",
                     )
                 )
             }
@@ -263,7 +263,7 @@ class DetektMultiplatformSpec {
         @Test
         fun `configures detekt task with type resolution`() {
             gradleRunner.runTasksAndCheckResult(":shared:detektMainAndroid") {
-                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline.xml """)
+                assertThat(it.output).containsPattern("""--baseline \S*[/\\]detekt-baseline-main.xml """)
                 assertThat(it.output).containsPattern("""--report checkstyle:\S*[/\\]mainAndroid.xml""")
                 assertDetektWithClasspath(it)
             }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -81,7 +81,7 @@ class DetektBasePlugin : Plugin<Project> {
 
             project.extensions.getByType(KotlinSourceSetContainer::class.java)
                 .sourceSets
-                .all { sourceSet ->
+                .configureEach { sourceSet ->
                     val taskName = "${DetektPlugin.DETEKT_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
                     tasks.register(taskName, Detekt::class.java) { detektTask ->
                         detektTask.source = sourceSet.kotlin

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -9,7 +9,9 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidExtension
 
 internal object DetektAndroidCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
-        project.extensions.getByType(KotlinAndroidExtension::class.java).target.compilations.all { compilation ->
+        project.extensions.getByType(
+            KotlinAndroidExtension::class.java
+        ).target.compilations.configureEach { compilation ->
             project.registerJvmCompilationDetektTask(extension, compilation)
             project.registerJvmCompilationCreateBaselineTask(extension, compilation)
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektJvmCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektJvmCompilations.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
 
 internal object DetektJvmCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
-        project.extensions.getByType(KotlinJvmExtension::class.java).target.compilations.all { compilation ->
+        project.extensions.getByType(KotlinJvmExtension::class.java).target.compilations.configureEach { compilation ->
             project.registerJvmCompilationDetektTask(extension, compilation)
             project.registerJvmCompilationCreateBaselineTask(extension, compilation)
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektKmpJvmCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektKmpJvmCompilations.kt
@@ -10,8 +10,8 @@ internal object DetektKmpJvmCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
         val kotlinExtension = project.extensions.getByType(KotlinTargetsContainer::class.java)
 
-        kotlinExtension.targets.matching { it.platformType in setOf(jvm, androidJvm) }.all { target ->
-            target.compilations.all { compilation ->
+        kotlinExtension.targets.matching { it.platformType in setOf(jvm, androidJvm) }.configureEach { target ->
+            target.compilations.configureEach { compilation ->
                 project.registerJvmCompilationDetektTask(extension, compilation, target)
                 project.registerJvmCompilationCreateBaselineTask(extension, compilation, target)
             }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -21,20 +21,32 @@ internal fun Project.registerJvmCompilationDetektTask(
 ) {
     val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
-        val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
+        val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
-        detektTask.setSource(siblingTask.sources)
-        detektTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        detektTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
-        detektTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
-        detektTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
+        detektTask.setSource(siblingTask.map { it.sources })
+        detektTask.classpath.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.libraries }
+        )
+        detektTask.friendPaths.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.friendPaths }
+        )
+        detektTask.apiVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.apiVersion.map { it.version } }
+        )
+        detektTask.languageVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.languageVersion.map { it.version } }
+        )
         /* Note: jvmTarget convention is also set in setDetektTaskDefaults. There may be a race between setting it here
            as well, but they should both set the same value. This should possibly be revisited in the future. */
-        detektTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
-        detektTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
-        detektTask.optIn.convention(siblingTask.compilerOptions.optIn)
-        detektTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
-        detektTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
+        detektTask.jvmTarget.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.jvmTarget.map { it.target } }
+        )
+        detektTask.freeCompilerArgs.convention(siblingTask.flatMap { it.compilerOptions.freeCompilerArgs })
+        detektTask.optIn.convention(siblingTask.flatMap { it.compilerOptions.optIn })
+        detektTask.noJdk.convention(siblingTask.flatMap { it.compilerOptions.noJdk })
+        detektTask.multiPlatformEnabled.convention(siblingTask.flatMap { it.multiPlatformEnabled })
         if (compilation.name == "main") {
             detektTask.explicitApi.convention(mapExplicitArgMode())
         }
@@ -65,20 +77,32 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         DetektPlugin.BASELINE_TASK_NAME + taskSuffix.capitalize(),
         DetektCreateBaselineTask::class.java,
     ) { createBaselineTask ->
-        val siblingTask = compilation.compileTaskProvider.get() as KotlinJvmCompile
+        val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
-        createBaselineTask.setSource(siblingTask.sources)
-        createBaselineTask.classpath.conventionCompat(compilation.output.classesDirs, siblingTask.libraries)
-        createBaselineTask.friendPaths.conventionCompat(compilation.output.classesDirs, siblingTask.friendPaths)
-        createBaselineTask.apiVersion.convention(siblingTask.compilerOptions.apiVersion.map { it.version })
-        createBaselineTask.languageVersion.convention(siblingTask.compilerOptions.languageVersion.map { it.version })
+        createBaselineTask.setSource(siblingTask.map { it.sources })
+        createBaselineTask.classpath.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.libraries }
+        )
+        createBaselineTask.friendPaths.conventionCompat(
+            compilation.output.classesDirs,
+            siblingTask.map { it.friendPaths }
+        )
+        createBaselineTask.apiVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.apiVersion.map { it.version } }
+        )
+        createBaselineTask.languageVersion.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.languageVersion.map { it.version } }
+        )
         /* Note: jvmTarget convention is also set in setCreateBaselineTaskDefaults. There may be a race between setting
            it here as well, but they should both set the same value. This should possibly be revisited in the future. */
-        createBaselineTask.jvmTarget.convention(siblingTask.compilerOptions.jvmTarget.map { it.target })
-        createBaselineTask.freeCompilerArgs.convention(siblingTask.compilerOptions.freeCompilerArgs)
-        createBaselineTask.optIn.convention(siblingTask.compilerOptions.optIn)
-        createBaselineTask.noJdk.convention(siblingTask.compilerOptions.noJdk)
-        createBaselineTask.multiPlatformEnabled.convention(siblingTask.multiPlatformEnabled)
+        createBaselineTask.jvmTarget.convention(
+            siblingTask.flatMap { task -> task.compilerOptions.jvmTarget.map { it.target } }
+        )
+        createBaselineTask.freeCompilerArgs.convention(siblingTask.flatMap { it.compilerOptions.freeCompilerArgs })
+        createBaselineTask.optIn.convention(siblingTask.flatMap { it.compilerOptions.optIn })
+        createBaselineTask.noJdk.convention(siblingTask.flatMap { it.compilerOptions.noJdk })
+        createBaselineTask.multiPlatformEnabled.convention(siblingTask.flatMap { it.multiPlatformEnabled })
         if (compilation.name == "main") {
             createBaselineTask.explicitApi.convention(mapExplicitArgMode())
         }


### PR DESCRIPTION
Most of the changes are replacing `.all` with `.configureEach`. The SharedTasks register methods were accessing the compileTaskProvider eagerly. This was fixed by changing the `siblingTask` from a `KotlinJvmCompile` type to `Provider<KotlinJvmCompile>`. This is the reason for the rest of the changes in the file.

This change did highlight an error in the DetektMultiplatformSpec test class. These tests have a `per_class` lifecycle being set by module.gradle.kts. The `configures detekt task with type resolution` test case expected detekt-baseline.xml to be used, but if the `configures baseline task` test case runs before it, a detekt-baseline-main.xml exists along with detekt-baseline.xml.

The `existingVariantOrBaseFile` logic causes the -main variant to be used since the test case runs `detektMainAndroid`. This wasn't an issue prior because of the eager logic since `existingVariantOrBaseFile` would run immediately and the file wouldn't exist at that point.

Now that it is read in the execution phase instead of the configuration phase, the file will exist if the baseline test case is run first. So to avoid issues with test ordering, I figured expecting -main would be the simplest fix. You could also explicitly set that nested class to use `per_method` instead of `per_class` as the test lifecycle.

