### PR TITLE
Fix indentation for 2.0.0-alpha.2 docs

### DIFF
--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/comments.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/comments.md
@@ -45,12 +45,12 @@ annotation constructor has dedicated fields for a message and a type (warning, e
 
 ```kotlin
 /**
-* This function prints a message followed by a new line.
-*
-* @deprecated Useless, the Kotlin standard library can already do this. Replace with println.
-*/
+ * This function prints a message followed by a new line.
+ *
+ * @deprecated Useless, the Kotlin standard library can already do this. Replace with println.
+ */
 fun printThenNewline(what: String) {
-// ...
+    // ...
 }
 ```
 
@@ -58,12 +58,12 @@ fun printThenNewline(what: String) {
 
 ```kotlin
 /**
-* This function prints a message followed by a new line.
-*/
+ * This function prints a message followed by a new line.
+ */
 @Deprecated("Useless, the Kotlin standard library can already do this.")
 @ReplaceWith("println(what)")
 fun printThenNewline(what: String) {
-// ...
+    // ...
 }
 ```
 
@@ -117,13 +117,13 @@ Clients do not need to know the implementation details.
 
 ```kotlin
 /**
-* Comment
-* [prop1] - non-public property
-* [prop2] - public property
-*/
+ * Comment
+ * [prop1] - non-public property
+ * [prop2] - public property
+ */
 class Test {
-private val prop1 = 0
-val prop2 = 0
+    private val prop1 = 0
+    val prop2 = 0
 }
 ```
 
@@ -131,12 +131,12 @@ val prop2 = 0
 
 ```kotlin
 /**
-* Comment
-* [prop2] - public property
-*/
+ * Comment
+ * [prop2] - public property
+ */
 class Test {
-private val prop1 = 0
-val prop2 = 0
+    private val prop1 = 0
+    val prop2 = 0
 }
 ```
 
@@ -167,15 +167,15 @@ turn off these features using configuration options.
 
 ```kotlin
 /**
-* @param someParam
-* @property someProp
-*/
+ * @param someParam
+ * @property someProp
+ */
 class MyClass(otherParam: String, val otherProp: String)
 
 /**
-* @param T
-* @param someParam
-*/
+ * @param T
+ * @param someParam
+ */
 fun <T, S> myFun(someParam: String)
 ```
 
@@ -183,16 +183,16 @@ fun <T, S> myFun(someParam: String)
 
 ```kotlin
 /**
-* @param someParam
-* @property someProp
-*/
+ * @param someParam
+ * @property someProp
+ */
 class MyClass(someParam: String, val someProp: String)
 
 /**
-* @param T
-* @param S
-* @param someParam
-*/
+ * @param T
+ * @param S
+ * @param someParam
+ */
 fun <T, S> myFun(someParam: String)
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/complexity.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/complexity.md
@@ -54,7 +54,7 @@ and call those instead.
 ```kotlin
 val str = "foo"
 val isFoo = if (str.startsWith("foo") && !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")) {
-// ...
+    // ...
 }
 ```
 
@@ -63,7 +63,7 @@ val isFoo = if (str.startsWith("foo") && !str.endsWith("foo") && !str.endsWith("
 ```kotlin
 val str = "foo"
 val isFoo = if (str.startsWith("foo") && hasCorrectEnding()) {
-// ...
+    // ...
 }
 
 fun hasCorrectEnding() = return !str.endsWith("foo") && !str.endsWith("bar") && !str.endsWith("_")
@@ -116,7 +116,7 @@ Each one of them adds one to the complexity count.
 - __Operators__ `&&`, `||`, `?:`
 - __Exceptions__ - `catch`, `use`
 - __Scope Functions__ - `let`, `run`, `with`, `apply`, and `also` ->
-[Reference](https://kotlinlang.org/docs/scope-functions.html)
+ [Reference](https://kotlinlang.org/docs/scope-functions.html)
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -166,16 +166,16 @@ way to get the instance of an outer class from an inner class in Kotlin.
 ```kotlin
 val range = listOf<String>("foo", "bar")
 loop@ for (r in range) {
-if (r == "bar") break@loop
-println(r)
+    if (r == "bar") break@loop
+    println(r)
 }
 
 class Outer {
-inner class Inner {
-fun f() {
-val i = this@Inner // referencing itself, use `this instead
-}
-}
+    inner class Inner {
+        fun f() {
+            val i = this@Inner // referencing itself, use `this instead
+        }
+    }
 }
 ```
 
@@ -184,19 +184,19 @@ val i = this@Inner // referencing itself, use `this instead
 ```kotlin
 val range = listOf<String>("foo", "bar")
 for (r in range) {
-if (r == "bar") break
-println(r)
+    if (r == "bar") break
+    println(r)
 }
 
 class Outer {
-inner class Inner {
-fun f() {
-val outer = this@Outer
-}
-fun Int.extend() {
-val inner = this@Inner // this would reference Int and not Inner
-}
-}
+    inner class Inner {
+        fun f() {
+            val outer = this@Outer
+        }
+        fun Int.extend() {
+            val inner = this@Inner // this would reference Int and not Inner
+        }
+    }
 }
 ```
 
@@ -356,10 +356,10 @@ it's easy to get confused about the current context object and the value of this
 ```kotlin
 // Try to figure out, what changed, without knowing the details
 first.apply {
-second.apply {
-b = a
-c = b
-}
+    second.apply {
+        b = a
+        c = b
+    }
 }
 ```
 
@@ -392,18 +392,18 @@ only one, as that will still improve code coverage and reduce cyclomatic complex
 
 ```kotlin
 val x = System.getenv()
-?.getValue("HOME")
-?.toLowerCase()
-?.split("/") ?: emptyList()
+            ?.getValue("HOME")
+            ?.toLowerCase()
+            ?.split("/") ?: emptyList()
 ```
 
 #### Compliant Code:
 
 ```kotlin
 val x = getenv()?.run {
-getValue("HOME")
-.toLowerCase()
-.split("/")
+    getValue("HOME")
+        .toLowerCase()
+        .split("/")
 } ?: emptyList()
 ```
 
@@ -450,11 +450,11 @@ class Foo {
 
 ```kotlin
 class Foo {
-val lorem = "lorem"
-val s1 = lorem
-fun bar(s: String = lorem) {
-s1.equals(lorem)
-}
+    val lorem = "lorem"
+    val s1 = lorem
+    fun bar(s: String = lorem) {
+        s1.equals(lorem)
+    }
 }
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/coroutines.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/coroutines.md
@@ -25,10 +25,10 @@ altering test results or causing crashes on other unrelated tests.
 ```kotlin
 @Test
 fun `test that launches a coroutine`() {
-val scope = CoroutineScope(Dispatchers.Unconfined)
-scope.launch {
-suspendFunction()
-}
+    val scope = CoroutineScope(Dispatchers.Unconfined)
+    scope.launch {
+        suspendFunction()
+    }
 }
 ```
 
@@ -37,9 +37,9 @@ suspendFunction()
 ```kotlin
 @Test
 fun `test that launches a coroutine`() = runTest {
-launch {
-suspendFunction()
-}
+    launch {
+        suspendFunction()
+    }
 }
 ```
 
@@ -61,7 +61,7 @@ See https://kotlin.github.io/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.
 
 ```kotlin
 fun foo() {
-GlobalScope.launch { delay(1_000L) }
+    GlobalScope.launch { delay(1_000L) }
 }
 ```
 
@@ -71,11 +71,11 @@ GlobalScope.launch { delay(1_000L) }
 val scope = CoroutineScope(Dispatchers.Default)
 
 fun foo() {
-scope.launch { delay(1_000L) }
+    scope.launch { delay(1_000L) }
 }
 
 fun onDestroy() {
-scope.cancel()
+   scope.cancel()
 }
 ```
 
@@ -99,7 +99,7 @@ https://developer.android.com/kotlin/coroutines/coroutines-best-practices#inject
 
 ```kotlin
 fun myFunc() {
-coroutineScope(Dispatchers.IO)
+    coroutineScope(Dispatchers.IO)
 }
 ```
 
@@ -107,7 +107,7 @@ coroutineScope(Dispatchers.IO)
 
 ```kotlin
 fun myFunc(dispatcher: CoroutineDispatcher = Dispatchers.IO) {
-coroutineScope(dispatcher)
+    coroutineScope(dispatcher)
 }
 
 class MyRepository(dispatchers: CoroutineDispatcher = Dispatchers.IO)
@@ -127,7 +127,7 @@ where it's not needed.
 
 ```kotlin
 suspend fun normalFunction() {
-println("string")
+    println("string")
 }
 ```
 
@@ -135,7 +135,7 @@ println("string")
 
 ```kotlin
 fun normalFunction() {
-println("string")
+    println("string")
 }
 ```
 
@@ -154,7 +154,7 @@ and cause unpredictable behavior.
 
 ```kotlin
 suspend fun foo() {
-Thread.sleep(1_000L)
+    Thread.sleep(1_000L)
 }
 ```
 
@@ -162,7 +162,7 @@ Thread.sleep(1_000L)
 
 ```kotlin
 suspend fun foo() {
-delay(1_000L)
+    delay(1_000L)
 }
 ```
 
@@ -179,11 +179,11 @@ Without a non-cancellable context, these functions will not execute if the paren
 
 ```kotlin
 launch {
-try {
-suspendingWork()
-} finally {
-suspendingCleanup()
-}
+    try {
+        suspendingWork()
+    } finally {
+        suspendingCleanup()
+    }
 }
 ```
 
@@ -191,11 +191,11 @@ suspendingCleanup()
 
 ```kotlin
 launch {
-try {
-suspendingWork()
-} finally {
-withContext(NonCancellable) { suspendingCleanup() }
-}
+    try {
+        suspendingWork()
+    } finally {
+        withContext(NonCancellable) { suspendingCleanup() }
+    }
 }
 ```
 
@@ -235,31 +235,31 @@ combinations by activating this rule.
 ```kotlin
 @Throws(IllegalStateException::class)
 suspend fun bar(delay: Long) {
-check(delay <= 1_000L)
-delay(delay)
+    check(delay <= 1_000L)
+    delay(delay)
 }
 
 suspend fun foo() {
-runCatching {
-bar(1_000L)
-}
+    runCatching {
+        bar(1_000L)
+    }
 }
 
 suspend fun baz() {
-try {
-bar(1_000L)
-} catch (e: IllegalStateException) {
-// catches CancellationException implicitly, since IllegalStateException is a super-class. Should be explicit
-}
+    try {
+        bar(1_000L)
+    } catch (e: IllegalStateException) {
+        // catches CancellationException implicitly, since IllegalStateException is a super-class. Should be explicit
+    }
 }
 
 suspend fun qux() {
-try {
-bar(1_000L)
-} catch (e: CancellationException) {
-doSomeWork() // potentially long-running bit of work before propagating the cancellation
-throw e
-}
+    try {
+        bar(1_000L)
+    } catch (e: CancellationException) {
+        doSomeWork() // potentially long-running bit of work before propagating the cancellation
+        throw e
+    }
 }
 ```
 
@@ -268,24 +268,24 @@ throw e
 ```kotlin
 @Throws(IllegalStateException::class)
 suspend fun bar(delay: Long) {
-check(delay <= 1_000L)
-delay(delay)
+    check(delay <= 1_000L)
+    delay(delay)
 }
 
 suspend fun foo() {
-try {
-bar(1_000L)
-} catch (e: CancellationException) {
-throw e // explicitly caught and immediately re-thrown
-} catch (e: IllegalStateException) {
-// handle error
-}
+    try {
+        bar(1_000L)
+    } catch (e: CancellationException) {
+        throw e // explicitly caught and immediately re-thrown
+    } catch (e: IllegalStateException) {
+        // handle error
+    }
 }
 
 // Alternate
 @Throws(IllegalStateException::class)
 suspend fun foo() {
-bar(1_000L)
+    bar(1_000L)
 }
 ```
 
@@ -308,9 +308,9 @@ See https://kotlinlang.org/docs/coroutines-basics.html#scope-builder-and-concurr
 
 ```kotlin
 suspend fun CoroutineScope.foo() {
-launch {
-delay(1.seconds)
-}
+    launch {
+        delay(1.seconds)
+    }
 }
 ```
 
@@ -318,16 +318,16 @@ delay(1.seconds)
 
 ```kotlin
 fun CoroutineScope.foo() {
-launch {
-delay(1.seconds)
-}
+    launch {
+        delay(1.seconds)
+    }
 }
 
 // Alternative
 suspend fun foo() = coroutineScope {
-launch {
-delay(1.seconds)
-}
+    launch {
+        delay(1.seconds)
+    }
 }
 ```
 
@@ -348,18 +348,18 @@ See https://kotlinlang.org/docs/flow.html#flows-are-cold
 
 ```kotlin
 suspend fun observeSignals(): Flow<Unit> {
-val pollingInterval = getPollingInterval() // Done outside of the flow builder block.
-return flow {
-while (true) {
-delay(pollingInterval)
-emit(Unit)
-}
-}
+    val pollingInterval = getPollingInterval() // Done outside of the flow builder block.
+    return flow {
+        while (true) {
+            delay(pollingInterval)
+            emit(Unit)
+        }
+    }
 }
 
 private suspend fun getPollingInterval(): Long {
-// Return the polling interval from some repository
-// in a suspending manner.
+    // Return the polling interval from some repository
+    // in a suspending manner.
 }
 ```
 
@@ -367,17 +367,17 @@ private suspend fun getPollingInterval(): Long {
 
 ```kotlin
 fun observeSignals(): Flow<Unit> {
-return flow {
-val pollingInterval = getPollingInterval() // Moved into the flow builder block.
-while (true) {
-delay(pollingInterval)
-emit(Unit)
-}
-}
+    return flow {
+        val pollingInterval = getPollingInterval() // Moved into the flow builder block.
+        while (true) {
+            delay(pollingInterval)
+            emit(Unit)
+        }
+    }
 }
 
 private suspend fun getPollingInterval(): Long {
-// Return the polling interval from some repository
-// in a suspending manner.
+    // Return the polling interval from some repository
+    // in a suspending manner.
 }
 ```

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/exceptions.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/exceptions.md
@@ -25,12 +25,12 @@ Instead, use `throw IllegalStateException(throwable)` to rethrow the throwable a
 
 ```kotlin
 fun foo() {
-try {
-// ... some code
-} catch(e: IOException) {
-// some addition handling
-error(e)
-}
+    try {
+        // ... some code
+    } catch(e: IOException) {
+        // some addition handling
+        error(e)
+    }
 }
 ```
 
@@ -38,12 +38,12 @@ error(e)
 
 ```kotlin
 fun foo() {
-try {
-// ... some code
-} catch(e: IOException) {
-// some addition handling
-throw e // or throw IllegalStateException(<some custom error msg>, e)
-}
+    try {
+        // ... some code
+    } catch(e: IOException) {
+        // some addition handling
+        throw e // or throw IllegalStateException(<some custom error msg>, e)
+    }
 }
 ```
 
@@ -87,11 +87,11 @@ use multiple catch blocks. These catch blocks should then catch the specific exc
 
 ```kotlin
 fun foo() {
-try {
-// ... do some I/O
-} catch(e: IOException) {
-if (e is MyException || (e as MyException) != null) { }
-}
+    try {
+        // ... do some I/O
+    } catch(e: IOException) {
+        if (e is MyException || (e as MyException) != null) { }
+    }
 }
 ```
 
@@ -99,11 +99,11 @@ if (e is MyException || (e as MyException) != null) { }
 
 ```kotlin
 fun foo() {
-try {
-// ... do some I/O
-} catch(e: MyException) {
-} catch(e: IOException) {
-}
+    try {
+        // ... do some I/O
+    } catch(e: MyException) {
+    } catch(e: IOException) {
+    }
 }
 ```
 
@@ -120,11 +120,11 @@ serve as temporary declarations and should not be put into production environmen
 
 ```kotlin
 fun foo() {
-throw NotImplementedError()
+    throw NotImplementedError()
 }
 
 fun todo() {
-TODO("")
+    TODO("")
 }
 ```
 
@@ -173,15 +173,15 @@ a better logging solution should be used.
 
 ```kotlin
 fun foo() {
-Thread.dumpStack()
+    Thread.dumpStack()
 }
 
 fun bar() {
-try {
-// ...
-} catch (e: IOException) {
-e.printStackTrace()
-}
+    try {
+        // ...
+    } catch (e: IOException) {
+        e.printStackTrace()
+    }
 }
 ```
 
@@ -191,11 +191,11 @@ e.printStackTrace()
 val LOGGER = Logger.getLogger()
 
 fun bar() {
-try {
-// ...
-} catch (e: IOException) {
-LOGGER.info(e)
-}
+    try {
+        // ...
+    } catch (e: IOException) {
+        LOGGER.info(e)
+    }
 }
 ```
 
@@ -212,11 +212,11 @@ It ignores cases:
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch (e: IOException) {
-throw e
-}
+    try {
+        // ...
+    } catch (e: IOException) {
+        throw e
+    }
 }
 ```
 
@@ -224,23 +224,23 @@ throw e
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch (e: IOException) {
-throw MyException(e)
-}
-try {
-// ...
-} catch (e: IOException) {
-print(e)
-throw e
-}
-try {
-// ...
-} catch (e: IOException) {
-print(e.message)
-throw e
-}
+    try {
+        // ...
+    } catch (e: IOException) {
+        throw MyException(e)
+    }
+    try {
+        // ...
+    } catch (e: IOException) {
+        print(e)
+        throw e
+    }
+    try {
+        // ...
+    } catch (e: IOException) {
+        print(e.message)
+        throw e
+    }
 
     try {
         // ...
@@ -276,21 +276,21 @@ as expected.
 
 ```kotlin
 fun foo() {
-try {
-throw MyException()
-} finally {
-return // prevents MyException from being propagated
-}
+    try {
+        throw MyException()
+    } finally {
+        return // prevents MyException from being propagated
+    }
 }
 
 val a: String = try {
-"s"
+  "s"
 } catch (e: Exception) {
-"e"
+  "e"
 } finally {
-// Implies assigning "f" to variable a, but the exception gets propagated first.
-// Misleading and not immediately obvious, this gets flagged!
-"f"
+  // Implies assigning "f" to variable a, but the exception gets propagated first.
+  // Misleading and not immediately obvious, this gets flagged!
+  "f"
 }
 ```
 
@@ -298,10 +298,10 @@ val a: String = try {
 
 ```kotlin
 fun bar(thing: Thing): Unit = try {
-thing.doSomethingReturningUnit()
+  thing.doSomethingReturningUnit()
 } finally {
-// Any exceptions will still be propagated, but the Unit-returning cleanup function will be called first
-thing.cleanUp()
+  // Any exceptions will still be propagated, but the Unit-returning cleanup function will be called first
+  thing.cleanUp()
 }
 ```
 
@@ -331,21 +331,21 @@ For that reason, this rule ignores that these configured exception types are cau
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch(e: IOException) {
-throw MyException(e.message) // e is swallowed
-}
-try {
-// ...
-} catch(e: IOException) {
-throw MyException() // e is swallowed
-}
-try {
-// ...
-} catch(e: IOException) {
-bar() // exception is unused
-}
+    try {
+        // ...
+    } catch(e: IOException) {
+        throw MyException(e.message) // e is swallowed
+    }
+    try {
+        // ...
+    } catch(e: IOException) {
+        throw MyException() // e is swallowed
+    }
+    try {
+        // ...
+    } catch(e: IOException) {
+        bar() // exception is unused
+    }
 }
 ```
 
@@ -353,16 +353,16 @@ bar() // exception is unused
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch(e: IOException) {
-throw MyException(e)
-}
-try {
-// ...
-} catch(e: IOException) {
-println(e) // logging is ok here
-}
+    try {
+        // ...
+    } catch(e: IOException) {
+        throw MyException(e)
+    }
+    try {
+        // ...
+    } catch(e: IOException) {
+        println(e) // logging is ok here
+    }
 }
 ```
 
@@ -377,11 +377,11 @@ block should be avoided as it can lead to confusion and discarded exceptions.
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} finally {
-throw IOException()
-}
+    try {
+        // ...
+    } finally {
+        throw IOException()
+    }
 }
 ```
 
