### PR TITLE
Performance improvement - consolidated KaLibraryModules

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -30,7 +30,6 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
 import java.io.OutputStream
 import java.io.PrintStream
-import java.util.UUID
 import kotlin.io.path.Path
 
 interface EnvironmentAware {


### PR DESCRIPTION
Initially I was looking into the StandaloneAnalysisAPISessionBuilder api to see if I could help with the `compile-test-snippets` memory issues, but I think this could be a lot more useful in the Detekt analysis logic itself. 

Kotlin's standalone analysis api doesn't have a lot of documentation, but one thing I noticed was that StandaloneAnalysisAPISessionBuilder [flattens all library binary roots into a single list](https://github.com/JetBrains/kotlin/blob/de4ab3558e72b7158759aaf8f402da9e4f766131/analysis/analysis-api-standalone/src/org/jetbrains/kotlin/analysis/api/standalone/StandaloneAnalysisAPISessionBuilder.kt#L228-L231). So I don't _think_ there should be a difference in the output. However I noticed a significant difference in the performance. 

I believe the main reason for this is each `buildKtLibraryModule` call creates a [GlobalSearchScope](https://github.com/JetBrains/intellij-community/blob/125ade59d8bc0f96547e3f6070ee3853dbaffa86/platform/core-api/src/com/intellij/psi/search/GlobalSearchScope.java#L35). I picked Signal-Android because of its size and it still uses AGP 8. Both this PR and the main branch generated the same baseline code smells (12,000+). I ran the following for each:
```
./gradlew detektPlayProdDebug -Dorg.gradle.internal.operations.trace=$PWD/trace --no-configuration-cache --no-build-cache --rerun-tasks
```

With this PR, the detekt task completes within ~1 minute vs 6 minutes with main.

PR:
<img width="800" src="https://github.com/user-attachments/assets/908ea1e3-8a52-4d24-ba47-b847cf8cd018" />

main:
<img width="800" src="https://github.com/user-attachments/assets/89251ec9-2f3a-4f53-9267-32f5d91ccc52" />

I also created a temp [repo](https://github.com/FletchMcKee/signal-detekt-proto) with these `.proto` files.