### PR TITLE
Bug fix for JvmSpec windows test failures

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
@@ -15,11 +15,13 @@ class JvmSpec {
             .buildAndFail()
 
         assertThat(result.output).contains("failed with 4 issues.")
-        assertThat(result.output).contains(
+        assertThat(result.output.normalizePaths()).contains(
             "src/main/kotlin/Errors.kt:7:9: Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
             "src/main/kotlin/Errors.kt:12:16: Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
             "src/main/kotlin/Caller.kt:5:18: The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in the detekt config. [ForbiddenMethodCall]",
             "src/main/kotlin/Caller.kt:6:9: Callee()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
         )
     }
+
+    private fun String.normalizePaths(): String = replace("\\", "/")
 }


### PR DESCRIPTION
Not sure why this came about after my lazy Gradle ticket, but it looks like the tests weren't running for Windows when looking at past commit build scans. 


