### PR TITLE
Allow single-argument Boolean generics in `NonBooleanPropertyPrefixedWithIs`

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -364,6 +364,7 @@ naming:
     active: true
   NonBooleanPropertyPrefixedWithIs:
     active: false
+    allowSingleTypedGenerics: false
   ObjectPropertyNaming:
     active: true
     aliases: ['ObjectPropertyName']

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -20,8 +20,9 @@ import org.jetbrains.kotlin.psi.KtProperty
  * Reports when property with 'is' prefix doesn't have a boolean type.
  * Please check [chapter 8.3.2 on the Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
  *
- * When `allowSingleTypedGenerics` is enabled, single-argument generic wrappers over a non-nullable
- * boolean (e.g. `StateFlow<Boolean>`) are also accepted.
+ * When `allowSingleTypedGenerics` is enabled, single-argument generic wrappers over a boolean (e.g.
+ * `StateFlow<Boolean>`, `StateFlow<Boolean?>`, `StateFlow<Boolean>?`) are also accepted, as well as lambda return
+ * types of such wrappers (e.g. `() -> StateFlow<Boolean>`).
  *
  * <noncompliant>
  * val isEnabled: Int = 500
@@ -74,12 +75,11 @@ class NonBooleanPropertyPrefixedWithIs(config: Config) :
                 val type = rawType.let { (it as? KaFunctionType)?.returnType ?: it }
                 val typeFqName = type.symbol?.classId?.asSingleFqName() ?: return
                 if (typeFqName !in booleanTypes) {
-                    // Function types are not exempted: () -> StateFlow<Boolean> is not boolean-like
-                    if (allowSingleTypedGenerics && rawType !is KaFunctionType) {
+                    if (allowSingleTypedGenerics) {
                         val typeArgs = (type as? KaClassType)?.typeArguments
                         val argType = typeArgs?.singleOrNull()?.type
                         val argFqName = argType?.symbol?.classId?.asSingleFqName()
-                        if (argFqName in booleanTypes && argType?.isMarkedNullable == false && !type.isMarkedNullable) {
+                        if (argFqName in booleanTypes) {
                             return
                         }
                     }

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -1,11 +1,14 @@
 package dev.detekt.rules.naming
 
 import dev.detekt.api.Config
+import dev.detekt.api.Configuration
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
+import dev.detekt.api.config
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.name.FqName
@@ -17,12 +20,20 @@ import org.jetbrains.kotlin.psi.KtProperty
  * Reports when property with 'is' prefix doesn't have a boolean type.
  * Please check [chapter 8.3.2 on the Java Language Specification](https://docs.oracle.com/javase/specs/jls/se8/html/jls-8.html#jls-8.3.2)
  *
+ * When `allowSingleTypedGenerics` is enabled, single-argument generic wrappers over a non-nullable
+ * boolean (e.g. `StateFlow<Boolean>`) are also accepted.
+ *
  * <noncompliant>
  * val isEnabled: Int = 500
+ *
+ * val isLoading: SomeGenericType<Boolean, Int>
  * </noncompliant>
  *
  * <compliant>
  * val isEnabled: Boolean = false
+
+ * // allowSingleTypedGenerics = true
+ * val isLoading: StateFlow<Boolean> = MutableStateFlow(false)
  * </compliant>
  */
 class NonBooleanPropertyPrefixedWithIs(config: Config) :
@@ -31,6 +42,9 @@ class NonBooleanPropertyPrefixedWithIs(config: Config) :
         "Only boolean property names can start with `is` prefix."
     ),
     RequiresAnalysisApi {
+
+    @Configuration("Treat generic types using Boolean as their single argument as boolean-like")
+    private val allowSingleTypedGenerics: Boolean by config(false)
 
     private val booleanTypes = listOf(
         "kotlin.Boolean",
@@ -56,9 +70,19 @@ class NonBooleanPropertyPrefixedWithIs(config: Config) :
         val name = declaration.name ?: return
         if (name.startsWith("is") && name.getOrNull(2)?.isUpperCase() == true) {
             analyze(declaration) {
-                val type = declaration.returnType.let { (it as? KaFunctionType)?.returnType ?: it }
+                val rawType = declaration.returnType
+                val type = rawType.let { (it as? KaFunctionType)?.returnType ?: it }
                 val typeFqName = type.symbol?.classId?.asSingleFqName() ?: return
                 if (typeFqName !in booleanTypes) {
+                    // Function types are not exempted: () -> StateFlow<Boolean> is not boolean-like
+                    if (allowSingleTypedGenerics && rawType !is KaFunctionType) {
+                        val typeArgs = (type as? KaClassType)?.typeArguments
+                        val argType = typeArgs?.singleOrNull()?.type
+                        val argFqName = argType?.symbol?.classId?.asSingleFqName()
+                        if (argFqName in booleanTypes && argType?.isMarkedNullable == false && !type.isMarkedNullable) {
+                            return
+                        }
+                    }
                     report(declaration, name, typeFqName)
                 }
             }

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/NonBooleanPropertyPrefixedWithIs.kt
@@ -25,6 +25,7 @@ import org.jetbrains.kotlin.psi.KtProperty
  * types of such wrappers (e.g. `() -> StateFlow<Boolean>`).
  *
  * <noncompliant>
+ * // allowSingleTypedGenerics = false
  * val isEnabled: Int = 500
  *
  * val isLoading: SomeGenericType<Boolean, Int>

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -497,11 +497,11 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                 import kotlin.reflect.KProperty                
 
                 interface MutableState<T> {
-                    operator fun <T> getValue(thisRef: Any?, property: KProperty<*>): T = TODO("stub")
-                    operator fun <T> setValue(thisRef: Any?, property: KProperty<*>, value: T) = TODO("stub")
+                    operator fun getValue(thisObj: Any?, property: KProperty<*>): T { TODO() }
+                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: T) { TODO() }
                 }
-                
-                fun <T> mutableStateOf(value: T): MutableState<T> = TODO("stub")
+
+                fun <T> mutableStateOf(value: T): MutableState<T> { TODO("stub") }
 
                 class Foo {
                     // resolves to Boolean
@@ -519,8 +519,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                 import kotlin.reflect.KProperty                
 
                 interface Bar<A, B> {
-                    operator fun getValue(thisRef: Any?, property: KProperty<*>): B = TODO("stub")
-                    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: B) = TODO("stub")
+                    operator fun getValue(thisObj: Any?, property: KProperty<*>): B { TODO() }
+                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: B) { TODO() }
                 }
 
                 class Foo(bar: Bar<Int, Boolean>) {

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -344,8 +344,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
-                    val isBar: StateFlow<Boolean> 
+                interface Foo {
+                    val isBar: StateFlow<Boolean>
                 }
             """.trimIndent()
             assertThat(subject.lintWithContext(env, code))
@@ -357,8 +357,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
-                    val isBar: StateFlow<Boolean> 
+                interface Foo {
+                    val isBar: StateFlow<Boolean>
                 }
             """.trimIndent()
             assertThatFindings(code).isEmpty()
@@ -369,35 +369,35 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
-                    val isBar: StateFlow<String> 
+                interface Foo {
+                    val isBar: StateFlow<String>
                 }
             """.trimIndent()
             assertThatFindings(code).hasSize(1)
         }
 
         @Test
-        fun `report inner-nullable StateFlow boolean`() {
+        fun `don't report inner-nullable StateFlow boolean`() {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
-                    val isBar: StateFlow<Boolean?> 
+                interface Foo {
+                    val isBar: StateFlow<Boolean?>
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThatFindings(code).isEmpty()
         }
 
         @Test
-        fun `report outer-nullable StateFlow boolean`() {
+        fun `don't report outer-nullable StateFlow boolean`() {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
-                    val isBar: StateFlow<Boolean>? 
+                interface Foo {
+                    val isBar: StateFlow<Boolean>?
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThatFindings(code).isEmpty()
         }
 
         @Test
@@ -405,8 +405,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
             val code = """
                 interface DataProvider<A, B>
 
-                interface Foo { 
-                    val isBar: DataProvider<Boolean, Int> 
+                interface Foo {
+                    val isBar: DataProvider<Boolean, Int>
                 }
             """.trimIndent()
             assertThatFindings(code).hasSize(1)
@@ -419,8 +419,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
 
                 class BooleanProvider : DataProvider<Boolean>
 
-                interface Foo { 
-                    val isBar: BooleanProvider 
+                interface Foo {
+                    val isBar: BooleanProvider
                 }
             """.trimIndent()
             assertThatFindings(code).hasSize(1)
@@ -431,7 +431,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
             val code = """
                 import kotlinx.coroutines.flow.MutableStateFlow
 
-                class Foo { 
+                class Foo {
                     // no explicit type annotation
                     val isBar = MutableStateFlow(false)
 
@@ -443,15 +443,27 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
         }
 
         @Test
-        fun `report lambda returning single-arg generic`() {
+        fun `don't report lambda returning single-arg generic`() {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
-                interface Foo { 
+                interface Foo {
                     val isBar: () -> StateFlow<Boolean>
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `don't report lambda with parameter returning single-arg generic`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo {
+                    val isBar: (String) -> StateFlow<Boolean>
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
         }
 
         @Test
@@ -485,8 +497,8 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                 typealias BoolStateFlow = StateFlow<Boolean>
 
                 interface Foo {
-                    val isBar: BoolStateFlow                
-                } 
+                    val isBar: BoolStateFlow
+                }
             """.trimIndent()
             assertThatFindings(code).isEmpty()
         }
@@ -494,11 +506,11 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
         @Test
         fun `don't report property delegated to single-arg boolean generic`() {
             val code = """
-                import kotlin.reflect.KProperty                
+                import kotlin.reflect.KProperty
 
                 interface MutableState<T> {
-                    operator fun getValue(thisObj: Any?, property: KProperty<*>): T { TODO() }
-                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: T) { TODO() }
+                    operator fun getValue(thisObj: Any?, property: KProperty<*>): T
+                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: T)
                 }
 
                 fun <T> mutableStateOf(value: T): MutableState<T> { TODO("stub") }
@@ -516,11 +528,11 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
         @Test
         fun `don't report delegated property from multi-arg boolean generic`() {
             val code = """
-                import kotlin.reflect.KProperty                
+                import kotlin.reflect.KProperty
 
                 interface Bar<A, B> {
-                    operator fun getValue(thisObj: Any?, property: KProperty<*>): B { TODO() }
-                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: B) { TODO() }
+                    operator fun getValue(thisObj: Any?, property: KProperty<*>): B
+                    operator fun setValue(thisObj: Any?, property: KProperty<*>, value: B)
                 }
 
                 class Foo(bar: Bar<Int, Boolean>) {

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -1,10 +1,13 @@
 package dev.detekt.rules.naming
 
 import dev.detekt.api.Config
+import dev.detekt.test.TestConfig
+import dev.detekt.test.assertj.FindingsAssert
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
+import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -329,5 +332,206 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(findings).isEmpty()
         }
+    }
+
+    @Nested
+    inner class `boolean generics` {
+        private val allowSingleTypedGenerics =
+            NonBooleanPropertyPrefixedWithIs(TestConfig("allowSingleTypedGenerics" to true))
+
+        @Test
+        fun `report StateFlow boolean for default config`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: StateFlow<Boolean> 
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code))
+                .hasSize(1)
+        }
+
+        @Test
+        fun `dont report StateFlow boolean`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: StateFlow<Boolean> 
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `report StateFlow string`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: StateFlow<String> 
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `report inner-nullable StateFlow boolean`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: StateFlow<Boolean?> 
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `report outer-nullable StateFlow boolean`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: StateFlow<Boolean>? 
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `report multi-type generic`() {
+            val code = """
+                interface DataProvider<A, B>
+
+                interface Foo { 
+                    val isBar: DataProvider<Boolean, Int> 
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `report type inheriting from single-arg generic`() {
+            val code = """
+                interface DataProvider<A>
+
+                class BooleanProvider : DataProvider<Boolean>
+
+                interface Foo { 
+                    val isBar: BooleanProvider 
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `don't report inferred single-arg generic`() {
+            val code = """
+                import kotlinx.coroutines.flow.MutableStateFlow
+
+                class Foo { 
+                    // no explicit type annotation
+                    val isBar = MutableStateFlow(false)
+
+                    // with explicit type annotation
+                    val isBaz: MutableStateFlow<Boolean> = MutableStateFlow(true)
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `report lambda returning single-arg generic`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                interface Foo { 
+                    val isBar: () -> StateFlow<Boolean>
+                }
+            """.trimIndent()
+            assertThatFindings(code).hasSize(1)
+        }
+
+        @Test
+        fun `don't report AtomicBoolean in single-arg generic`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+                import java.util.concurrent.atomic.AtomicBoolean
+
+                interface Foo {
+                    val isBar: StateFlow<AtomicBoolean>
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `don't report single-arg generic as constructor param`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                class Foo(val isBar: StateFlow<Boolean>)
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `don't report typealias representing single-arg generic`() {
+            val code = """
+                import kotlinx.coroutines.flow.StateFlow
+
+                typealias BoolStateFlow = StateFlow<Boolean>
+
+                interface Foo {
+                    val isBar: BoolStateFlow                
+                } 
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `don't report property delegated to single-arg boolean generic`() {
+            val code = """
+                import kotlin.reflect.KProperty                
+
+                interface MutableState<T> {
+                    operator fun <T> getValue(thisRef: Any?, property: KProperty<*>): T = TODO("stub")
+                    operator fun <T> setValue(thisRef: Any?, property: KProperty<*>, value: T) = TODO("stub")
+                }
+                
+                fun <T> mutableStateOf(value: T): MutableState<T> = TODO("stub")
+
+                class Foo {
+                    // resolves to Boolean
+                    var isDelegatedBar by mutableStateOf(false)
+                    // resolves to MutableState<Boolean>
+                    var isDirectBar = mutableStateOf(false)
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        @Test
+        fun `don't report delegated property from multi-arg boolean generic`() {
+            val code = """
+                import kotlin.reflect.KProperty                
+
+                interface Bar<A, B> {
+                    operator fun getValue(thisRef: Any?, property: KProperty<*>): B = TODO("stub")
+                    operator fun setValue(thisRef: Any?, property: KProperty<*>, value: B) = TODO("stub")
+                }
+
+                class Foo(bar: Bar<Int, Boolean>) {
+                    // resolves to Boolean
+                    var isEnabled by bar
+                }
+            """.trimIndent()
+            assertThatFindings(code).isEmpty()
+        }
+
+        private fun assertThatFindings(@Language("kotlin") code: String): FindingsAssert =
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code))
     }
 }

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/NonBooleanPropertyWithPrefixIsSpec.kt
@@ -2,12 +2,10 @@ package dev.detekt.rules.naming
 
 import dev.detekt.api.Config
 import dev.detekt.test.TestConfig
-import dev.detekt.test.assertj.FindingsAssert
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
-import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -335,12 +333,12 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Nested
-    inner class `boolean generics` {
-        private val allowSingleTypedGenerics =
-            NonBooleanPropertyPrefixedWithIs(TestConfig("allowSingleTypedGenerics" to true))
+    inner class `allowSingleTypedGenerics = false` {
+        private val disallowSingleTypedGenerics =
+            NonBooleanPropertyPrefixedWithIs(TestConfig("allowSingleTypedGenerics" to false))
 
         @Test
-        fun `report StateFlow boolean for default config`() {
+        fun `report StateFlow boolean when allowSingleTypedGenerics is disabled`() {
             val code = """
                 import kotlinx.coroutines.flow.StateFlow
 
@@ -348,9 +346,15 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<Boolean>
                 }
             """.trimIndent()
-            assertThat(subject.lintWithContext(env, code))
+            assertThat(disallowSingleTypedGenerics.lintWithContext(env, code))
                 .hasSize(1)
         }
+    }
+
+    @Nested
+    inner class `allowSingleTypedGenerics = true` {
+        private val allowSingleTypedGenerics =
+            NonBooleanPropertyPrefixedWithIs(TestConfig("allowSingleTypedGenerics" to true))
 
         @Test
         fun `dont report StateFlow boolean`() {
@@ -361,7 +365,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<Boolean>
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -373,7 +377,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<String>
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -385,7 +389,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<Boolean?>
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -397,7 +401,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<Boolean>?
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -409,7 +413,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: DataProvider<Boolean, Int>
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -423,7 +427,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: BooleanProvider
                 }
             """.trimIndent()
-            assertThatFindings(code).hasSize(1)
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -439,7 +443,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBaz: MutableStateFlow<Boolean> = MutableStateFlow(true)
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -451,7 +455,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: () -> StateFlow<Boolean>
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -463,7 +467,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: (String) -> StateFlow<Boolean>
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -476,7 +480,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: StateFlow<AtomicBoolean>
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -486,7 +490,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
 
                 class Foo(val isBar: StateFlow<Boolean>)
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -500,7 +504,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     val isBar: BoolStateFlow
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -522,7 +526,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     var isDirectBar = mutableStateOf(false)
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -540,10 +544,7 @@ class NonBooleanPropertyWithPrefixIsSpec(val env: KotlinEnvironmentContainer) {
                     var isEnabled by bar
                 }
             """.trimIndent()
-            assertThatFindings(code).isEmpty()
+            assertThat(allowSingleTypedGenerics.lintWithContext(env, code)).isEmpty()
         }
-
-        private fun assertThatFindings(@Language("kotlin") code: String): FindingsAssert =
-            assertThat(allowSingleTypedGenerics.lintWithContext(env, code))
     }
 }


### PR DESCRIPTION
Closes #9172

Added a load of test cases, most of which are up to opinion. Let me know if you disagree with anything :+1: 