### PR TITLE
Fix false positive for `ExplicitCollectionElementAccessMethod` with lambdas

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ExplicitCollectionElementAccessMethod.kt
@@ -143,7 +143,13 @@ class ExplicitCollectionElementAccessMethod(config: Config) :
         val block = expression.parent.parent as? KtBlockExpression ?: return false
 
         // If the block is a lambda body and this expression is the last statement, the return value is implicitly
-        // used as the lambda's return value
-        return !(block.parent is KtFunctionLiteral && block.statements.lastOrNull() == expression.parent)
+        // used as the lambda's return value — unless the lambda returns Unit
+        val functionLiteral = block.parent as? KtFunctionLiteral
+        if (functionLiteral != null && block.statements.lastOrNull() == expression.parent) {
+            return analyze(functionLiteral) {
+                functionLiteral.symbol.returnType.isUnitType
+            }
+        }
+        return true
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ExplicitCollectionElementAccessMethodSpec.kt
@@ -200,6 +200,40 @@ class ExplicitCollectionElementAccessMethodSpec {
             }
 
             @Test
+            fun `reports when put is last statement in Unit-returning lambda`() {
+                val code = """
+                    fun doSomething(action: () -> Unit) {
+                        action()
+                    }
+
+                    fun main() {
+                        val map = mutableMapOf<Int, String>()
+                        doSomething { map.put(123, "abc") }
+                    }
+                """.trimIndent()
+                assertThat(subject.lintWithContext(env, code)).hasSize(1)
+            }
+
+            @Test
+            fun `reports when put is called multiple times in Unit-returning lambda`() {
+                val code = """
+                    fun doSomething(action: () -> Unit) {
+                        action()
+                    }
+
+                    fun main() {
+                        val map = mutableMapOf<Int, String>()
+                        doSomething { 
+                            map.put(123, "abc") 
+                            map.put(456, "def") 
+                            map.put(789, "ghi") 
+                        }
+                    }
+                """.trimIndent()
+                assertThat(subject.lintWithContext(env, code)).hasSize(3)
+            }
+
+            @Test
             fun `does not report for a custom map type`() {
                 val code = $$"""
                     interface PersistentMap<K, V> : Map<K, V> {


### PR DESCRIPTION
Fixed ExplicitCollectionElementAccessMethod incorrectly reporting `map.put()` when its return value is implicitly used as a lambda's return value.

For context: I was getting this when calling `PersistentMap.put()`, which returns a copy of the previous map plus the new data. But I was calling that inside a `MutableStateFlow.update` lambda block, and that triggered an issue from this rule.