### PR TITLE
SpacingAfterPackageDeclaration: Fix false negative for top level declaration

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/SpacingAfterPackageDeclaration.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/SpacingAfterPackageDeclaration.kt
@@ -6,17 +6,16 @@ import dev.detekt.api.Config
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
-import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtPackageDirective
-import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.siblings
 
 /**
- * This rule verifies spacing between package and import statements as well as between import statements and class
- * declarations.
+ * This rule verifies spacing between package and import statements as well as between import statements and top
+ * level declarations.
  *
  * <noncompliant>
  * package foo
@@ -36,7 +35,7 @@ class SpacingAfterPackageDeclaration(config: Config) :
     Rule(config, "Violation of the package declaration style detected.") {
 
     override fun visitKtFile(file: KtFile) {
-        if (file.hasPackage() && file.anyDescendantOfType<KtClassOrObject>()) {
+        if (file.hasPackage()) {
             file.importList?.let {
                 if (it.imports.isNotEmpty()) {
                     checkPackageDeclaration(it)
@@ -65,7 +64,7 @@ class SpacingAfterPackageDeclaration(config: Config) :
         val ktElement = importList.siblings(withItself = false).filterIsInstance<KtElement>().firstOrNull() ?: return
         val nextSibling = importList.nextSibling
         if (nextSibling is PsiWhiteSpace || nextSibling is KtElement) {
-            val name = (ktElement as? KtClassOrObject)?.name ?: "the class or object"
+            val name = (ktElement as? KtNamedDeclaration)?.name ?: "the declaration"
 
             checkLinebreakAfterElement(
                 nextSibling,

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/SpacingAfterPackageDeclarationSpec.kt
@@ -117,10 +117,28 @@ class SpacingAfterPackageDeclarationSpec {
     fun `has no class`() {
         val code = """
             package com.my.has.no.clazz
-            
+
             import kotlin.collections.List
             import kotlin.collections.Set
         """.trimIndent()
         assertThat(subject.lint(code)).isEmpty()
+    }
+
+    @Test
+    fun `reports missing blank line between package and import without class`() {
+        val code = "package test\nimport a.b"
+        assertThat(subject.lint(code, compile = false)).hasSize(1)
+    }
+
+    @Test
+    fun `reports missing blank line between import and function`() {
+        val code = "package test\n\nimport a.b\nfun foo() {}"
+        assertThat(subject.lint(code, compile = false)).hasSize(1)
+    }
+
+    @Test
+    fun `reports missing blank line between import and property`() {
+        val code = "package test\n\nimport a.b\nval hello = \"hola\""
+        assertThat(subject.lint(code, compile = false)).hasSize(1)
     }
 }


### PR DESCRIPTION
This pull request updates the `SpacingAfterPackageDeclaration` rule in Detekt to improve how spacing is checked between package/import statements and top-level declarations. The changes generalize the rule to handle any top-level declaration (not just classes/objects), and add new tests to verify this behavior.

Fixes #9079