### PR TITLE
Remove unnecessary `@Suppress`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
@@ -56,10 +56,9 @@ class ProcessingSettings(val spec: ProcessingSpec, override val config: Config, 
 private fun ConfigSpec.extractUris(): Collection<URI> {
     fun initFileSystem(uri: URI) {
         runCatching {
-            @Suppress("SwallowedException") // Create file system inferred from URI if it does not exist.
             try {
                 FileSystems.getFileSystem(uri)
-            } catch (e: FileSystemNotFoundException) {
+            } catch (_: FileSystemNotFoundException) {
                 FileSystems.newFileSystem(uri, mapOf("create" to "true"))
             }
         }


### PR DESCRIPTION
`SwallowedException` doesn't complain when the name of the cached exception is `_`.