### PR TITLE
[Tests] Don't check compilation errors with `compile-test-snippets=false`

### DIFF
--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -10,8 +10,8 @@ public final class dev/detekt/test/utils/CompileExtensionsKt {
 public final class dev/detekt/test/utils/KotlinAnalysisApiEngine : java/lang/AutoCloseable {
 	public fun <init> ()V
 	public fun close ()V
-	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lorg/jetbrains/kotlin/psi/KtFile;
-	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
 public final class dev/detekt/test/utils/KotlinEnvironmentContainer {
@@ -23,10 +23,6 @@ public final class dev/detekt/test/utils/KotlinEnvironmentContainer {
 public final class dev/detekt/test/utils/KotlinEnvironmentContainerKt {
 	public static final fun createEnvironment (Ljava/util/List;)Ldev/detekt/test/utils/KotlinEnvironmentContainer;
 	public static synthetic fun createEnvironment$default (Ljava/util/List;ILjava/lang/Object;)Ldev/detekt/test/utils/KotlinEnvironmentContainer;
-}
-
-public final class dev/detekt/test/utils/KtFileKt {
-	public static final fun checkNoCompilationErrors (Lorg/jetbrains/kotlin/psi/KtFile;)V
 }
 
 public final class dev/detekt/test/utils/NullPrintStream : java/io/PrintStream {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
@@ -14,6 +14,10 @@ import java.lang.AutoCloseable
 import java.nio.file.Path
 import kotlin.io.path.Path
 
+private val shouldCompileTestSnippets by lazy(LazyThreadSafetyMode.NONE) {
+    System.getProperty("compile-test-snippets", "false")!!.toBoolean()
+}
+
 /**
  * The object to use the Kotlin Analysis API for code compilation.
  */
@@ -32,6 +36,7 @@ class KotlinAnalysisApiEngine : AutoCloseable {
         javaSourceRoots: List<Path> = emptyList(),
         jvmClasspathRoots: List<Path> =
             listOf(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath()),
+        allowCompilationErrors: Boolean = shouldCompileTestSnippets,
     ): KtFile {
         val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
@@ -69,7 +74,9 @@ class KotlinAnalysisApiEngine : AutoCloseable {
             }
         }
 
-        return session.modulesWithFiles.values.flatten().single { it.name == "dummy.kt" } as KtFile
+        return (session.modulesWithFiles.values.flatten().single { it.name == "dummy.kt" } as KtFile).also {
+            if (!allowCompilationErrors) it.checkNoCompilationErrors()
+        }
     }
 
     override fun close() {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KtFile.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KtFile.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtFile
  * Throw an exception if the KtFile had any compilation error
  */
 @OptIn(KaExperimentalApi::class)
-fun KtFile.checkNoCompilationErrors() {
+internal fun KtFile.checkNoCompilationErrors() {
     val file = this
     analyze(file) {
         val result = compile(

--- a/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
+++ b/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
@@ -16,8 +16,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             
             class A
         """.trimIndent()
-        analysisApiEngine.compile(code)
-            .checkNoCompilationErrors()
+        analysisApiEngine.compile(code, allowCompilationErrors = false)
     }
 
     @Test
@@ -27,7 +26,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             
             val unknownType: UnknownType
         """.trimIndent()
-        assertThatThrownBy { analysisApiEngine.compile(invalidCode).checkNoCompilationErrors() }
+        assertThatThrownBy { analysisApiEngine.compile(invalidCode, allowCompilationErrors = false) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 
@@ -41,8 +40,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             }
         """.trimIndent()
 
-        analysisApiEngine.compile(validCode)
-            .checkNoCompilationErrors()
+        analysisApiEngine.compile(validCode, allowCompilationErrors = false)
 
         val codeWithMissingImport = """
             fun useRandom() {
@@ -50,7 +48,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             }
         """.trimIndent()
 
-        assertThatThrownBy { analysisApiEngine.compile(codeWithMissingImport).checkNoCompilationErrors() }
+        assertThatThrownBy { analysisApiEngine.compile(codeWithMissingImport, allowCompilationErrors = false) }
             .isInstanceOf(IllegalStateException::class.java)
             .hasMessage("ERROR Unresolved reference 'Random'. (dummy.kt:2:5)")
     }
@@ -62,7 +60,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             
             class A
         """.trimIndent()
-        analysisApiEngine.compile(code).checkNoCompilationErrors()
+        analysisApiEngine.compile(code, allowCompilationErrors = false)
     }
 
     @RepeatedTest(10)
@@ -72,7 +70,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             
             val unknownType: UnknownType
         """.trimIndent()
-        assertThatThrownBy { analysisApiEngine.compile(invalidCode).checkNoCompilationErrors() }
+        assertThatThrownBy { analysisApiEngine.compile(invalidCode, allowCompilationErrors = false) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 
@@ -93,8 +91,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
         """.trimIndent()
 
         val junitApiJar = File(Test::class.java.protectionDomain.codeSource.location.path).toPath()
-        analysisApiEngine.compile(code = code, jvmClasspathRoots = listOf(junitApiJar))
-            .checkNoCompilationErrors()
+        analysisApiEngine.compile(code = code, jvmClasspathRoots = listOf(junitApiJar), allowCompilationErrors = false)
     }
 
     @Test
@@ -113,7 +110,7 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
             }
         """.trimIndent()
 
-        assertThatThrownBy { analysisApiEngine.compile(code).checkNoCompilationErrors() }
+        assertThatThrownBy { analysisApiEngine.compile(code, allowCompilationErrors = false) }
             .isInstanceOf(IllegalStateException::class.java)
     }
 }

--- a/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
@@ -6,7 +6,6 @@ import dev.detekt.api.Rule
 import dev.detekt.api.RuleName
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.KotlinEnvironmentContainer
-import dev.detekt.test.utils.checkNoCompilationErrors
 import dev.detekt.test.utils.compileContentForTest
 import dev.detekt.test.utils.createEnvironment
 import org.intellij.lang.annotations.Language
@@ -32,8 +31,11 @@ fun Rule.lint(
     if (compile && shouldCompileTestSnippets) {
         try {
             KotlinAnalysisApiEngine().use {
-                it.compile(content, jvmClasspathRoots = createEnvironment().jvmClasspathRoots)
-                    .checkNoCompilationErrors()
+                it.compile(
+                    content,
+                    jvmClasspathRoots = createEnvironment().jvmClasspathRoots,
+                    allowCompilationErrors = false,
+                )
             }
         } catch (ex: RuntimeException) {
             if (!ex.isNoMatchingOutputFiles()) throw ex
@@ -56,8 +58,8 @@ fun <T> T.lintWithContext(
             dependencyCodes = dependencyContents.toList(),
             javaSourceRoots = environment.javaSourceRoots,
             jvmClasspathRoots = environment.jvmClasspathRoots,
+            allowCompilationErrors = allowCompilationErrors || !shouldCompileTestSnippets
         )
-        if (!allowCompilationErrors && shouldCompileTestSnippets) ktFile.checkNoCompilationErrors()
         visitFile(ktFile, languageVersionSettings).filterSuppressed(this)
     }
 


### PR DESCRIPTION
We have `compile-test-snippets` property to disable compilation checks of our test snippets when we run `test` by default. We only check if they compile correctly with `compile-test-snippets=true`. With AA that wasn't true anymore. We were always checking. This PR brings back that old behavior with huge time saves.

The numbers (time in ms):

| | main before autoclose  (#9144) | current main | this PR |
| --- | ---: | ---: | ---: |
| `./gw test` | 239,717 | 219,082 | 158,105 |
| `./gw :detekt-rules-style:test` | 71,501 | 52,289 | 31,731 |

So we are talking that now `:detekt-rules-style:test` is 66% faster than yesterday and running ALL our tests is 34% faster (keep in mind that we have a lot of tests that doesn't benefit from this change, only the rule modules do).

---

Note: This PR also disables the checking when `allowCompilationErrors = true`. Because we were paying the time to check if there were errors just to ignore them.