@@ -396,8 +396,8 @@ An exception should only be thrown if it can be handled by a "higher" function.
 
 ```kotlin
 fun main(args: Array<String>) {
-// ...
-throw IOException() // exception should not be thrown here
+    // ...
+    throw IOException() // exception should not be thrown here
 }
 ```
 
@@ -420,10 +420,10 @@ down an underlying issue in a better way.
 
 ```kotlin
 fun foo(bar: Int) {
-if (bar < 1) {
-throw IllegalArgumentException()
-}
-// ...
+    if (bar < 1) {
+        throw IllegalArgumentException()
+    }
+    // ...
 }
 ```
 
@@ -431,10 +431,10 @@ throw IllegalArgumentException()
 
 ```kotlin
 fun foo(bar: Int) {
-if (bar < 1) {
-throw IllegalArgumentException("bar must be greater than zero")
-}
-// ...
+    if (bar < 1) {
+        throw IllegalArgumentException("bar must be greater than zero")
+    }
+    // ...
 }
 ```
 
@@ -449,11 +449,11 @@ meaningful exception types.
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch (e: IllegalStateException) {
-throw IllegalStateException(e) // rethrows the same exception
-}
+    try {
+        // ...
+    } catch (e: IllegalStateException) {
+        throw IllegalStateException(e) // rethrows the same exception
+    }
 }
 ```
 
@@ -461,11 +461,11 @@ throw IllegalStateException(e) // rethrows the same exception
 
 ```kotlin
 fun foo() {
-try {
-// ...
-} catch (e: IllegalStateException) {
-throw MyException(e)
-}
+    try {
+        // ...
+    } catch (e: IllegalStateException) {
+        throw MyException(e)
+    }
 }
 ```
 
@@ -491,9 +491,9 @@ exception is too broad it can lead to unintended exceptions being caught.
 
 ```kotlin
 fun foo() {
-try {
-// ... do some I/O
-} catch(e: Exception) { } // too generic exception caught here
+    try {
+        // ... do some I/O
+    } catch(e: Exception) { } // too generic exception caught here
 }
 ```
 
@@ -501,9 +501,9 @@ try {
 
 ```kotlin
 fun foo() {
-try {
-// ... do some I/O
-} catch(e: IOException) { }
+    try {
+        // ... do some I/O
+    } catch(e: IOException) { }
 }
 ```
 
@@ -524,10 +524,10 @@ exceptions to the case that has currently occurred.
 
 ```kotlin
 fun foo(bar: Int) {
-if (bar < 1) {
-throw Exception() // too generic exception thrown here
-}
-// ...
+    if (bar < 1) {
+        throw Exception() // too generic exception thrown here
+    }
+    // ...
 }
 ```
 
@@ -535,9 +535,9 @@ throw Exception() // too generic exception thrown here
 
 ```kotlin
 fun foo(bar: Int) {
-if (bar < 1) {
-throw IllegalArgumentException("bar must be greater than zero")
-}
-// ...
+    if (bar < 1) {
+        throw IllegalArgumentException("bar must be greater than zero")
+    }
+    // ...
 }
 ```

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/libraries.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/libraries.md
@@ -68,7 +68,7 @@ See also: [Kotlin 1.4 Explicit API](https://kotlinlang.org/docs/whatsnew14.html#
 val strs = listOf("foo, bar")
 fun bar() = 5
 class Parser {
-fun parse() = ...
+     fun parse() = ...
 }
 ```
 
