### PR TITLE
Less verbose generator

### DIFF
--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/DetektPrinter.kt
@@ -9,14 +9,15 @@ import dev.detekt.generator.printer.RuleSetPagePrinter
 import dev.detekt.generator.printer.defaultconfig.ConfigPrinter
 import dev.detekt.generator.printer.defaultconfig.printRuleSetPage
 import dev.detekt.utils.yaml
+import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.io.path.Path
 
-class DetektPrinter(private val documentationPath: Path?, private val configPath: Path?) {
+class DetektPrinter(private val documentationPath: Path?, private val configPath: Path?, outPrinter: PrintStream) {
 
-    private val markdownWriter = MarkdownWriter(System.out)
-    private val yamlWriter = YamlWriter(System.out)
-    private val propertiesWriter = PropertiesWriter(System.out)
+    private val markdownWriter = MarkdownWriter(outPrinter)
+    private val yamlWriter = YamlWriter(outPrinter)
+    private val propertiesWriter = PropertiesWriter(outPrinter)
 
     fun print(pages: List<RuleSetPage>) {
         if (documentationPath != null) {

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/DetektPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/DetektPrinter.kt
@@ -7,13 +7,14 @@ import dev.detekt.generator.out.YamlWriter
 import dev.detekt.generator.printer.DeprecatedPrinter
 import dev.detekt.generator.printer.RuleSetPagePrinter
 import dev.detekt.generator.printer.defaultconfig.ConfigPrinter
+import java.io.PrintStream
 import java.nio.file.Path
 
-class DetektPrinter(private val documentationPath: Path?, private val configPath: Path?) {
+class DetektPrinter(private val documentationPath: Path?, private val configPath: Path?, outPrinter: PrintStream) {
 
-    private val markdownEnhancedWriter = MarkdownEnhancedWriter(System.out)
-    private val yamlWriter = YamlWriter(System.out)
-    private val propertiesWriter = PropertiesWriter(System.out)
+    private val markdownEnhancedWriter = MarkdownEnhancedWriter(outPrinter)
+    private val yamlWriter = YamlWriter(outPrinter)
+    private val propertiesWriter = PropertiesWriter(outPrinter)
 
     fun print(pages: List<RuleSetPage>) {
         if (documentationPath != null) {

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
@@ -18,7 +18,7 @@ class Generator(
     private val outPrinter: PrintStream = System.out,
 ) {
     private val collector = DetektCollector(textReplacements)
-    private val printer = DetektPrinter(documentationPath, configPath)
+    private val printer = DetektPrinter(documentationPath, configPath, outPrinter)
 
     fun execute() {
         val time = measureTime {

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
@@ -15,7 +15,7 @@ class Generator(
     private val textReplacements: Map<String, String>,
     documentationPath: Path?,
     configPath: Path?,
-    private val outPrinter: PrintStream = System.out,
+    private val outPrinter: PrintStream,
 ) {
     private val collector = DetektCollector(textReplacements)
     private val printer = DetektPrinter(documentationPath, configPath, outPrinter)

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
@@ -14,7 +14,7 @@ class Generator(
     private val inputPaths: List<Path>,
     documentationPath: Path?,
     configPath: Path?,
-    private val outPrinter: PrintStream = System.out,
+    private val outPrinter: PrintStream,
 ) {
     private val collector = DetektCollector()
     private val printer = DetektPrinter(documentationPath, configPath, outPrinter)

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Generator.kt
@@ -17,7 +17,7 @@ class Generator(
     private val outPrinter: PrintStream = System.out,
 ) {
     private val collector = DetektCollector()
-    private val printer = DetektPrinter(documentationPath, configPath)
+    private val printer = DetektPrinter(documentationPath, configPath, outPrinter)
 
     fun execute() {
         val time = measureTime {

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
@@ -60,6 +60,12 @@ class GeneratorArgs {
     )
     var textReplacements: Map<String, String> = mutableMapOf()
 
+    @Parameter(
+        names = ["--debug"],
+        description = "Prints extra information about the execution."
+    )
+    var debug: Boolean = false
+
     class PathSplitter : IParameterSplitter {
         override fun split(value: String): List<String> = value.split(',', ';')
     }

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/GeneratorArgs.kt
@@ -51,6 +51,12 @@ class GeneratorArgs {
     )
     var generateCustomRuleConfig: Boolean = false
 
+    @Parameter(
+        names = ["--debug"],
+        description = "Prints extra information about the execution."
+    )
+    var debug: Boolean = false
+
     class PathSplitter : IParameterSplitter {
         override fun split(value: String): List<String> = value.split(',', ';')
     }

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Main.kt
@@ -3,6 +3,8 @@
 package dev.detekt.generator
 
 import com.beust.jcommander.JCommander
+import java.io.OutputStream
+import java.io.PrintStream
 import kotlin.system.exitProcess
 
 @Suppress("detekt.SpreadOperator")
@@ -21,6 +23,7 @@ fun main(args: Array<String>) {
         textReplacements = options.textReplacements,
         documentationPath = options.documentationPath,
         configPath = options.configPath,
+        outPrinter = if (options.debug) System.out else NullPrintStream
     )
     if (options.generateCustomRuleConfig) {
         generator.executeCustomRuleConfig()
@@ -28,3 +31,11 @@ fun main(args: Array<String>) {
         generator.execute()
     }
 }
+
+private object NullPrintStream : PrintStream(
+    object : OutputStream() {
+        override fun write(b: Int) {
+            // no-op
+        }
+    }
+)

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/Main.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/Main.kt
@@ -3,6 +3,8 @@
 package dev.detekt.generator
 
 import com.beust.jcommander.JCommander
+import java.io.OutputStream
+import java.io.PrintStream
 import kotlin.system.exitProcess
 
 @Suppress("detekt.SpreadOperator")
@@ -20,6 +22,7 @@ fun main(args: Array<String>) {
         inputPaths = options.inputPath,
         documentationPath = options.documentationPath,
         configPath = options.configPath,
+        outPrinter = if (options.debug) System.out else NullPrintStream
     )
     if (options.generateCustomRuleConfig) {
         generator.executeCustomRuleConfig()
@@ -27,3 +30,11 @@ fun main(args: Array<String>) {
         generator.execute()
     }
 }
+
+private object NullPrintStream : PrintStream(
+    object : OutputStream() {
+        override fun write(b: Int) {
+            // no-op
+        }
+    }
+)


### PR DESCRIPTION
Right now `detekt-generator` cli is verbose:

```
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/comments.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/complexity.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/coroutines.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/empty-blocks.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/exceptions.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/ktlint.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/libraries.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/naming.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/performance.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/potential-bugs.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/ruleauthors.md
Wrote: /Users/brais.gabin/Workspace/detekt/website/docs/rules/style.md
Wrote: /Users/brais.gabin/Workspace/detekt/detekt-core/src/main/resources/default-detekt-config.yml
Wrote: /Users/brais.gabin/Workspace/detekt/detekt-core/src/main/resources/deprecation.properties
Wrote: ../detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
Wrote: ../detekt-rules-libraries/src/main/resources/config/config.yml
Wrote: ../detekt-rules-ruleauthors/src/main/resources/config/config.yml

Generated all detekt documentation in 1.568045458s.
```

At least it is only print in one task. But once #5855 is fixed it will be executed ~10 times so it is too noisy. This PR fixes that, the output is only shown if someone executes the `cli` with the `--debug` flag. And, by default, we are not going to make that.

This is a draft because this nosie also show that fixing #5855 may make the full compilation a bit slower. I want to keep the noise there until #5855 is merged and we agree that #5855 is worth even with that slowdown.