### PR TITLE
Make `functionalTest` os dependent

### DIFF
--- a/build-logic/src/main/kotlin/dev/detekt/buildlogic/Utils.kt
+++ b/build-logic/src/main/kotlin/dev/detekt/buildlogic/Utils.kt
@@ -1,0 +1,15 @@
+package dev.detekt.buildlogic
+
+import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Task
+
+private val operativeSystem: String = when {
+    Os.isFamily(Os.FAMILY_WINDOWS) -> Os.FAMILY_WINDOWS
+    Os.isFamily(Os.FAMILY_MAC) -> Os.FAMILY_MAC
+    Os.isFamily(Os.FAMILY_UNIX) -> Os.FAMILY_UNIX
+    else -> System.getProperty("os.name").lowercase()
+}
+
+fun Task.osDependent() {
+    inputs.property("os.name", operativeSystem)
+}

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -2,6 +2,7 @@
 // https://github.com/gradle/gradle/issues/21285
 @file:Suppress("StringLiteralDuplication")
 
+import dev.detekt.buildlogic.osDependent
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
@@ -89,6 +90,7 @@ testing {
             targets {
                 all {
                     testTask.configure {
+                        osDependent()
                         // If `androidSdkInstalled` is false, skip running DetektAndroidSpec
                         val isAndroidSdkInstalled = providers.environmentVariable("ANDROID_SDK_ROOT").isPresent ||
                             providers.environmentVariable("ANDROID_HOME").isPresent


### PR DESCRIPTION
This change should avoid this type of issues: #9087.

I don't want to add `osDependent()` to all the `test` tasks because that can be overkill. But probably we will need to add it to more test tasks so, for that reason, I created the `osDependent` function so we can add it to any other module that we need.

cc @FletchMcKee