@@ -80,7 +80,7 @@ val strs: List<String> = listOf("foo, bar")
 fun bar(): Int = 5
 
 class Parser {
-fun parse(): ParsingResult = ...
+     fun parse(): ParsingResult = ...
 }
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/naming.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/naming.md
@@ -230,7 +230,7 @@ fun Foo.toBar(): Bar = ...
 
 ```kotlin
 class Foo { // Foo.kt
-fun stuff() = 42
+    fun stuff() = 42
 }
 
 fun Bar.toFoo(): Foo = ...
@@ -295,13 +295,13 @@ except of underscore lambda parameters for unused variables.
 
 ```kotlin
 fun test(i: Int, j: Int, k: Int) {
-val i = 1
-val (j, _) = 1 to 2
-listOf(1).map { k -> println(k) }
-listOf(1).forEach {
-listOf(2).forEach {
-}
-}
+    val i = 1
+    val (j, _) = 1 to 2
+    listOf(1).map { k -> println(k) }
+    listOf(1).forEach {
+        listOf(2).forEach {
+        }
+    }
 }
 ```
 
@@ -309,14 +309,14 @@ listOf(2).forEach {
 
 ```kotlin
 fun test(i: Int, j: Int, k: Int) {
-val x = 1
-val (y, _) = 1 to 2
-listOf(1).map { z -> println(z) }
-listOf(1).forEach {
-listOf(2).forEach { x ->
-}
-}
-listOf(1).map { _ -> println("_") }
+    val x = 1
+    val (y, _) = 1 to 2
+    listOf(1).map { z -> println(z) }
+    listOf(1).forEach {
+        listOf(2).forEach { x ->
+        }
+    }
+    listOf(1).map { _ -> println("_") }
 }
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/performance.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/performance.md
@@ -85,13 +85,13 @@ To solve this code smell, the forEach usage should be replaced by a for loop.
 
 ```kotlin
 (1..10).forEach {
-println(it)
+    println(it)
 }
 (1 until 10).forEach {
-println(it)
+    println(it)
 }
 (10 downTo 1).forEach {
-println(it)
+    println(it)
 }
 ```
 
@@ -99,7 +99,7 @@ println(it)
 
 ```kotlin
 for (i in 1..10) {
-println(i)
+    println(i)
 }
 ```
 
@@ -126,7 +126,7 @@ val strs = arrayOf("value one", "value two")
 val foo = bar(*strs)
 
 fun bar(vararg strs: String) {
-strs.forEach { println(it) }
+    strs.forEach { println(it) }
 }
 ```
 
@@ -140,7 +140,7 @@ val foo = bar(*arrayOf("value one", "value two"))
 val foo2 = bar("value one", "value two")
 
 fun bar(vararg strs: String) {
-strs.forEach { println(it) }
+    strs.forEach { println(it) }
 }
 ```
 
@@ -177,8 +177,8 @@ val e = CharArray(10)
 
 // with side effect(s)
 val k = IntArray(10) {
-println("Some side-effect")
-0
+    println("Some side-effect")
+    0
 }
 ```
 
@@ -238,8 +238,8 @@ replaced with type checking for performance reasons.
 
 ```kotlin
 fun foo() {
-val objList: List<Any> = emptyList()
-objList.any { it as? String != null }
+ val objList: List<Any> = emptyList()
+ objList.any { it as? String != null }
 }
 ```
 
@@ -247,7 +247,7 @@ objList.any { it as? String != null }
 
 ```kotlin
 fun foo() {
-val objList: List<Any> = emptyList()
-objList.any { it is String }
+ val objList: List<Any> = emptyList()
+ objList.any { it is String }
 }
 ```

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/potential-bugs.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/potential-bugs.md
@@ -29,22 +29,22 @@ likely not intentional and may cause unexpected results.
 #### Noncompliant Code:
 
 ```kotlin
-val areEqual = "aString" === otherString
-val areNotEqual = "aString" !== otherString
+    val areEqual = "aString" === otherString
+    val areNotEqual = "aString" !== otherString
 ```
 
 #### Compliant Code:
 
 ```kotlin
-val areEqual = "aString" == otherString
-val areNotEqual = "aString" != otherString
+    val areEqual = "aString" == otherString
+    val areNotEqual = "aString" != otherString
 ```
 
 ### CastNullableToNonNullableType
 
 Reports cast of nullable variable to non-null type. Cast like this can hide `null`
 problems in your code. The compliant code would be that which will correctly check
-for two things (nullability and type) and not just one (cast).
+ for two things (nullability and type) and not just one (cast).
 
 **Active by default**: No
 
@@ -60,7 +60,7 @@ for two things (nullability and type) and not just one (cast).
 
 ```kotlin
 fun foo(bar: Any?) {
-val x = bar as String
+    val x = bar as String
 }
 ```
 
@@ -68,12 +68,12 @@ val x = bar as String
 
 ```kotlin
 fun foo(bar: Any?) {
-val x = checkNotNull(bar) as String
+    val x = checkNotNull(bar) as String
 }
 
 // Alternative
 fun foo(bar: Any?) {
-val x = (bar ?: error("null assertion message")) as String
+    val x = (bar ?: error("null assertion message")) as String
 }
 ```
 
@@ -90,7 +90,7 @@ Reports unsafe cast to nullable types.
 
 ```kotlin
 fun foo(a: Any?) {
-val x: String? = a as String? // If 'a' is not String, ClassCastException will be thrown.
+    val x: String? = a as String? // If 'a' is not String, ClassCastException will be thrown.
 }
 ```
 
@@ -98,7 +98,7 @@ val x: String? = a as String? // If 'a' is not String, ClassCastException will b
 
 ```kotlin
 fun foo(a: Any?) {
-val x: String? = a as? String
+    val x: String? = a as? String
 }
 ```
 
@@ -160,7 +160,7 @@ Prefer to use instead the `toMutable<Type>()` functions.
 ```kotlin
 val list : List<Int> = getAList()
 if (list is MutableList) {
-list.add(42)
+    list.add(42)
 }
 
 (list as MutableList).add(42)
@@ -239,15 +239,15 @@ or changing the nullability of a boolean, since this will be implicitly handled 
 
 ```kotlin
 enum class Color {
-RED,
-GREEN,
-BLUE
+    RED,
+    GREEN,
+    BLUE
 }
 
 when(c) {
-Color.RED -> {}
-Color.GREEN -> {}
-else -> {}
+    Color.RED -> {}
+    Color.GREEN -> {}
+    else -> {}
 }
 ```
 
@@ -255,15 +255,15 @@ else -> {}
 
 ```kotlin
 enum class Color {
-RED,
-GREEN,
-BLUE
+    RED,
+    GREEN,
+    BLUE
 }
 
 when(c) {
-Color.RED -> {}
-Color.GREEN -> {}
-Color.BLUE -> {}
+    Color.RED -> {}
+    Color.GREEN -> {}
+    Color.BLUE -> {}
 }
 ```
 
@@ -281,7 +281,7 @@ https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-any/equals.html
 
 ```kotlin
 override fun equals(other: Any?): Boolean {
-return true
+    return true
 }
 ```
 
@@ -289,7 +289,7 @@ return true
 
 ```kotlin
 override fun equals(other: Any?): Boolean {
-return this === other
+    return this === other
 }
 ```
 
@@ -344,12 +344,12 @@ failure in the program. In almost all cases it is more appropriate to throw an e
 
 ```kotlin
 fun randomFunction() {
-val result = doWork()
-if (result == FAILURE) {
-exitProcess(2)
-} else {
-exitProcess(0)
-}
+    val result = doWork()
+    if (result == FAILURE) {
+        exitProcess(2)
+    } else {
+        exitProcess(0)
+    }
 }
 ```
 
@@ -357,12 +357,12 @@ exitProcess(0)
 
 ```kotlin
 fun main() {
-val result = doWork()
-if (result == FAILURE) {
-exitProcess(2)
-} else {
-exitProcess(0)
-}
+    val result = doWork()
+    if (result == FAILURE) {
+        exitProcess(2)
+    } else {
+        exitProcess(0)
+    }
 }
 ```
 
