### PR TITLE
fix: increase test heap and add forkEvery for compile-test-snippets OOM

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -23,7 +23,12 @@ tasks.withType<Test>().configureEach {
     val compileTestSnippets = providers.gradleProperty("compile-test-snippets").orNull.toBoolean()
     systemProperty("compile-test-snippets", compileTestSnippets)
 
-    maxHeapSize = "3g"
+    if (compileTestSnippets) {
+        maxHeapSize = "4g"
+        forkEvery = 200
+    } else {
+        maxHeapSize = "3g"
+    }
 
     testLogging {
         // set options for log level LIFECYCLE


### PR DESCRIPTION
## Summary

- The `compile-test-snippets` CI job has been consistently failing with `OutOfMemoryError: Java heap space` in `:detekt-rules-style:test` since ~March 3
- Root cause: each `lint()` call with `compile-test-snippets=true` creates a full `buildStandaloneAnalysisAPISession`. With 900+ lint calls in the style rules tests, LL FIR sessions accumulate memory beyond the 3GB heap limit
- Fix: when `compile-test-snippets` is enabled, increase `maxHeapSize` from 3GB to 4GB and set `forkEvery=200` to periodically restart the test JVM, preventing unbounded memory growth

## Test plan

- [x] Verified build compiles with `compile-test-snippets=true`
- [x] Verified build compiles without the flag (normal mode unchanged)
- [ ] CI `compile-test-snippets` job should pass

🤖 Generated with [Claude Code](https://claude.ai/code)