### PR TITLE
[Generator] The --config flag value should be a directory or it shouldn't exist

### DIFF
--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
@@ -74,7 +74,9 @@ class GeneratorArgs {
 
     class DirectoryValidator : IValueValidator<Path> {
         override fun validate(name: String, value: Path) {
-            if (!value.isDirectory()) throw ParameterException("Value passed to $name must be a directory.")
+            if (value.exists() && !value.isDirectory()) {
+                throw ParameterException("Value passed to $name must be a directory.")
+            }
         }
     }
 }


### PR DESCRIPTION
Right now this is not a problem because `detekt-core/src/main/resources` always exist. But I'm working on #5855 and that's not going to be always the case.

The actual code already create the intermediate dirs so there is no need to any other change.