@@ -394,7 +394,7 @@ Platform types must be declared explicitly in public APIs to prevent unexpected 
 
 ```kotlin
 class Person {
-fun apiCall() = System.getProperty("propertyName")
+    fun apiCall() = System.getProperty("propertyName")
 }
 ```
 
@@ -402,7 +402,7 @@ fun apiCall() = System.getProperty("propertyName")
 
 ```kotlin
 class Person {
-fun apiCall(): String = System.getProperty("propertyName")
+    fun apiCall(): String = System.getProperty("propertyName")
 }
 ```
 
@@ -511,7 +511,7 @@ fun String.errorProneUnitWithReceiver() = run { println(this) }
 
 ```kotlin
 fun blockStatementUnit() {
-// code
+    // code
 }
 
 // explicit Unit is compliant by default; can be configured to enforce block statement
@@ -618,8 +618,8 @@ guaranteed. Try using constructor injection or delegation to initialize properti
 
 ```kotlin
 class Foo {
-private lateinit var i1: Int
-lateinit var i2: Int
+    private lateinit var i1: Int
+    lateinit var i2: Int
 }
 ```
 
@@ -638,11 +638,11 @@ Based on an IntelliJ IDEA inspection MapGetWithNotNullAssertionOperatorInspectio
 #### Noncompliant Code:
 
 ```kotlin
-val map = emptyMap<String, String>()
-map["key"]!!
+ val map = emptyMap<String, String>()
+ map["key"]!!
 
-val map = emptyMap<String, String>()
-map.get("key")!!
+ val map = emptyMap<String, String>()
+ map.get("key")!!
 ```
 
 #### Compliant Code:
@@ -685,14 +685,14 @@ This rule checks whether overriding methods invoke the super method when the sup
 
 ```kotlin
 open class ParentClass {
-@CallSuper
-open fun someMethod(arg: Int) {
-}
+    @CallSuper
+    open fun someMethod(arg: Int) {
+    }
 }
 class MyClass : ParentClass() {
-override fun someMethod(arg: Int) {
-doSomething()
-}
+    override fun someMethod(arg: Int) {
+        doSomething()
+    }
 }
 ```
 
@@ -700,15 +700,15 @@ doSomething()
 
 ```kotlin
 open class ParentClass {
-@CallSuper
-open fun someMethod(arg: Int) {
-}
+    @CallSuper
+    open fun someMethod(arg: Int) {
+    }
 }
 class MyClass : ParentClass() {
-override fun someMethod(arg: Int) {
-super.someMethod(arg)
-doSomething()
-}
+    override fun someMethod(arg: Int) {
+        super.someMethod(arg)
+        doSomething()
+    }
 }
 ```
 
@@ -736,7 +736,7 @@ functionThatReturnsClosable().doStuff()
 
 ```kotlin
 MyCloseable().use {
-// do stuff with myCloseable
+    // do stuff with myCloseable
 }
 
 MyClosable().use { it.doStuff() }
@@ -758,11 +758,11 @@ if-statement.
 
 ```kotlin
 class A(private var a: Int?) {
-fun foo() {
-if (a != null) {
-println(2 + a!!)
-}
-}
+  fun foo() {
+    if (a != null) {
+      println(2 + a!!)
+    }
+  }
 }
 ```
 
@@ -770,11 +770,11 @@ println(2 + a!!)
 
 ```kotlin
 class A(private val a: Int?) {
-fun foo() {
-if (a != null) {
-println(2 + a)
-}
-}
+  fun foo() {
+    if (a != null) {
+      println(2 + a)
+    }
+  }
 }
 ```
 
@@ -790,11 +790,11 @@ Reports `toString()` calls with a nullable receiver that may return the string "
 
 ```kotlin
 fun foo(a: Any?): String {
-return a.toString()
+    return a.toString()
 }
 
 fun bar(a: Any?): String {
-return "$a"
+    return "$a"
 }
 ```
 
@@ -802,11 +802,11 @@ return "$a"
 
 ```kotlin
 fun foo(a: Any?): String {
-return a?.toString() ?: "-"
+    return a?.toString() ?: "-"
 }
 
 fun bar(a: Any?): String {
-return "${a ?: "-"}"
+    return "${a ?: "-"}"
 }
 ```
 
@@ -822,8 +822,8 @@ Reports properties that are used before declaration.
 
 ```kotlin
 class C {
-private val number
-get() = if (isValid) 1 else 0
+    private val number
+        get() = if (isValid) 1 else 0
 
     val list = listOf(number)
 
@@ -831,7 +831,7 @@ get() = if (isValid) 1 else 0
 }
 
 fun main() {
-println(C().list) // [0]
+    println(C().list) // [0]
 }
 ```
 
@@ -839,7 +839,7 @@ println(C().list) // [0]
 
 ```kotlin
 class C {
-private val isValid = true
+    private val isValid = true
 
     private val number
         get() = if (isValid) 1 else 0
@@ -848,7 +848,7 @@ private val isValid = true
 }
 
 fun main() {
-println(C().list) // [1]
+    println(C().list) // [1]
 }
 ```
 
@@ -870,7 +870,7 @@ for (i in 1..2) break
 
 ```kotlin
 for (i in 1..2) {
-if (i == 1) break
+    if (i == 1) break
 }
 ```
 
@@ -905,31 +905,31 @@ type changes. And code gets error prone as it gets easy to mix up parameters of 
 
 ```kotlin
 fun log(enabled: Boolean, shouldLog: Boolean) {
-if (shouldLog) println(enabled)
+    if (shouldLog) println(enabled)
 }
 fun test() {
-log(false, true)
+    log(false, true)
 }
 
 // allowAdjacentDifferentTypeParams = false
 fun logMsg(msg: String, shouldLog: Boolean) {
-if(shouldLog) println(msg)
+   if(shouldLog) println(msg)
 }
 fun test() {
-logMsg("test", true)
+    logMsg("test", true)
 }
 
 // allowSingleParamUse = false and allowAdjacentDifferentTypeParams = false
 fun logMsg(msg: String) {
-println(msg)
+    println(msg)
 }
 fun test() {
-logMsg("test")
+    logMsg("test")
 }
 
 // ignoreArgumentsMatchingNames = false
 fun test(enabled: Boolean, shouldLog: Boolean) {
-log(enabled, shouldLog)
+    log(enabled, shouldLog)
 }
 ```
 
@@ -937,30 +937,30 @@ log(enabled, shouldLog)
 
 ```kotlin
 fun log(enabled: Boolean, shouldLog: Boolean) {
-if (shouldLog) println(enabled)
+    if (shouldLog) println(enabled)
 }
 fun test() {
-log(enabled = false, shouldLog = true)
+    log(enabled = false, shouldLog = true)
 }
 // ignoreArgumentsMatchingNames = true
 fun test(enabled: Boolean, shouldLog: Boolean) {
-log(enabled, shouldLog)
+    log(enabled, shouldLog)
 }
 
 // allowAdjacentDifferentTypeParams = true
 fun logMsg(msg: String, shouldLog: Boolean) {
-if(shouldLog) println(msg)
+   if(shouldLog) println(msg)
 }
 fun test() {
-logMsg("test", true)
+    logMsg("test", true)
 }
 
 // allowSingleParamUse = true
 fun logMsg(msg: String) {
-println(msg)
+    println(msg)
 }
 fun test() {
-logMsg("test")
+    logMsg("test")
 }
 ```
 
@@ -1043,14 +1043,14 @@ Catch blocks can be unreachable if the exception has already been caught in the 
 
 ```kotlin
 fun test() {
-try {
-foo()
-} catch (t: Throwable) {
-bar()
-} catch (e: Exception) {
-// Unreachable
-baz()
-}
+    try {
+        foo()
+    } catch (t: Throwable) {
+        bar()
+    } catch (e: Exception) {
+        // Unreachable
+        baz()
+    }
 }
 ```
 
@@ -1058,13 +1058,13 @@ baz()
 
 ```kotlin
 fun test() {
-try {
-foo()
-} catch (e: Exception) {
-baz()
-} catch (t: Throwable) {
-bar()
-}
+    try {
+        foo()
+    } catch (e: Exception) {
+        baz()
+    } catch (t: Throwable) {
+        bar()
+    }
 }
 ```
 
@@ -1082,16 +1082,16 @@ This unreachable code should be removed as it serves no purpose.
 
 ```kotlin
 for (i in 1..2) {
-break
-println() // unreachable
+    break
+    println() // unreachable
 }
 
 throw IllegalArgumentException()
 println() // unreachable
 
 fun f() {
-return
-println() // unreachable
+    return
+    println() // unreachable
 }
 ```
 
@@ -1109,7 +1109,7 @@ null safety. Guard the code appropriately to prevent NullPointerExceptions.
 
 ```kotlin
 fun foo(str: String?) {
-println(str!!.length)
+    println(str!!.length)
 }
 ```
 
@@ -1117,7 +1117,7 @@ println(str!!.length)
 
 ```kotlin
 fun foo(str: String?) {
-println(str?.length)
+    println(str?.length)
 }
 ```
 
@@ -1135,11 +1135,11 @@ Reports casts that will never succeed.
 
 ```kotlin
 fun foo(s: String) {
-println(s as Int)
+    println(s as Int)
 }
 
 fun bar(s: String) {
-println(s as? Int)
+    println(s as? Int)
 }
 ```
 
@@ -1147,7 +1147,7 @@ println(s as? Int)
 
 ```kotlin
 fun foo(s: Any) {
-println(s as Int)
+    println(s as Int)
 }
 ```
 
@@ -1163,7 +1163,7 @@ Detects unused unary operators.
 
 ```kotlin
 val x = 1 + 2
-+ 3 + 4
+    + 3 + 4
 println(x) // 3
 ```
 
