### PR TITLE
`YamlConfig.load` returns `YamlConfig` instead of `Config`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
@@ -26,7 +26,7 @@ class YamlConfig internal constructor(
 ) : Config,
     ValidatableConfiguration {
 
-    override fun subConfig(key: String): Config {
+    override fun subConfig(key: String): YamlConfig {
         @Suppress("UNCHECKED_CAST")
         val subProperties = properties.getOrElse(key) { emptyMap<String, Any>() } as Map<String, Any>
         return YamlConfig(
@@ -69,7 +69,7 @@ class YamlConfig internal constructor(
         /**
          * Factory method to load a yaml configuration. Given path must exist and point to a readable file.
          */
-        fun load(path: Path): Config {
+        fun load(path: Path): YamlConfig {
             require(path.exists()) { "Configuration does not exist: $path" }
             require(path.isRegularFile()) { "Configuration must be a file: $path" }
             require(path.isReadable()) { "Configuration must be readable: $path" }
@@ -82,7 +82,7 @@ class YamlConfig internal constructor(
          *
          * Note the reader will be consumed and closed.
          */
-        fun load(reader: Reader): Config =
+        fun load(reader: Reader): YamlConfig =
             reader.buffered().use { bufferedReader ->
                 val map: Map<*, *>? = try {
                     createYamlLoad().loadFromReader(bufferedReader) as Map<*, *>?

--- a/detekt-core/src/test/kotlin/dev/detekt/core/AnalyzerSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/AnalyzerSpec.kt
@@ -487,4 +487,4 @@ internal fun createRuleDescriptor(provider: (Config) -> Rule, config: Config) =
 // The @receiver:Language("yaml") does nothing because of this bug on IntelliJ
 // https://youtrack.jetbrains.com/issue/KTIJ-5643/Language-injection-does-not-work-for-extension-receivers
 private fun @receiver:Language("yaml") String.toConfig(vararg subConfigs: String): Config =
-    subConfigs.fold(yamlConfigFromContent(this)) { acc, key -> acc.subConfig(key) }
+    subConfigs.fold(yamlConfigFromContent(this) as Config) { acc, key -> acc.subConfig(key) }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/YamlConfigUtils.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/YamlConfigUtils.kt
@@ -1,12 +1,11 @@
 package dev.detekt.core
 
-import dev.detekt.api.Config
 import dev.detekt.core.config.YamlConfig
 import dev.detekt.test.utils.resource
 import dev.detekt.utils.openSafeStream
 import org.intellij.lang.annotations.Language
 import java.io.StringReader
 
-fun yamlConfig(name: String): Config = resource(name).toURL().openSafeStream().reader().use(YamlConfig::load)
+fun yamlConfig(name: String): YamlConfig = resource(name).toURL().openSafeStream().reader().use(YamlConfig::load)
 
-fun yamlConfigFromContent(@Language("yaml") content: String): Config = StringReader(content).use(YamlConfig::load)
+fun yamlConfigFromContent(@Language("yaml") content: String): YamlConfig = StringReader(content).use(YamlConfig::load)

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DetektYmlConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DetektYmlConfigSpec.kt
@@ -19,7 +19,7 @@ class DetektYmlConfigSpec {
 
     private val config: YamlConfig = YamlConfig.load(
         Path("../detekt-core/src/main/resources/default-detekt-config.yml").absolute()
-    ) as YamlConfig
+    )
 
     private fun ruleSetsNamesToPackage(): List<Arguments> =
         listOf(

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/DeprecatedPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/DeprecatedPropertiesConfigValidatorSpec.kt
@@ -1,7 +1,6 @@
 package dev.detekt.core.config.validation
 
 import dev.detekt.api.Notification
-import dev.detekt.core.config.YamlConfig
 import dev.detekt.core.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -27,7 +26,7 @@ internal class DeprecatedPropertiesConfigValidatorSpec {
                   FunctionParameterNaming:
                     ignoreOverriddenFunctions: ''
             """.trimIndent()
-        ) as YamlConfig
+        )
 
         val result = subject.validate(config, settings)
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
@@ -3,7 +3,6 @@ package dev.detekt.core.config.validation
 import dev.detekt.api.Config
 import dev.detekt.api.Notification
 import dev.detekt.core.config.CompositeConfig
-import dev.detekt.core.config.YamlConfig
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.nestedConfigurationExpected
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.propertyDoesNotExists
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.unexpectedNestedConfiguration
@@ -23,7 +22,7 @@ internal class InvalidPropertiesConfigValidatorSpec {
             description = "use xxx instead"
         )
     )
-    private val baseline = yamlConfig("config_validation/baseline.yml") as YamlConfig
+    private val baseline = yamlConfig("config_validation/baseline.yml")
     private val defaultExcludePatterns = DEFAULT_PROPERTY_EXCLUDES.toSet()
     private val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, defaultExcludePatterns)
 
@@ -77,7 +76,7 @@ internal class InvalidPropertiesConfigValidatorSpec {
     fun `reports unexpected nested configs`() {
         // note that the baseline config is now the config to validate
         val subject = InvalidPropertiesConfigValidator(
-            yamlConfig("config_validation/no-value.yml") as YamlConfig,
+            yamlConfig("config_validation/no-value.yml"),
             deprecatedProperties,
             defaultExcludePatterns
         )
@@ -157,18 +156,14 @@ internal class InvalidPropertiesConfigValidatorSpec {
         fun `does not report any complexity properties`() {
             val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, patterns("complexity"))
 
-            val result = subject.validate(
-                yamlConfig("config_validation/other-nested-property-names.yml") as YamlConfig,
-            )
+            val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
             assertThat(result).isEmpty()
         }
 
         @Test
         fun `does not report 'complexity_LargeClass_howMany'`() {
             val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, patterns(".*>.*>howMany"))
-            val result = subject.validate(
-                yamlConfig("config_validation/other-nested-property-names.yml") as YamlConfig
-            )
+            val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
 
             assertThat(result).contains(
                 propertyDoesNotExists("complexity>LongLongMethod"),
@@ -186,9 +181,7 @@ internal class InvalidPropertiesConfigValidatorSpec {
         @DisplayName("does not report .*>InnerMap")
         fun `does not report innerMap`() {
             val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, patterns(".*>InnerMap"))
-            val result = subject.validate(
-                yamlConfig("config_validation/other-nested-property-names.yml") as YamlConfig
-            )
+            val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
 
             assertThat(result).contains(
                 propertyDoesNotExists("complexity>LargeClass>howMany"),

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/MissingRulesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/MissingRulesConfigValidatorSpec.kt
@@ -1,13 +1,12 @@
 package dev.detekt.core.config.validation
 
-import dev.detekt.core.config.YamlConfig
 import dev.detekt.core.yamlConfig
 import dev.detekt.core.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class MissingRulesConfigValidatorSpec {
-    private val baseline = yamlConfig("config_validation/baseline.yml") as YamlConfig
+    private val baseline = yamlConfig("config_validation/baseline.yml")
     private val subject = MissingRulesConfigValidator(baseline, DEFAULT_PROPERTY_EXCLUDES.toSet())
 
     @Test


### PR DESCRIPTION
It has not sense to hide the type of `YamlConfig.load` for multiple reasons:

- It's in core, no one depend on us and if they do that's their problem. (aka it is internal API)
- To call `YamlConfig.load` you need to know that `YamlConfig` exists so why to hide it?
- On the tests we are casting the output of `YamlConfig.load` to `YamlConfig`. That have no sense, we can directly define the correct type and avoid foot guns.

(same applies for `YamlConfig.subConfig`)