### PR TITLE
Register explicit API config for plain `detekt` task

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/DetektPlain.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/DetektPlain.kt
@@ -4,10 +4,12 @@ import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.plugin.DetektPlugin
+import dev.detekt.gradle.plugin.internal.mapExplicitArgMode
 import org.gradle.api.Project
 import org.gradle.api.file.FileCollection
 import org.gradle.api.provider.Provider
 import org.gradle.language.base.plugins.LifecycleBasePlugin
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
 
 internal class DetektPlain(private val project: Project) {
 
@@ -24,15 +26,28 @@ internal class DetektPlain(private val project: Project) {
             detektTask.setExcludes(DetektPlugin.defaultExcludes)
         }
 
+        plugins.withType(KotlinBasePlugin::class.java) {
+            detektTaskProvider.configure { detektTask ->
+                detektTask.explicitApi.convention(mapExplicitArgMode())
+            }
+        }
+
         tasks.matching { it.name == LifecycleBasePlugin.CHECK_TASK_NAME }.configureEach {
             it.dependsOn(detektTaskProvider)
         }
     }
 
     private fun Project.registerCreateBaselineTask(extension: DetektExtension) {
-        tasks.register(DetektPlugin.BASELINE_TASK_NAME, DetektCreateBaselineTask::class.java) {
-            it.baseline.convention(extension.baseline)
-            it.setSource(existingInputDirectoriesProvider(project, extension))
+        val baselineTaskProvider =
+            tasks.register(DetektPlugin.BASELINE_TASK_NAME, DetektCreateBaselineTask::class.java) {
+                it.baseline.convention(extension.baseline)
+                it.setSource(existingInputDirectoriesProvider(project, extension))
+            }
+
+        plugins.withType(KotlinBasePlugin::class.java) {
+            baselineTaskProvider.configure { baselineTask ->
+                baselineTask.explicitApi.convention(mapExplicitArgMode())
+            }
         }
     }
 


### PR DESCRIPTION
Closes #9063

Makes sure that explicitly-public symbols aren't flagged under the `RedundantVisibilityModifier` rule when running `gradle detekt`.

We could also remove the "main" sourceset checks from four other places to also pass the explicit API flag to the sourceset-specific tasks, see:

- [SharedTasks 1/2](https://github.com/detekt/detekt/blob/main/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt#L50-L52)
- [SharedTasks 2/2](https://github.com/detekt/detekt/blob/main/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt#L106-L108)
- [DetektBasePlugin 1/2](https://github.com/detekt/detekt/blob/main/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt#L97-L99)
- [DetektBasePlugin 2/2](https://github.com/detekt/detekt/blob/main/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt#L115-L117)

But I'm not 100% sure why those checks were added in the first place so didn't want to break anything in some weird way. My assumption is that it was because test source sets don't enforce the explicit API in the regular kotlin compiler? [It was added here, for reference](https://github.com/detekt/detekt/pull/7418)

Either way this PR fixes my initial problem as it stands.