### PR TITLE
Make `KotlinAnalysisApiEngine` `AutoCloseable`

### DIFF
--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     testImplementation(projects.detektReportCheckstyle)
     testImplementation(projects.detektReportSarif)
     testImplementation(projects.detektTest)
+    testImplementation(projects.detektTestJunit)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.classgraph)

--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.core.suppressors
 
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.compileContentForTest
 import dev.detekt.tooling.api.AnalysisMode
@@ -284,7 +285,8 @@ class AnnotationSuppressorSpec {
     }
 
     @Nested
-    inner class `Full Qualified names` {
+    @KotlinAnalysisApiEngineTest
+    inner class `Full Qualified names`(val analysisApiEngine: KotlinAnalysisApiEngine) {
         val composableFiles = listOf(
             """
                 package androidx.compose.runtime
@@ -312,7 +314,7 @@ class AnnotationSuppressorSpec {
             fun getFile() =
                 listOf(
                     Arguments.of(compileContentForTest(code), AnalysisMode.light),
-                    Arguments.of(KotlinAnalysisApiEngine.compile(code, composableFiles), AnalysisMode.full),
+                    Arguments.of(analysisApiEngine.compile(code, composableFiles), AnalysisMode.full),
                 )
 
             @ParameterizedTest
@@ -402,7 +404,7 @@ class AnnotationSuppressorSpec {
                 AnalysisMode.full,
             )!!
 
-            val root = KotlinAnalysisApiEngine.compile(
+            val root = analysisApiEngine.compile(
                 """
                     package foo.bar
                     
@@ -423,7 +425,7 @@ class AnnotationSuppressorSpec {
                 AnalysisMode.full,
             )!!
 
-            val root = KotlinAnalysisApiEngine.compile(
+            val root = analysisApiEngine.compile(
                 """
                     package foo.bar
                     
@@ -444,7 +446,7 @@ class AnnotationSuppressorSpec {
                 AnalysisMode.full,
             )!!
 
-            val root = KotlinAnalysisApiEngine.compile(
+            val root = analysisApiEngine.compile(
                 """
                     package foo.bar
                     
@@ -486,13 +488,14 @@ class AnnotationSuppressorSpec {
         """.trimIndent()
 
         @Test
-        fun `suppress if it has parameters with type solving`() {
+        @KotlinAnalysisApiEngineTest
+        fun `suppress if it has parameters with type solving`(analysisApiEngine: KotlinAnalysisApiEngine) {
             val suppressor = annotationSuppressorFactory(
                 buildRule("ignoreAnnotated" to listOf("Preview")),
                 AnalysisMode.full,
             )!!
 
-            val root = KotlinAnalysisApiEngine.compile(code, composableFiles)
+            val root = analysisApiEngine.compile(code, composableFiles)
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
             assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.psi
 
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -12,14 +13,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvFileSource
 
-class AnnotationExcluderSpec {
+@KotlinAnalysisApiEngineTest
+class AnnotationExcluderSpec(val analysisApiEngine: KotlinAnalysisApiEngine) {
 
     @ParameterizedTest(
         name = "Given {0} is excluded when the {1} is found then the excluder returns {2} without Analysis API"
     )
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases`(exclusion: String, annotation: String, shouldExclude: Boolean) {
-        val (file, ktAnnotation) = createKtFile(annotation, enableAnalysisApi = false)
+        val (file, ktAnnotation) = analysisApiEngine.createKtFile(annotation, enableAnalysisApi = false)
         val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), false)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
@@ -30,7 +32,7 @@ class AnnotationExcluderSpec {
     )
     @CsvFileSource(resources = ["/annotation_excluder.csv"])
     fun `all cases - AnalysisAPI`(exclusion: String, annotation: String, shouldExclude: Boolean) {
-        val (file, ktAnnotation) = createKtFile(annotation, enableAnalysisApi = true)
+        val (file, ktAnnotation) = analysisApiEngine.createKtFile(annotation, enableAnalysisApi = true)
         val excluder = AnnotationExcluder(file, listOf(exclusion.toRegex()), true)
 
         assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isEqualTo(shouldExclude)
@@ -40,7 +42,7 @@ class AnnotationExcluderSpec {
     inner class `special cases` {
         @Test
         fun `should not exclude when the annotation was not found`() {
-            val (file, ktAnnotation) = createKtFile("@Component", enableAnalysisApi = false)
+            val (file, ktAnnotation) = analysisApiEngine.createKtFile("@Component", enableAnalysisApi = false)
             val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -48,7 +50,7 @@ class AnnotationExcluderSpec {
 
         @Test
         fun `should not exclude when no annotations should be excluded`() {
-            val (file, ktAnnotation) = createKtFile("@Component", enableAnalysisApi = false)
+            val (file, ktAnnotation) = analysisApiEngine.createKtFile("@Component", enableAnalysisApi = false)
             val excluder = AnnotationExcluder(file, emptyList(), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -56,7 +58,7 @@ class AnnotationExcluderSpec {
 
         @Test
         fun `should also exclude an annotation that is not imported`() {
-            val (file, ktAnnotation) = createKtFile("@SinceKotlin", enableAnalysisApi = false)
+            val (file, ktAnnotation) = analysisApiEngine.createKtFile("@SinceKotlin", enableAnalysisApi = false)
             val excluder = AnnotationExcluder(file, listOf("SinceKotlin".toRegex()), false)
 
             assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
@@ -71,7 +73,7 @@ class AnnotationExcluderSpec {
 
             @Test
             fun `incorrect without Analysis API`() {
-                val (file, ktAnnotation) = createKtFile("@Deprecated", enableAnalysisApi = false)
+                val (file, ktAnnotation) = analysisApiEngine.createKtFile("@Deprecated", enableAnalysisApi = false)
                 val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), false)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isTrue()
@@ -79,7 +81,7 @@ class AnnotationExcluderSpec {
 
             @Test
             fun `correct with Analysis API`() {
-                val (file, ktAnnotation) = createKtFile("@Deprecated(\"\")", enableAnalysisApi = true)
+                val (file, ktAnnotation) = analysisApiEngine.createKtFile("@Deprecated(\"\")", enableAnalysisApi = true)
                 val excluder = AnnotationExcluder(file, listOf("foo\\.Deprecated".toRegex()), true)
 
                 assertThat(excluder.shouldExclude(listOf(ktAnnotation))).isFalse()
@@ -114,7 +116,7 @@ class AnnotationExcluderSpec {
             @Test
             @Disabled("This should be doable but it's not imlemented yet")
             fun `correct with Analysis API`() {
-                val file = KotlinAnalysisApiEngine.compile(code, listOf(helloWorldAnnotationsCode))
+                val file = analysisApiEngine.compile(code, listOf(helloWorldAnnotationsCode))
                 val ktAnnotation = file.annotationEntry()
                 val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), true)
 
@@ -153,7 +155,7 @@ class AnnotationExcluderSpec {
 
             @Test
             fun `correct with Analysis API`() {
-                val file = KotlinAnalysisApiEngine.compile(file, listOf(helloWorldAnnotationsKtFile))
+                val file = analysisApiEngine.compile(file, listOf(helloWorldAnnotationsKtFile))
                 val ktAnnotation = file.annotationEntry()
                 val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), true)
 
@@ -167,7 +169,10 @@ class AnnotationExcluderSpec {
     }
 }
 
-private fun createKtFile(annotation: String, enableAnalysisApi: Boolean): Pair<KtFile, KtAnnotationEntry> {
+private fun KotlinAnalysisApiEngine.createKtFile(
+    annotation: String,
+    enableAnalysisApi: Boolean,
+): Pair<KtFile, KtAnnotationEntry> {
     val code = """
         package foo
         
@@ -178,7 +183,7 @@ private fun createKtFile(annotation: String, enableAnalysisApi: Boolean): Pair<K
         fun function() = Unit
     """.trimIndent()
     val file = if (enableAnalysisApi) {
-        KotlinAnalysisApiEngine.compile(
+        compile(
             code,
             listOf(
                 """

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/FunctionMatcherSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/FunctionMatcherSpec.kt
@@ -1,6 +1,8 @@
 package dev.detekt.psi
 
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
+import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.KotlinEnvironmentContainer
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -16,7 +18,11 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 
 @KotlinCoreEnvironmentTest
-class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
+@KotlinAnalysisApiEngineTest
+class FunctionMatcherSpec(
+    private val env: KotlinEnvironmentContainer,
+    private val analysisApiEngine: KotlinAnalysisApiEngine,
+) {
 
     @TestFactory
     @Suppress("LongMethod")
@@ -104,7 +110,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -122,7 +128,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString without package`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code, false)
+            val function = buildKtFunction(env, analysisApiEngine, code, false)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -140,7 +146,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString()`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString()")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -158,7 +164,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(kotlin#String)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(kotlin.String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -176,7 +182,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(vararg kotlin#String)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(vararg kotlin.String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -194,7 +200,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(kotlin#Int)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(kotlin.Int)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -212,7 +218,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(kotlin#String, kotlin#Int)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(kotlin.String, kotlin.Int)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -230,7 +236,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(String)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -248,7 +254,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun compare(hello: String, world: Int) = Unit',  false",
         )
         fun `When toString(String) without package`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code, false)
+            val function = buildKtFunction(env, analysisApiEngine, code, false)
             val methodSignature = FunctionMatcher.fromFunctionSignature("toString(String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -263,7 +269,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "fun foo(a: (Int) -> Unit) {},         false",
         )
         fun `When foo(() - kotlin#String)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo(() -> kotlin.String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -278,7 +284,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "fun foo(a: (Int) -> Unit) {},         true",
         )
         fun `When foo((kotlin#String) - Unit)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo((kotlin.String) -> Unit)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -293,7 +299,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun foo(a: String, ba: Int) {}', false",
         )
         fun `When foo(kotlin#String)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo(kotlin.String)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -308,7 +314,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun foo(a: String, ba: Int) {}', true",
         )
         fun `When foo(kotlin#String, kotlin#Int)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo(kotlin.String, kotlin.Int)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -323,7 +329,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
             "'fun <T, U> U.foo(a: T) {}',          false",
         )
         fun `When foo(T, U)`(code: String, result: Boolean) {
-            val function = buildKtFunction(env, code)
+            val function = buildKtFunction(env, analysisApiEngine, code)
             val methodSignature = FunctionMatcher.fromFunctionSignature("foo(T, U)")
             assertThat(methodSignature.match(function, fullAnalysis = true)).isEqualTo(result)
         }
@@ -364,6 +370,7 @@ class FunctionMatcherSpec(private val env: KotlinEnvironmentContainer) {
                     }
                 """.trimIndent(),
                 env,
+                analysisApiEngine,
             )
             val function = ktFile.findChildByClass(KtClass::class.java)!!
                 .findFunctionByName("bar") as KtNamedFunction
@@ -382,6 +389,7 @@ private class TestCase(
 
 private fun buildKtFunction(
     environment: KotlinEnvironmentContainer,
+    kotlinAnalysisApiEngine: KotlinAnalysisApiEngine,
     code: String,
     includePackage: Boolean = true,
 ): KtNamedFunction {
@@ -390,7 +398,8 @@ private fun buildKtFunction(
             ${if (includePackage) "package io.github.detekt" else ""}
             $code
         """.trimIndent(),
-        environment
+        environment,
+        kotlinAnalysisApiEngine,
     )
     return ktFile.findChildByClass(KtNamedFunction::class.java)!!
 }

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/TypeUtilsSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/TypeUtilsSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.psi
 
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtClass
@@ -9,14 +10,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
-internal class TypeUtilsSpec {
+@KotlinAnalysisApiEngineTest
+internal class TypeUtilsSpec(val analysisApiEngine: KotlinAnalysisApiEngine) {
     @Test
     fun `TypeUtils#isNullable returns true for expression that can be null`() {
         val code = """
             var a: Int? = null
             val b = a
         """.trimIndent()
-        val file = KotlinAnalysisApiEngine.compile(code)
+        val file = analysisApiEngine.compile(code)
         val expression = file.children.filterIsInstance<KtProperty>().last().initializer!!
 
         assertThat(expression.isNullable(false)).isTrue()
@@ -35,7 +37,7 @@ internal class TypeUtilsSpec {
             var a: Int? = null
             $codeToTest
         """.trimIndent()
-        val file = KotlinAnalysisApiEngine.compile(code)
+        val file = analysisApiEngine.compile(code)
         val expression = file.children.filterIsInstance<KtProperty>().last().initializer!!
 
         assertThat(expression.isNullable(false)).isFalse()
@@ -48,7 +50,7 @@ internal class TypeUtilsSpec {
                 val f = javaClass.simpleName
             }
         """.trimIndent()
-        val file = KotlinAnalysisApiEngine.compile(code)
+        val file = analysisApiEngine.compile(code)
         val expression = file
             .children
             .filterIsInstance<KtClass>()

--- a/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
+++ b/detekt-rules-coroutines/src/test/kotlin/dev/detekt/rules/coroutines/CoroutineLaunchedInTestWithoutRunTestSpec.kt
@@ -1,9 +1,11 @@
 package dev.detekt.rules.coroutines
 
 import dev.detekt.api.Config
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.location
+import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.KotlinEnvironmentContainer
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -307,7 +309,8 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinEnvironme
     }
 
     @Test
-    fun `FunTraverseHelper correctly caches explored functions states`() {
+    @KotlinAnalysisApiEngineTest
+    fun `FunTraverseHelper correctly caches explored functions states`(analysisApiEngine: KotlinAnalysisApiEngine) {
         val subject = FunCoroutineLaunchesTraverseHelper()
 
         val code = """
@@ -344,7 +347,7 @@ class CoroutineLaunchedInTestWithoutRunTestSpec(private val env: KotlinEnvironme
             }
         """.trimIndent()
 
-        val ktFile = compileContentForTest(code, env)
+        val ktFile = compileContentForTest(code, env, analysisApiEngine)
 
         val namedFunctions = ktFile
             .collectDescendantsOfType<KtNamedFunction>()

--- a/detekt-test-junit/api/detekt-test-junit.api
+++ b/detekt-test-junit/api/detekt-test-junit.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class dev/detekt/test/junit/KotlinAnalysisApiEngineTest : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class dev/detekt/test/junit/KotlinCoreEnvironmentTest : java/lang/annotation/Annotation {
 	public abstract fun additionalJavaSourcePaths ()[Ljava/lang/String;
 }

--- a/detekt-test-junit/src/main/kotlin/dev/detekt/test/junit/KotlinAnalysisApiEngineTest.kt
+++ b/detekt-test-junit/src/main/kotlin/dev/detekt/test/junit/KotlinAnalysisApiEngineTest.kt
@@ -1,0 +1,43 @@
+package dev.detekt.test.junit
+
+import dev.detekt.test.utils.KotlinAnalysisApiEngine
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+import java.lang.AutoCloseable
+
+/**
+ * TODO
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@ExtendWith(KotlinAnalysisApiEngineResolver::class)
+annotation class KotlinAnalysisApiEngineTest
+
+internal class KotlinAnalysisApiEngineResolver : ParameterResolver {
+    override fun supportsParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext): Boolean =
+        parameterContext.parameter.type == KotlinAnalysisApiEngine::class.java
+
+    override fun resolveParameter(parameterContext: ParameterContext, extensionContext: ExtensionContext) =
+        extensionContext.getStore(NAMESPACE)
+            .getOrComputeIfAbsent(
+                KEY,
+                { _ -> CloseableWrapper(KotlinAnalysisApiEngine()) },
+                CloseableWrapper::class.java
+            )
+            .resource as KotlinAnalysisApiEngine
+
+    companion object {
+        private val NAMESPACE = ExtensionContext.Namespace.create("KotlinAnalysisApiEngine")
+        private const val KEY = "KotlinAnalysisApiEngine"
+    }
+}
+
+private class CloseableWrapper<T : AutoCloseable>(val resource: T) :
+    ExtensionContext.Store.CloseableResource,
+    AutoCloseable {
+    override fun close() {
+        resource.close()
+    }
+}

--- a/detekt-test-junit/src/test/kotlin/dev/detekt/test/junit/KotlinEnvironmentTestSetupTests.kt
+++ b/detekt-test-junit/src/test/kotlin/dev/detekt/test/junit/KotlinEnvironmentTestSetupTests.kt
@@ -1,11 +1,16 @@
 package dev.detekt.test.junit
 
+import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.KotlinEnvironmentContainer
 import dev.detekt.test.utils.compileContentForTest
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
-class CompileWithSourcesTest(private val environment: KotlinEnvironmentContainer) {
+@KotlinAnalysisApiEngineTest
+class CompileWithSourcesTest(
+    private val environment: KotlinEnvironmentContainer,
+    private val analysisApiEngine: KotlinAnalysisApiEngine,
+) {
     @Test
     fun `can compile snippet with test resources`() {
         val content = $$"""
@@ -18,12 +23,16 @@ class CompileWithSourcesTest(private val environment: KotlinEnvironmentContainer
             }
         """.trimIndent()
 
-        compileContentForTest(content, environment)
+        compileContentForTest(content, environment, analysisApiEngine)
     }
 }
 
 @KotlinCoreEnvironmentTest
-class CompileWithThirdPartyLib(private val environment: KotlinEnvironmentContainer) {
+@KotlinAnalysisApiEngineTest
+class CompileWithThirdPartyLib(
+    private val environment: KotlinEnvironmentContainer,
+    private val analysisApiEngine: KotlinAnalysisApiEngine,
+) {
     @Test
     fun `can compile snippet with junit5 api`() {
         val content = """
@@ -38,14 +47,16 @@ class CompileWithThirdPartyLib(private val environment: KotlinEnvironmentContain
             }
         """.trimIndent()
 
-        compileContentForTest(content, environment)
+        compileContentForTest(content, environment, analysisApiEngine)
     }
 }
 
-@KotlinCoreEnvironmentTest(
-    additionalJavaSourcePaths = ["java"],
-)
-class CompileWithBoth(private val environment: KotlinEnvironmentContainer) {
+@KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
+@KotlinAnalysisApiEngineTest
+class CompileWithBoth(
+    private val environment: KotlinEnvironmentContainer,
+    private val analysisApiEngine: KotlinAnalysisApiEngine,
+) {
     @Test
     fun `can compile snippet with external library and test resources`() {
         val content = """
@@ -63,6 +74,6 @@ class CompileWithBoth(private val environment: KotlinEnvironmentContainer) {
             }
         """.trimIndent()
 
-        compileContentForTest(content, environment)
+        compileContentForTest(content, environment, analysisApiEngine)
     }
 }

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -1,14 +1,15 @@
 public final class dev/detekt/test/utils/CompileExtensionsKt {
-	public static final fun compileContentForTest (Ljava/lang/String;Ldev/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static final fun compileContentForTest (Ljava/lang/String;Ldev/detekt/test/utils/KotlinEnvironmentContainer;Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static final fun compileContentForTest (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static final fun compileContentForTest (Ljava/lang/String;Ljava/nio/file/Path;)Lorg/jetbrains/kotlin/psi/KtFile;
-	public static synthetic fun compileContentForTest$default (Ljava/lang/String;Ldev/detekt/test/utils/KotlinEnvironmentContainer;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static synthetic fun compileContentForTest$default (Ljava/lang/String;Ldev/detekt/test/utils/KotlinEnvironmentContainer;Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static synthetic fun compileContentForTest$default (Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static final fun compileForTest (Ljava/nio/file/Path;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
-public final class dev/detekt/test/utils/KotlinAnalysisApiEngine {
-	public static final field INSTANCE Ldev/detekt/test/utils/KotlinAnalysisApiEngine;
+public final class dev/detekt/test/utils/KotlinAnalysisApiEngine : java/lang/AutoCloseable {
+	public fun <init> ()V
+	public fun close ()V
 	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Lorg/jetbrains/kotlin/psi/KtFile;
 	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 }

--- a/detekt-test-utils/build.gradle.kts
+++ b/detekt-test-utils/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(libs.kotlin.scriptingJvm)
 
     testImplementation(libs.assertj.core)
+    testImplementation(projects.detektTestJunit)
 }
 
 kotlin {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
@@ -22,13 +22,14 @@ fun compileContentForTest(@Language("kotlin") content: String, filename: String 
 fun compileContentForTest(
     @Language("kotlin") content: String,
     environment: KotlinEnvironmentContainer,
+    kotlinAnalysisApiEngine: KotlinAnalysisApiEngine,
     filename: String = "Test.kt",
 ): KtFile {
     require('/' !in filename && '\\' !in filename) {
         "filename must be a file name only and not contain any path elements"
     }
 
-    return KotlinAnalysisApiEngine.compile(
+    return kotlinAnalysisApiEngine.compile(
         code = content,
         javaSourceRoots = environment.javaSourceRoots,
         jvmClasspathRoots = environment.jvmClasspathRoots,

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.diagnostics.PsiDiagnosticUtils
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
+import java.lang.AutoCloseable
 import java.nio.file.Path
 import kotlin.io.path.Path
 
@@ -27,10 +28,11 @@ import kotlin.io.path.Path
  * The object to use the Kotlin Analysis API for code compilation.
  */
 @OptIn(KaExperimentalApi::class)
-object KotlinAnalysisApiEngine {
+class KotlinAnalysisApiEngine : AutoCloseable {
     private val targetPlatform = JvmPlatforms.defaultJvmPlatform
     private val configuration = CompilerConfiguration()
     private val target = KaCompilerTarget.Jvm(isTestMode = false, compiledClassHandler = null, debuggerExtension = null)
+    private val disposable = Disposer.newDisposable()
 
     /**
      * Compiles a given code string using Kotlin's Analysis API.
@@ -46,8 +48,6 @@ object KotlinAnalysisApiEngine {
             listOf(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath()),
         allowCompilationErrors: Boolean = false,
     ): KtFile {
-        val disposable = Disposer.newDisposable()
-
         @OptIn(KaImplementationDetail::class, KaPlatformInterface::class)
         val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
@@ -85,36 +85,36 @@ object KotlinAnalysisApiEngine {
             }
         }
 
-        try {
-            val file = session.modulesWithFiles.values.flatten().single { it.name == "dummy.kt" } as KtFile
+        val file = session.modulesWithFiles.values.flatten().single { it.name == "dummy.kt" } as KtFile
 
-            analyze(file) {
-                val result = compile(file, configuration, target) {
-                    it.severity != KaSeverity.ERROR
-                }
-
-                if (result is KaCompilationResult.Failure) {
-                    val errors = result.errors.joinToString("\n") {
-                        if (it is KaDiagnosticWithPsi<*>) {
-                            val lineAndColumn = PsiDiagnosticUtils.offsetToLineAndColumn(
-                                it.psi.containingFile.viewProvider.document,
-                                it.psi.textOffset
-                            )
-                            "${it.severity.name} ${it.defaultMessage} (${it.psi.containingFile.name}:${lineAndColumn.line}:${lineAndColumn.column})"
-                        } else {
-                            "${it.severity.name} ${it.defaultMessage}"
-                        }
-                    }
-
-                    if (!allowCompilationErrors) {
-                        error(errors)
-                    }
-                }
+        analyze(file) {
+            val result = compile(file, configuration, target) {
+                it.severity != KaSeverity.ERROR
             }
 
-            return file
-        } finally {
-            disposable.dispose()
+            if (result is KaCompilationResult.Failure) {
+                val errors = result.errors.joinToString("\n") {
+                    if (it is KaDiagnosticWithPsi<*>) {
+                        val lineAndColumn = PsiDiagnosticUtils.offsetToLineAndColumn(
+                            it.psi.containingFile.viewProvider.document,
+                            it.psi.textOffset
+                        )
+                        "${it.severity.name} ${it.defaultMessage} (${it.psi.containingFile.name}:${lineAndColumn.line}:${lineAndColumn.column})"
+                    } else {
+                        "${it.severity.name} ${it.defaultMessage}"
+                    }
+                }
+
+                if (!allowCompilationErrors) {
+                    error(errors)
+                }
+            }
         }
+
+        return file
+    }
+
+    override fun close() {
+        Disposer.dispose(disposable)
     }
 }

--- a/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
+++ b/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
@@ -1,11 +1,13 @@
 package dev.detekt.test.utils
 
+import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.File
 
-class KotlinAnalysisApiEngineTest {
+@KotlinAnalysisApiEngineTest
+class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine) {
 
     @Test
     fun `can compile a valid script`() {
@@ -14,7 +16,7 @@ class KotlinAnalysisApiEngineTest {
             
             class A
         """.trimIndent()
-        KotlinAnalysisApiEngine.compile(code)
+        analysisApiEngine.compile(code)
     }
 
     @Test
@@ -24,7 +26,7 @@ class KotlinAnalysisApiEngineTest {
             
             val unknownType: UnknownType
         """.trimIndent()
-        assertThatThrownBy { KotlinAnalysisApiEngine.compile(invalidCode) }
+        assertThatThrownBy { analysisApiEngine.compile(invalidCode) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 
@@ -38,7 +40,7 @@ class KotlinAnalysisApiEngineTest {
             }
         """.trimIndent()
 
-        KotlinAnalysisApiEngine.compile(validCode)
+        analysisApiEngine.compile(validCode)
 
         val codeWithMissingImport = """
             fun useRandom() {
@@ -46,7 +48,7 @@ class KotlinAnalysisApiEngineTest {
             }
         """.trimIndent()
 
-        assertThatThrownBy { KotlinAnalysisApiEngine.compile(codeWithMissingImport) }
+        assertThatThrownBy { analysisApiEngine.compile(codeWithMissingImport) }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("ERROR Unresolved reference 'Random'. (dummy.kt:2:5)")
     }
@@ -58,7 +60,7 @@ class KotlinAnalysisApiEngineTest {
             
             class A
         """.trimIndent()
-        KotlinAnalysisApiEngine.compile(code)
+        analysisApiEngine.compile(code)
     }
 
     @RepeatedTest(10)
@@ -68,7 +70,7 @@ class KotlinAnalysisApiEngineTest {
             
             val unknownType: UnknownType
         """.trimIndent()
-        assertThatThrownBy { KotlinAnalysisApiEngine.compile(invalidCode) }
+        assertThatThrownBy { analysisApiEngine.compile(invalidCode) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 
@@ -89,7 +91,7 @@ class KotlinAnalysisApiEngineTest {
         """.trimIndent()
 
         val junitApiJar = File(Test::class.java.protectionDomain.codeSource.location.path).toPath()
-        KotlinAnalysisApiEngine.compile(
+        analysisApiEngine.compile(
             code = code,
             jvmClasspathRoots = listOf(junitApiJar)
         )
@@ -111,7 +113,7 @@ class KotlinAnalysisApiEngineTest {
             }
         """.trimIndent()
 
-        assertThatThrownBy { KotlinAnalysisApiEngine.compile(code) }
+        assertThatThrownBy { analysisApiEngine.compile(code) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 }

--- a/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
@@ -30,7 +30,9 @@ fun Rule.lint(
     }
     if (compile && shouldCompileTestSnippets) {
         try {
-            KotlinAnalysisApiEngine.compile(content, jvmClasspathRoots = createEnvironment().jvmClasspathRoots)
+            KotlinAnalysisApiEngine().use {
+                it.compile(content, jvmClasspathRoots = createEnvironment().jvmClasspathRoots)
+            }
         } catch (ex: RuntimeException) {
             if (!ex.isNoMatchingOutputFiles()) throw ex
         }
@@ -45,16 +47,17 @@ fun <T> T.lintWithContext(
     @Language("kotlin") vararg dependencyContents: String,
     allowCompilationErrors: Boolean = false,
     languageVersionSettings: LanguageVersionSettings = LanguageVersionSettingsImpl.DEFAULT,
-): List<Finding> where T : Rule, T : RequiresAnalysisApi {
-    val ktFile = KotlinAnalysisApiEngine.compile(
-        code = content,
-        dependencyCodes = dependencyContents.toList(),
-        javaSourceRoots = environment.javaSourceRoots,
-        jvmClasspathRoots = environment.jvmClasspathRoots,
-        allowCompilationErrors = allowCompilationErrors
-    )
-    return visitFile(ktFile, languageVersionSettings).filterSuppressed(this)
-}
+): List<Finding> where T : Rule, T : RequiresAnalysisApi =
+    KotlinAnalysisApiEngine().use {
+        val ktFile = it.compile(
+            code = content,
+            dependencyCodes = dependencyContents.toList(),
+            javaSourceRoots = environment.javaSourceRoots,
+            jvmClasspathRoots = environment.jvmClasspathRoots,
+            allowCompilationErrors = allowCompilationErrors
+        )
+        visitFile(ktFile, languageVersionSettings).filterSuppressed(this)
+    }
 
 fun Rule.lint(
     ktFile: KtFile,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,7 @@ android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "
 
 # This represents the oldest JUnit version supported by detekt-test-junit.
 # This should only be updated when updating the minimum version supported by detekt-test-junit.
-junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.0.0" }
+junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.1.0" }
 
 # This represents the oldest Kotlin version that is supported by detekt's Gradle plugin.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.


### PR DESCRIPTION
Based on @FletchMcKee's [comment](https://github.com/detekt/detekt/pull/9125#issuecomment-4041116940)

We weren't closing the `AnalysisAPISession` properly. To make that possible I made `KotlinAnalysisApiEngine` `AutoCloseable` and now it's a `class` instead of an `object`.

I created `@KotlinAnalysisApiEngineTest`. With this JUnit extension you can inject a `KotlinAnalysisApiEngine` and JUnit closes it for you. To made that I had to upgrade our minimum JUnit supported version from 5.0 to 5.1.

I'm not 100% sure if this is how the final API should look like but at least we aren't leaking memory.