### PR TITLE
Update docs for rule testing

### DIFF
--- a/website/docs/introduction/extensions.md
+++ b/website/docs/introduction/extensions.md
@@ -37,7 +37,7 @@ A `RuleSetProvider` must also be implemented, declaring a `RuleSet` in the `inst
 
 Example of a custom rule:
 ```kotlin
-class TooManyFunctions2(config: Config) : Rule(
+class TooManyFunctions(config: Config) : Rule(
     config,
     "This rule reports a file with an excessive function count.",
 ) {
@@ -64,14 +64,14 @@ If you want your rule to be configurable, write down your properties inside the 
 
 ```yaml
 MyRuleSet:
-  TooManyFunctions2:
+  TooManyFunctions:
     active: true
     threshold: 5
   OtherRule:
     active: false
 ```
 
-By specifying the rule set and rule IDs, _detekt_ will use the sub-configuration of `TooManyFunctions2`.
+By specifying the rule set and rule IDs, _detekt_ will use the sub-configuration of `TooManyFunctions`.
 
 ### Testing custom rules {#testing}
 


### PR DESCRIPTION
Followup to https://github.com/detekt/detekt/pull/9051#issuecomment-3892847843

Main change is fleshing out the docs for testing custom rulesets. It's not exhaustive but it'll help more than before. Also made some more general changes the same page, while I was there:

- fixed some clunky grammar/phrasing
- fixed markdown header usage, so we now get a navigable TOC on the right of the page
- other tidying/clarifications

Tried not to change the meaning of the non-testing changes too much.