@@ -1191,9 +1191,9 @@ i = 1 + i++
 i = i++ + 1
 
 fun foo(): Int {
-var i = 0
-// ...
-return i++
+    var i = 0
+    // ...
+    return i++
 }
 ```
 
@@ -1206,10 +1206,10 @@ i = i + 2
 i = i + 2
 
 fun foo(): Int {
-var i = 0
-// ...
-i++
-return i
+    var i = 0
+    // ...
+    i++
+    return i
 }
 ```
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/style.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/style.md
@@ -35,13 +35,13 @@ abstract class OnlyConcreteMembersInAbstractClass { // violation: no abstract me
 
 ```kotlin
 interface OnlyAbstractMembersInInterface {
-val i: Int
-fun f()
+    val i: Int
+    fun f()
 }
 
 class OnlyConcreteMembersInClass {
-val i: Int = 0
-fun f() { }
+    val i: Int = 0
+    fun f() { }
 }
 ```
 
@@ -68,8 +68,8 @@ abstract class OnlyAbstractMembersInAbstractClass { // violation: no concrete me
 
 ```kotlin
 interface Interface {
-val i: Int
-fun f()
+    val i: Int
+    fun f()
 }
 
 abstract class NonAbstractMembersInAbstractClass {
@@ -93,8 +93,8 @@ thus making the block more concise and easier to read.
 
 ```kotlin
 Buzz().also {
-it.init()
-it.block()
+  it.init()
+  it.block()
 }
 ```
 
@@ -102,13 +102,13 @@ it.block()
 
 ```kotlin
 Buzz().apply {
-init()
-block()
+  init()
+  block()
 }
 
 // Also compliant
 fun foo(a: Int): Int {
-return a.also { println(it) }
+  return a.also { println(it) }
 }
 ```
 
@@ -118,12 +118,12 @@ This rule detects `if` statements which do not comply with the specified rules.
 Keeping braces consistent will improve readability and avoid possible errors.
 
 The available options are:
-* `always`: forces braces on all `if` and `else` branches in the whole codebase.
-* `consistent`: ensures that braces are consistent within each `if`-`else if`-`else` chain.
-If there's a brace on one of the branches, all branches should have it.
-* `necessary`: forces no braces on any `if` and `else` branches in the whole codebase
-except where necessary for multi-statement branches.
-* `never`: forces no braces on any `if` and `else` branches in the whole codebase.
+ * `always`: forces braces on all `if` and `else` branches in the whole codebase.
+ * `consistent`: ensures that braces are consistent within each `if`-`else if`-`else` chain.
+   If there's a brace on one of the branches, all branches should have it.
+ * `necessary`: forces no braces on any `if` and `else` branches in the whole codebase
+   except where necessary for multi-statement branches.
+ * `never`: forces no braces on any `if` and `else` branches in the whole codebase.
 
 Single-line if-statement has no line break (\n):
 ```kotlin
@@ -159,9 +159,9 @@ if (a) b else { c; d }
 
 // multiLine = 'never'
 if (a) {
-b
+   b
 } else {
-c
+   c
 }
 
 // singleLine = 'always'
@@ -171,9 +171,9 @@ if (a) { b } else c
 
 // multiLine = 'always'
 if (a) {
-b
+   b
 } else
-c
+   c
 
 // singleLine = 'consistent'
 if (a) b else { c }
@@ -181,9 +181,9 @@ if (a) b else if (c) d else { e }
 
 // multiLine = 'consistent'
 if (a)
-b
+   b
 else {
-c
+   c
 }
 
 // singleLine = 'necessary'
@@ -191,12 +191,12 @@ if (a) { b } else { c; d }
 
 // multiLine = 'necessary'
 if (a) {
-b
-c
+   b
+   c
 } else if (d) {
-e
+   e
 } else {
-f
+   f
 }
 ```
 
@@ -208,9 +208,9 @@ if (a) b else c
 
 // multiLine = 'never'
 if (a)
-b
+   b
 else
-c
+   c
 
 // singleLine = 'always'
 if (a) { b } else { c }
@@ -219,15 +219,15 @@ if (a) { b } else if (c) { d }
 
 // multiLine = 'always'
 if (a) {
-b
+   b
 } else {
-c
+   c
 }
 
 if (a) {
-b
+   b
 } else if (c) {
-d
+   d
 }
 
 // singleLine = 'consistent'
@@ -239,9 +239,9 @@ if (a) { b } else { c; d }
 
 // multiLine = 'consistent'
 if (a) {
-b
+   b
 } else {
-c
+   c
 }
 
 if (a) b
@@ -252,12 +252,12 @@ if (a) b else { c; d }
 
 // multiLine = 'necessary'
 if (a) {
-b
-c
+   b
+   c
 } else if (d)
-e
+   e
 else
-f
+   f
 ```
 
 ### BracesOnWhenStatements
@@ -272,13 +272,13 @@ Multi-line `when` statement is:
 a `when` where at least one of the branches is multi-line (has a break line `\n`).
 
 Available options are:
-* `never`: forces no braces on any branch.
-_Tip_: this is very strict, it will force a simple expression, like a single function call / expression.
-Extracting a function for "complex" logic is one way to adhere to this policy.
-* `necessary`: forces no braces on any branch except where necessary for multi-statement branches.
-* `consistent`: ensures that braces are consistent within `when` statement.
-If there are braces on one of the branches, all branches should have it.
-* `always`: forces braces on all branches.
+ * `never`: forces no braces on any branch.
+ _Tip_: this is very strict, it will force a simple expression, like a single function call / expression.
+ Extracting a function for "complex" logic is one way to adhere to this policy.
+ * `necessary`: forces no braces on any branch except where necessary for multi-statement branches.
+ * `consistent`: ensures that braces are consistent within `when` statement.
+   If there are braces on one of the branches, all branches should have it.
+ * `always`: forces braces on all branches.
 
 **Active by default**: No
 
@@ -295,126 +295,126 @@ If there are braces on one of the branches, all branches should have it.
 #### Noncompliant Code:
 
 ```kotlin
-// singleLine = 'never'
-when (a) {
-1 -> { f1() } // Not allowed.
-2 -> f2()
-}
-// multiLine = 'never'
-when (a) {
-1 -> { // Not allowed.
-f1()
-}
-2 -> f2()
-}
-// singleLine = 'necessary'
-when (a) {
-1 -> { f1() } // Unnecessary braces.
-2 -> f2()
-}
-// multiLine = 'necessary'
-when (a) {
-1 -> { // Unnecessary braces.
-f1()
-}
-2 -> f2()
-}
+ // singleLine = 'never'
+ when (a) {
+     1 -> { f1() } // Not allowed.
+     2 -> f2()
+ }
+ // multiLine = 'never'
+ when (a) {
+     1 -> { // Not allowed.
+         f1()
+     }
+     2 -> f2()
+ }
+ // singleLine = 'necessary'
+ when (a) {
+     1 -> { f1() } // Unnecessary braces.
+     2 -> f2()
+ }
+ // multiLine = 'necessary'
+ when (a) {
+     1 -> { // Unnecessary braces.
+         f1()
+     }
+     2 -> f2()
+ }
 
-// singleLine = 'consistent'
-when (a) {
-1 -> { f1() }
-2 -> f2()
-}
-// multiLine = 'consistent'
-when (a) {
-1 ->
-f1() // Missing braces.
-2 -> {
-f2()
-f3()
-}
-}
+ // singleLine = 'consistent'
+ when (a) {
+     1 -> { f1() }
+     2 -> f2()
+ }
+ // multiLine = 'consistent'
+ when (a) {
+     1 ->
+         f1() // Missing braces.
+     2 -> {
+         f2()
+         f3()
+     }
+ }
 
-// singleLine = 'always'
-when (a) {
-1 -> { f1() }
-2 -> f2() // Missing braces.
-}
-// multiLine = 'always'
-when (a) {
-1 ->
-f1() // Missing braces.
-2 -> {
-f2()
-f3()
-}
-}
+ // singleLine = 'always'
+ when (a) {
+     1 -> { f1() }
+     2 -> f2() // Missing braces.
+ }
+ // multiLine = 'always'
+ when (a) {
+     1 ->
+         f1() // Missing braces.
+     2 -> {
+         f2()
+         f3()
+     }
+ }
 ```
 
 #### Compliant Code:
 
 ```kotlin
-// singleLine = 'never'
-when (a) {
-1 -> f1()
-2 -> f2()
-}
-// multiLine = 'never'
-when (a) {
-1 ->
-f1()
-2 -> f2()
-}
-// singleLine = 'necessary'
-when (a) {
-1 -> f1()
-2 -> { f2(); f3() } // Necessary braces because of multiple statements.
-}
-// multiLine = 'necessary'
-when (a) {
-1 ->
-f1()
-2 -> { // Necessary braces because of multiple statements.
-f2()
-f3()
-}
-}
+ // singleLine = 'never'
+ when (a) {
+     1 -> f1()
+     2 -> f2()
+ }
+ // multiLine = 'never'
+ when (a) {
+     1 ->
+         f1()
+     2 -> f2()
+ }
+ // singleLine = 'necessary'
+ when (a) {
+     1 -> f1()
+     2 -> { f2(); f3() } // Necessary braces because of multiple statements.
+ }
+ // multiLine = 'necessary'
+ when (a) {
+     1 ->
+         f1()
+     2 -> { // Necessary braces because of multiple statements.
+         f2()
+         f3()
+     }
+ }
 
-// singleLine = 'consistent'
-when (a) {
-1 -> { f1() }
-2 -> { f2() }
-}
-when (a) {
-1 -> f1()
-2 -> f2()
-}
-// multiLine = 'consistent'
-when (a) {
-1 -> {
-f1()
-}
-2 -> {
-f2()
-f3()
-}
-}
+ // singleLine = 'consistent'
+ when (a) {
+     1 -> { f1() }
+     2 -> { f2() }
+ }
+ when (a) {
+     1 -> f1()
+     2 -> f2()
+ }
+ // multiLine = 'consistent'
+ when (a) {
+     1 -> {
+         f1()
+     }
+     2 -> {
+         f2()
+         f3()
+     }
+ }
 
-// singleLine = 'always'
-when (a) {
-1 -> { f1() }
-2 -> { f2() }
-}
-// multiLine = 'always'
-when (a) {
-1 -> {
-f1()
-}
-2 -> {
-f2()
-f3()
-}
-}
+ // singleLine = 'always'
+ when (a) {
+     1 -> { f1() }
+     2 -> { f2() }
+ }
+ // multiLine = 'always'
+ when (a) {
+     1 -> {
+         f1()
+     }
+     2 -> {
+         f2()
+         f3()
+     }
+ }
 ```
 
 ### CanBeNonNullable
@@ -438,7 +438,7 @@ This could lead to less nullability overall in the codebase.
 
 ```kotlin
 class A {
-var a: Int? = 5
+    var a: Int? = 5
 
     fun foo() {
         a = 6
@@ -446,23 +446,23 @@ var a: Int? = 5
 }
 
 class A {
-val a: Int?
-get() = 5
+    val a: Int?
+        get() = 5
 }
 
 fun foo(a: Int?) {
-val b = a!! + 2
+    val b = a!! + 2
 }
 
 fun foo(a: Int?) {
-if (a != null) {
-println(a)
-}
+    if (a != null) {
+        println(a)
+    }
 }
 
 fun foo(a: Int?) {
-if (a == null) return
-println(a)
+    if (a == null) return
+    println(a)
 }
 ```
 
@@ -470,7 +470,7 @@ println(a)
 
 ```kotlin
 class A {
-var a: Int = 5
+    var a: Int = 5
 
     fun foo() {
         a = 6
@@ -478,16 +478,16 @@ var a: Int = 5
 }
 
 class A {
-val a: Int
-get() = 5
+    val a: Int
+        get() = 5
 }
 
 fun foo(a: Int) {
-val b = a + 2
+    val b = a + 2
 }
 
 fun foo(a: Int) {
-println(a)
+    println(a)
 }
 ```
 
@@ -507,7 +507,7 @@ Requires that all chained calls are placed on a new line if a preceding one is.
 
 ```kotlin
 foo()
-.bar().baz()
+  .bar().baz()
 ```
 
 #### Compliant Code:
@@ -516,8 +516,8 @@ foo()
 foo().bar().baz()
 
 foo()
-.bar()
-.baz()
+  .bar()
+  .baz()
 ```
 
 ### ClassOrdering
@@ -535,9 +535,9 @@ This rule ensures class contents are ordered as follows as recommended by the Ko
 
 ```kotlin
 class OutOfOrder {
-companion object {
-const val IMPORTANT_VALUE = 3
-}
+    companion object {
+        const val IMPORTANT_VALUE = 3
+    }
 
     fun returnX(): Int {
         return x
@@ -551,7 +551,7 @@ const val IMPORTANT_VALUE = 3
 
 ```kotlin
 class InOrder {
-private val x = 2
+    private val x = 2
 
     fun returnX(): Int {
         return x
@@ -577,9 +577,9 @@ statements may hide some edge cases from the reader.
 ```kotlin
 val i = 1
 if (i > 0) {
-if (i < 5) {
-println(i)
-}
+    if (i < 5) {
+        println(i)
+    }
 }
 ```
 
@@ -588,7 +588,7 @@ println(i)
 ```kotlin
 val i = 1
 if (i > 0 && i < 5) {
-println(i)
+    println(i)
 }
 ```
 
@@ -616,7 +616,7 @@ Data classes will automatically have a generated `equals`, `toString` and `hashC
 
 ```kotlin
 data class DataClassWithFunctions(val i: Int) {
-fun foo() { }
+    fun foo() { }
 }
 ```
 
@@ -633,7 +633,7 @@ mutable properties.
 
 ```kotlin
 data class MutableDataClass(var i: Int) {
-var s: String? = null
+    var s: String? = null
 }
 ```
 
@@ -641,8 +641,8 @@ var s: String? = null
 
 ```kotlin
 data class ImmutableDataClass(
-val i: Int,
-val s: String?
+    val i: Int,
+    val s: String?
 )
 ```
 
@@ -757,10 +757,10 @@ rest of the function signature.
 
 ```kotlin
 fun stuff(): Int
-= 5
+    = 5
 
 fun <V> foo(): Int where V : Int
-= 5
+    = 5
 ```
 
 #### Compliant Code:
@@ -769,7 +769,7 @@ fun <V> foo(): Int where V : Int
 fun stuff() = 5
 
 fun stuff() =
-foo.bar()
+    foo.bar()
 
 fun <V> foo(): Int where V : Int = 5
 ```
@@ -787,17 +787,17 @@ Prefer the usage of the indexed access operator `[]` for map or list element acc
 #### Noncompliant Code:
 
 ```kotlin
-val map = mutableMapOf<String, String>()
-map.put("key", "value")
-val value = map.get("key")
+ val map = mutableMapOf<String, String>()
+ map.put("key", "value")
+ val value = map.get("key")
 ```
 
 #### Compliant Code:
 
 ```kotlin
-val map = mutableMapOf<String, String>()
-map["key"] = "value"
-val value = map["key"]
+ val map = mutableMapOf<String, String>()
+ map["key"] = "value"
+ val value = map["key"]
 ```
 
 ### ExplicitItLambdaMultipleParameters
@@ -821,7 +821,7 @@ collection.zipWithNext { it, next -> Pair(it, next) }
 ```kotlin
 // Lambdas with multiple parameter should be named clearly, using it for one of them can be confusing
 collection.zipWithNext { prev, next ->
-Pair(prev, next)
+    Pair(prev, next)
 }
 ```
 
@@ -841,7 +841,7 @@ makes your code misleading, especially when dealing with nested functions.
 a?.let { it -> it.plus(1) }
 foo.flatMapObservable { it -> Observable.fromIterable(it) }
 listOfPairs.map(::second).forEach { it ->
-it.execute()
+    it.execute()
 }
 ```
 
@@ -854,7 +854,7 @@ foo.flatMapObservable(Observable::fromIterable) // Here we can have a method ref
 
 // For multiline blocks it is usually better come up with a clear and more meaningful name
 listOfPairs.map(::second).forEach { apiRequest ->
-apiRequest.execute()
+    apiRequest.execute()
 }
 ```
 
@@ -875,7 +875,7 @@ cleans up the code.
 
 ```kotlin
 fun stuff(): Int {
-return 5
+    return 5
 }
 ```
 
@@ -885,10 +885,10 @@ return 5
 fun stuff() = 5
 
 fun stuff() {
-return
-moreStuff()
-.getStuff()
-.stuffStuff()
+    return
+        moreStuff()
+            .getStuff()
+            .stuffStuff()
 }
 ```
 
@@ -927,56 +927,56 @@ This rule allows to set a list of comments which are forbidden in the codebase a
 development. Offending code comments will then be reported.
 
 The regular expressions in `comments` list will have the following behaviors while matching the comments:
-* **Each comment will be handled individually.**
-* single line comments are always separate, consecutive lines are not merged.
-* multi line comments are not split up, the regex will be applied to the whole comment.
-* KDoc comments are not split up, the regex will be applied to the whole comment.
-* **The following comment delimiters (and indentation before them) are removed** before applying the regex:
-`//`, `// `, `/​*`, `/​* `, `/​**`, `*` aligners, `*​/`, ` *​/`
-* **The regex is applied as a multiline regex**,
-see [Anchors](https://www.regular-expressions.info/anchors.html) for more info.
-To match the start and end of each line, use `^` and `$`.
-To match the start and end of the whole comment, use `\A` and `\Z`.
-To turn off multiline, use `(?-m)` at the start of your regex.
-* **The regex is applied with dotall semantics**, meaning `.` will match any character including newlines,
-this is to ensure that freeform line-wrapping doesn't mess with simple regexes.
-To turn off this behavior, use `(?-s)` at the start of your regex, or use `[^\r\n]*` instead of `.*`.
-* **The regex will be searched using "contains" semantics** not "matches",
-so partial comment matches will flag forbidden comments.
-In practice this means there's no need to start and end the regex with `.*`.
+ * **Each comment will be handled individually.**
+   * single line comments are always separate, consecutive lines are not merged.
+   * multi line comments are not split up, the regex will be applied to the whole comment.
+   * KDoc comments are not split up, the regex will be applied to the whole comment.
+ * **The following comment delimiters (and indentation before them) are removed** before applying the regex:
+   `//`, `// `, `/​*`, `/​* `, `/​**`, `*` aligners, `*​/`, ` *​/`
+ * **The regex is applied as a multiline regex**,
+   see [Anchors](https://www.regular-expressions.info/anchors.html) for more info.
+   To match the start and end of each line, use `^` and `$`.
+   To match the start and end of the whole comment, use `\A` and `\Z`.
+   To turn off multiline, use `(?-m)` at the start of your regex.
+ * **The regex is applied with dotall semantics**, meaning `.` will match any character including newlines,
+   this is to ensure that freeform line-wrapping doesn't mess with simple regexes.
+   To turn off this behavior, use `(?-s)` at the start of your regex, or use `[^\r\n]*` instead of `.*`.
+ * **The regex will be searched using "contains" semantics** not "matches",
+   so partial comment matches will flag forbidden comments.
+   In practice this means there's no need to start and end the regex with `.*`.
 
 The rule can be configured to add extra comments to the list of forbidden comments, here are some examples:
 ```yaml
-ForbiddenComment:
-  comments:
-    # Repeat the default configuration if it's still needed.
-    - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
-      value: 'FIXME:'
-    - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
-      value: 'STOPSHIP:'
-    - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
-      value: 'TODO:'
-    # Add additional patterns to the list.
+  ForbiddenComment:
+    comments:
+      # Repeat the default configuration if it's still needed.
+      - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
+        value: 'FIXME:'
+      - reason: 'Forbidden STOPSHIP todo marker in comment, please address the problem before shipping the code.'
+        value: 'STOPSHIP:'
+      - reason: 'Forbidden TODO todo marker in comment, please do the changes.'
+        value: 'TODO:'
+      # Add additional patterns to the list.
 
-    - reason: 'Authors are not recorded in KDoc.'
-      value: '@author'
+      - reason: 'Authors are not recorded in KDoc.'
+        value: '@author'
 
-    - reason: 'REVIEW markers are not allowed in production code, only use before PR is merged.'
-      value: '^\s*(?i)REVIEW\b'
-      # Non-compliant: // REVIEW this code before merging.
-      # Compliant: // Preview will show up here.
+      - reason: 'REVIEW markers are not allowed in production code, only use before PR is merged.'
+        value: '^\s*(?i)REVIEW\b'
+        # Non-compliant: // REVIEW this code before merging.
+        # Compliant: // Preview will show up here.
 
-    - reason: 'Use @androidx.annotation.VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) instead.'
-      value: '^private$'
-      # Non-compliant: /*private*/fun f() { }
+      - reason: 'Use @androidx.annotation.VisibleForTesting(otherwise = VisibleForTesting.PRIVATE) instead.'
+        value: '^private$'
+        # Non-compliant: /*private*/ fun f() { }
 
       - reason: 'KDoc tag should have a value.'
         value: '^\s*@(?!suppress|hide)\w+\s*$'
         # Non-compliant: /** ... @see */
-    # Compliant: /** ... @throws IOException when there's a network problem */
+        # Compliant: /** ... @throws IOException when there's a network problem */
 
-    - reason: 'include an issue link at the beginning preceded by a space'
-      value: 'BUG:(?! https://github\.com/company/repo/issues/\d+).*'
+      - reason: 'include an issue link at the beginning preceded by a space'
+        value: 'BUG:(?! https://github\.com/company/repo/issues/\d+).*'
 ```
 
 By default the commonly used todo markers are forbidden: `TODO:`, `FIXME:` and `STOPSHIP:`.
@@ -998,8 +998,8 @@ By default the commonly used todo markers are forbidden: `TODO:`, `FIXME:` and `
 ```kotlin
 val a = "" // TODO: remove please
 /**
-* FIXME: this is a hack
-*/
+ * FIXME: this is a hack
+ */
 fun foo() { }
 /* STOPSHIP: */
 ```
@@ -1051,9 +1051,9 @@ of unstable, experimental or deprecated methods, especially for methods imported
 
 ```kotlin
 fun main() {
-println()
-val myPrintln : () -> Unit = ::println
-kotlin.io.print("Hello, World!")
+  println()
+  val myPrintln : () -> Unit = ::println
+  kotlin.io.print("Hello, World!")
 }
 ```
 
@@ -1080,8 +1080,8 @@ discourage the use named parameters.
 
 ```kotlin
 fun foo() {
-// `id =` here adds no value
-painterResource(id = R.drawable.ic_close)
+    // `id =` here adds no value
+    painterResource(id = R.drawable.ic_close)
 }
 ```
 
@@ -1089,7 +1089,7 @@ painterResource(id = R.drawable.ic_close)
 
 ```kotlin
 fun foo() {
-painterResource(R.drawable.ic_close)
+    painterResource(R.drawable.ic_close)
 }
 ```
 
@@ -1230,11 +1230,11 @@ To increase readability they should be refactored into simpler loops.
 ```kotlin
 val strs = listOf("foo, bar")
 for (str in strs) {
-if (str == "bar") {
-break
-} else {
-continue
-}
+    if (str == "bar") {
+        break
+    } else {
+        continue
+    }
 }
 ```
 
@@ -1334,13 +1334,13 @@ Adding braces would improve readability and avoid possible errors.
 
 ```kotlin
 for (i in 0..10)
-println(i)
+    println(i)
 
 while (true)
-println("Hello, world")
+    println("Hello, world")
 
 do
-println("Hello, world")
+    println("Hello, world")
 while (true)
 ```
 
@@ -1348,19 +1348,19 @@ while (true)
 
 ```kotlin
 for (i in 0..10) {
-println(i)
+    println(i)
 }
 
 for (i in 0..10) println(i)
 
 while (true) {
-println("Hello, world")
+    println("Hello, world")
 }
 
 while (true) println("Hello, world")
 
 do {
-println("Hello, world")
+    println("Hello, world")
 } while (true)
 
 do println("Hello, world") while (true)
@@ -1390,7 +1390,7 @@ a().b().c().d().e().f()
 
 ```kotlin
 a().b().c()
-.d().e().f()
+  .d().e().f()
 ```
 
 ### MaxLineLength
@@ -1479,18 +1479,18 @@ explicitly.
 
 ```kotlin
 val digits = 1234.let {
-println(it)
-listOf(it)
+    println(it)
+    listOf(it)
 }
 
 val digits = 1234.let { it ->
-println(it)
-listOf(it)
+    println(it)
+    listOf(it)
 }
 
 val flat = listOf(listOf(1), listOf(2)).mapIndexed { index, it ->
-println(it)
-it + index
+    println(it)
+    it + index
 }
 ```
 
@@ -1498,26 +1498,26 @@ it + index
 
 ```kotlin
 val digits = 1234.let { explicitParameterName ->
-println(explicitParameterName)
-listOf(explicitParameterName)
+    println(explicitParameterName)
+    listOf(explicitParameterName)
 }
 
 val lambda = { item: Int, that: String ->
-println(item)
-item.toString() + that
+    println(item)
+    item.toString() + that
 }
 
 val digits = 1234.let { listOf(it) }
 val digits = 1234.let {
-listOf(it)
+    listOf(it)
 }
 val digits = 1234.let { it -> listOf(it) }
 val digits = 1234.let { it ->
-listOf(it)
+    listOf(it)
 }
 val digits = 1234.let { explicit -> listOf(explicit) }
 val digits = 1234.let { explicit ->
-listOf(explicit)
+    listOf(explicit)
 }
 ```
 
@@ -1551,22 +1551,22 @@ How are you?
 """.trimMargin()
 
 val a = """
-Hello World!
-How are you?
-""".trimMargin()
+        Hello World!
+        How are you?
+        """.trimMargin()
 ```
 
 #### Compliant Code:
 
 ```kotlin
 val a = """
-Hello World!
-How are you?
+    Hello World!
+    How are you?
 """.trimMargin()
 
 val a = """
-Hello World!
-How are you?
+    Hello World!
+      How are you?
 """.trimMargin()
 ```
 
@@ -1585,8 +1585,8 @@ because the nested class still has an internal visibility.
 
 ```kotlin
 internal class Outer {
-// explicit public modifier still results in an internal nested class
-public class Nested
+    // explicit public modifier still results in an internal nested class
+    public class Nested
 }
 ```
 
@@ -1594,8 +1594,8 @@ public class Nested
 
 ```kotlin
 internal class Outer {
-class Nested1
-internal class Nested2
+    class Nested1
+    internal class Nested2
 }
 ```
 
@@ -1657,8 +1657,8 @@ See [SAM conversions](https://kotlinlang.org/docs/java-interop.html#sam-conversi
 
 ```kotlin
 object : Foo {
-override fun bar() {
-}
+    override fun bar() {
+    }
 }
 ```
 
@@ -1709,12 +1709,12 @@ of a lone Unit statement.
 
 ```kotlin
 fun foo(): Unit {
-return Unit
+    return Unit
 }
 fun foo() = Unit
 
 fun doesNothing() {
-Unit
+    Unit
 }
 ```
 
@@ -1738,7 +1738,7 @@ members. Consider using `private` or `internal` modifiers instead.
 
 ```kotlin
 class ProtectedMemberInFinalClass {
-protected var i = 0
+    protected var i = 0
 }
 ```
 
@@ -1746,7 +1746,7 @@ protected var i = 0
 
 ```kotlin
 class ProtectedMemberInFinalClass {
-private var i = 0
+    private var i = 0
 }
 ```
 
@@ -1791,7 +1791,7 @@ data class Foo constructor(val foo: Int)
 data class Foo(val foo: Int)
 
 data class Bar private constructor(val bar: String) {
-constructor(bar: Int): this("$foo")
+    constructor(bar: Int): this("$foo")
 }
 ```
 
@@ -1807,7 +1807,7 @@ Local properties do not need their type to be explicitly provided when the infer
 
 ```kotlin
 fun function() {
-val x: String = "string"
+    val x: String = "string"
 }
 ```
 
@@ -1815,7 +1815,7 @@ val x: String = "string"
 
 ```kotlin
 fun function() {
-val x = "string"
+    val x = "string"
 }
 ```
 
@@ -1832,22 +1832,22 @@ operator.
 
 ```kotlin
 fun foo(list: List<Int>): List<Int> {
-return list
-.filter { it > 5 }
-.map { it }
+    return list
+        .filter { it > 5 }
+        .map { it }
 }
 
 fun bar(list: List<Int>): List<Int> {
-return list
-.filter { it > 5 }
-.map {
-doSomething(it)
-it
-}
+    return list
+        .filter { it > 5 }
+        .map {
+            doSomething(it)
+            it
+        }
 }
 
 fun baz(set: Set<Int>): List<Int> {
-return set.map { it }
+    return set.map { it }
 }
 ```
 
@@ -1855,20 +1855,20 @@ return set.map { it }
 
 ```kotlin
 fun foo(list: List<Int>): List<Int> {
-return list
-.filter { it > 5 }
+    return list
+        .filter { it > 5 }
 }
 
 fun bar(list: List<Int>): List<Int> {
-return list
-.filter { it > 5 }
-.onEach {
-doSomething(it)
-}
+    return list
+        .filter { it > 5 }
+        .onEach {
+            doSomething(it)
+        }
 }
 
 fun baz(set: Set<Int>): List<Int> {
-return set.toList()
+    return set.toList()
 }
 ```
 
@@ -1935,11 +1935,11 @@ code.
 
 ```kotlin
 fun foo(i: Int): String {
-when (i) {
-1 -> return "one"
-2 -> return "two"
-else -> return "other"
-}
+    when (i) {
+        1 -> return "one"
+        2 -> return "two"
+        else -> return "other"
+    }
 }
 ```
 
@@ -1947,11 +1947,11 @@ else -> return "other"
 
 ```kotlin
 fun foo(i: Int): String {
-return when (i) {
-1 -> "one"
-2 -> "two"
-else -> "other"
-}
+    return when (i) {
+        1 -> "one"
+        2 -> "two"
+        else -> "other"
+    }
 }
 ```
 
@@ -1965,8 +1965,8 @@ This rule inspects casts and reports casts which could be replaced with safe cas
 
 ```kotlin
 fun numberMagic(number: Number) {
-val i = if (number is Int) number else null
-// ...
+    val i = if (number is Int) number else null
+    // ...
 }
 ```
 
@@ -1974,8 +1974,8 @@ val i = if (number is Int) number else null
 
 ```kotlin
 fun numberMagic(number: Number) {
-val i = number as? Int
-// ...
+    val i = number as? Int
+    // ...
 }
 ```
 
@@ -2059,13 +2059,13 @@ recommendation on using multiline strings
 
 ```kotlin
 val windowJson = "{\n" +
-"  \"window\": {\n" +
-"    \"title\": \"Sample Quantum With AI and ML Widget\",\n" +
-"    \"name\": \"main_window\",\n" +
-"    \"width\": 500,\n" +
-"    \"height\": 500\n" +
-"  }\n" +
-"}"
+                 "  \"window\": {\n" +
+                 "    \"title\": \"Sample Quantum With AI and ML Widget\",\n" +
+                 "    \"name\": \"main_window\",\n" +
+                 "    \"width\": 500,\n" +
+                 "    \"height\": 500\n" +
+                 "  }\n" +
+                 "}"
 
 val patRegex = "/^(\\/[^\\/]+){0,2}\\/?\$/gm\n"
 ```
@@ -2074,14 +2074,14 @@ val patRegex = "/^(\\/[^\\/]+){0,2}\\/?\$/gm\n"
 
 ```kotlin
 val windowJson = """
-{
-"window": {
-"title": "Sample Quantum With AI and ML Widget",
-"name": "main_window",
-"width": 500,
-"height": 500
-}
-}
+    {
+         "window": {
+             "title": "Sample Quantum With AI and ML Widget",
+             "name": "main_window",
+             "width": 500,
+             "height": 500
+         }
+    }
 """.trimIndent()
 
 val patRegex = """/^(\/[^\/]+){0,2}\/?$/gm"""
@@ -2108,11 +2108,11 @@ to confusion. Instead, prefer limiting the number of `throw` statements in a fun
 
 ```kotlin
 fun foo(i: Int) {
-when (i) {
-1 -> throw IllegalArgumentException()
-2 -> throw IllegalArgumentException()
-3 -> throw IllegalArgumentException()
-}
+    when (i) {
+        1 -> throw IllegalArgumentException()
+        2 -> throw IllegalArgumentException()
+        3 -> throw IllegalArgumentException()
+    }
 }
 ```
 
@@ -2120,9 +2120,9 @@ when (i) {
 
 ```kotlin
 fun foo(i: Int) {
-when (i) {
-1,2,3 -> throw IllegalArgumentException()
-}
+    when (i) {
+        1,2,3 -> throw IllegalArgumentException()
+    }
 }
 ```
 
@@ -2154,8 +2154,8 @@ All the Raw strings that have more than one line should be followed by `trimMarg
 
 ```kotlin
 """
-Hello World!
-How are you?
+  Hello World!
+  How are you?
 """
 ```
 
@@ -2163,13 +2163,13 @@ How are you?
 
 ```kotlin
 """
-|  Hello World!
-|  How are you?
+  |  Hello World!
+  |  How are you?
 """.trimMargin()
 
 """
-Hello World!
-How are you?
+  Hello World!
+  How are you?
 """.trimIndent()
 
 """Hello World! How are you?"""
@@ -2249,8 +2249,8 @@ config?.apply { println(version) } // `apply` can be replaced by `let`
 
 ```kotlin
 config.apply {
-version = "1.2"
-environment = "test"
+    version = "1.2"
+    environment = "test"
 }
 ```
 
@@ -2287,9 +2287,9 @@ Prefer the usage of trailing lambda.
 
 ```kotlin
 fun test() {
-repeat(10, {
-println(it)
-})
+    repeat(10, {
+        println(it)
+    })
 }
 ```
 
@@ -2297,9 +2297,9 @@ println(it)
 
 ```kotlin
 fun test() {
-repeat(10) {
-println(it)
-}
+    repeat(10) {
+        println(it)
+    }
 }
 ```
 
@@ -2315,22 +2315,22 @@ Unnecessary filters add complexity to the code and accomplish nothing. They shou
 
 ```kotlin
 val x = listOf(1, 2, 3)
-.filter { it > 1 }
-.count()
+     .filter { it > 1 }
+     .count()
 
 val x = listOf(1, 2, 3)
-.filter { it > 1 }
-.isEmpty()
+     .filter { it > 1 }
+     .isEmpty()
 ```
 
 #### Compliant Code:
 
 ```kotlin
 val x = listOf(1, 2, 3)
-.count { it > 2 }
+     .count { it > 2 }
 
 val x = listOf(1, 2, 3)
-.none { it > 1 }
+     .none { it > 1 }
 ```
 
 ### UnnecessaryFullyQualifiedName
@@ -2353,13 +2353,13 @@ for a similar rule in the Java ecosystem.
 
 ```kotlin
 class Foo {
-fun bar(): java.util.List<String> {
-val date = java.time.LocalDate.now()
-return java.util.ArrayList()
-}
-fun baz() {
-kotlin.io.println("Hello")
-}
+    fun bar(): java.util.List<String> {
+        val date = java.time.LocalDate.now()
+        return java.util.ArrayList()
+    }
+    fun baz() {
+        kotlin.io.println("Hello")
+    }
 }
 ```
 
@@ -2371,13 +2371,13 @@ import java.util.ArrayList
 import java.util.List
 
 class Foo {
-fun bar(): List<String> {
-val date = LocalDate.now()
-return ArrayList()
-}
-fun baz() {
-println("Hello")
-}
+    fun bar(): List<String> {
+        val date = LocalDate.now()
+        return ArrayList()
+    }
+    fun baz() {
+        println("Hello")
+    }
 }
 ```
 
@@ -2408,7 +2408,7 @@ not require the `inner` qualifier.
 
 ```kotlin
 class A {
-val foo = "BAR"
+    val foo = "BAR"
 
     inner class B {
         val fizz = "BUZZ"
@@ -2473,7 +2473,7 @@ val local = (5 + 3)
 if ((local == 8)) { }
 
 fun foo() {
-function({ input -> println(input) })
+    function({ input -> println(input) })
 }
 ```
 
@@ -2485,7 +2485,7 @@ val local = 5 + 3
 if (local == 8) { }
 
 fun foo() {
-function { input -> println(input) }
+    function { input -> println(input) }
 }
 ```
 
@@ -2502,15 +2502,15 @@ should be replaced by single equivalent sort operation.
 
 ```kotlin
 listOf(1,2)
-.sorted()
-.asReversed()
+ .sorted()
+ .asReversed()
 ```
 
 #### Compliant Code:
 
 ```kotlin
 listOf(1,2)
-.sortedDescending()
+ .sortedDescending()
 ```
 
 ### UnusedImport
@@ -2547,7 +2547,7 @@ An unused parameter can be removed to simplify the signature of the function.
 
 ```kotlin
 fun foo(unused: String) {
-println()
+    println()
 }
 ```
 
@@ -2555,7 +2555,7 @@ println()
 
 ```kotlin
 fun foo(used: String) {
-println(used)
+    println(used)
 }
 ```
 
@@ -2610,7 +2610,7 @@ properties of the class when they are declared with `val` or `var`.
 
 ```kotlin
 class Foo {
-private val unused = "unused"
+    private val unused = "unused"
 }
 ```
 
@@ -2618,7 +2618,7 @@ private val unused = "unused"
 
 ```kotlin
 class Foo {
-private val used = "used"
+    private val used = "used"
 
     fun greet() {
         println(used)
@@ -2646,7 +2646,7 @@ An unused variable can be removed to simplify the source file.
 
 ```kotlin
 fun foo() {
-val unused = "unused"
+    val unused = "unused"
 }
 ```
 
@@ -2654,8 +2654,8 @@ val unused = "unused"
 
 ```kotlin
 fun foo() {
-val used = "used"
-println(used)
+    val used = "used"
+    println(used)
 }
 ```
 
@@ -2735,8 +2735,8 @@ Prefer them instead of manually throwing an IllegalStateException.
 if (value == null) throw IllegalStateException("value should not be null")
 if (value < 0) throw IllegalStateException("value is $value but should be at least 0")
 when(a) {
-1 -> doSomething()
-else -> throw IllegalStateException("Unexpected value")
+    1 -> doSomething()
+    else -> throw IllegalStateException("Unexpected value")
 }
 ```
 
@@ -2746,8 +2746,8 @@ else -> throw IllegalStateException("Unexpected value")
 checkNotNull(value) { "value should not be null" }
 check(value >= 0) { "value is $value but should be at least 0" }
 when(a) {
-1 -> doSomething()
-else -> error("Unexpected value")
+    1 -> doSomething()
+    else -> error("Unexpected value")
 }
 ```
 
@@ -2772,7 +2772,7 @@ Read more about [data classes](https://kotlinlang.org/docs/data-classes.html)
 
 ```kotlin
 class DataClassCandidate(val i: Int) {
-val i2: Int = 0
+    val i2: Int = 0
 }
 ```
 
@@ -2828,10 +2828,10 @@ This rule detects `isEmpty` or `isBlank` calls to assign a default value. They c
 
 ```kotlin
 fun test(list: List<Int>, s: String) {
-val a = if (list.isEmpty()) listOf(1) else list
-val b = if (list.isNotEmpty()) list else listOf(2)
-val c = if (s.isBlank()) "foo" else s
-val d = if (s.isNotBlank()) s else "bar"
+    val a = if (list.isEmpty()) listOf(1) else list
+    val b = if (list.isNotEmpty()) list else listOf(2)
+    val c = if (s.isBlank()) "foo" else s
+    val d = if (s.isNotBlank()) s else "bar"
 }
 ```
 
@@ -2839,10 +2839,10 @@ val d = if (s.isNotBlank()) s else "bar"
 
 ```kotlin
 fun test(list: List<Int>, s: String) {
-val a = list.ifEmpty { listOf(1) }
-val b = list.ifEmpty { listOf(2) }
-val c = s.ifBlank { "foo" }
-val d = s.ifBlank { "bar" }
+    val a = list.ifEmpty { listOf(1) }
+    val b = list.ifEmpty { listOf(2) }
+    val c = s.ifBlank { "foo" }
+    val d = s.ifBlank { "bar" }
 }
 ```
 
@@ -2864,8 +2864,8 @@ See [if versus when](https://kotlinlang.org/docs/coding-conventions.html#if-vers
 
 ```kotlin
 when (x) {
-null -> true
-else -> false
+    null -> true
+    else -> false
 }
 ```
 
@@ -2887,13 +2887,13 @@ This rule detects null or empty checks that can be replaced with `isNullOrEmpty(
 
 ```kotlin
 fun foo(x: List<Int>?) {
-if (x == null || x.isEmpty()) return
+    if (x == null || x.isEmpty()) return
 }
 fun bar(x: List<Int>?) {
-if (x == null || x.count() == 0) return
+    if (x == null || x.count() == 0) return
 }
 fun baz(x: List<Int>?) {
-if (x == null || x.size == 0) return
+    if (x == null || x.size == 0) return
 }
 ```
 
@@ -2936,8 +2936,8 @@ This rule detects `?: emptyList()` that can be replaced with `orEmpty()` call.
 
 ```kotlin
 fun test(x: List<Int>?, s: String?) {
-val a = x ?: emptyList()
-val b = s ?: ""
+    val a = x ?: emptyList()
+    val b = s ?: ""
 }
 ```
 
@@ -2945,8 +2945,8 @@ val b = s ?: ""
 
 ```kotlin
 fun test(x: List<Int>?, s: String?) {
-val a = x.orEmpty()
-val b = s.orEmpty()
+    val a = x.orEmpty()
+    val b = s.orEmpty()
 }
 ```
 
@@ -3119,8 +3119,8 @@ the current state easier.
 
 ```kotlin
 fun example() {
-var i = 1 // violation: this variable is never re-assigned
-val j = i + 1
+    var i = 1 // violation: this variable is never re-assigned
+    val j = i + 1
 }
 ```
 
@@ -3128,8 +3128,8 @@ val j = i + 1
 
 ```kotlin
 fun example() {
-val i = 1
-val j = i + 1
+    val i = 1
+    val j = i + 1
 }
 ```
 
@@ -3157,8 +3157,8 @@ When suppressing an issue of WildcardImport in the baseline file, make sure to s
 import dev.detekt.*
 
 class DetektElements {
-val element1 = DetektElement1()
-val element2 = DetektElement2()
+    val element1 = DetektElement1()
+    val element2 = DetektElement2()
 }
 ```
 
@@ -3169,7 +3169,7 @@ import dev.detekt.DetektElement1
 import dev.detekt.DetektElement2
 
 class DetektElements {
-val element1 = DetektElement1()
-val element2 = DetektElement2()
+    val element1 = DetektElement1()
+    val element2 = DetektElement2()
 }
 ```


### PR DESCRIPTION
I've regenerated the docs for 2.0.0-alpha.2 with correct indentation