### PR TITLE
Move classes from `:detekt-parser` to `detekt-core`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/DetektMessageCollector.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/DetektMessageCollector.kt
@@ -1,4 +1,4 @@
-package dev.detekt.parser
+package dev.detekt.core.parser
 
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSourceLocation

--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -1,4 +1,4 @@
-package dev.detekt.parser
+package dev.detekt.core.parser
 
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -5,8 +5,8 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.Disposer
 import com.intellij.pom.PomModel
 import com.intellij.pom.tree.TreeAspect
+import dev.detekt.core.parser.createCompilerConfiguration
 import dev.detekt.parser.DetektPomModel
-import dev.detekt.parser.createCompilerConfiguration
 import dev.detekt.tooling.api.spec.CompilerSpec
 import dev.detekt.tooling.api.spec.LoggingSpec
 import dev.detekt.tooling.api.spec.ProjectSpec

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/Lifecycle.kt
@@ -10,10 +10,10 @@ import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.config.validation.checkConfiguration
 import dev.detekt.core.extensions.handleReportingExtensions
 import dev.detekt.core.getRules
+import dev.detekt.core.parser.DetektMessageCollector
 import dev.detekt.core.reporting.OutputFacade
 import dev.detekt.core.rules.createRuleProviders
 import dev.detekt.core.util.PerformanceMonitor.Phase
-import dev.detekt.parser.DetektMessageCollector
 import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter

--- a/detekt-core/src/test/kotlin/dev/detekt/core/parser/DetektMessageCollectorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/parser/DetektMessageCollectorSpec.kt
@@ -1,4 +1,4 @@
-package dev.detekt.parser
+package dev.detekt.core.parser
 
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity

--- a/detekt-parser/build.gradle.kts
+++ b/detekt-parser/build.gradle.kts
@@ -4,5 +4,4 @@ plugins {
 
 dependencies {
     api(libs.kotlin.compiler)
-    testImplementation(libs.assertj.core)
 }


### PR DESCRIPTION
These tow classes are only used at `core`. These change reduce the need to re-run tests when these classes are changed because `detekt-test-utils` depend on `detekt-parser` so a change in `detekt-parser` force to run nearly all the tests in the project.

This PR makes that `:detekt-parser` only has one file now so I'm going to open an issue to decide what to do with it.