### PR TITLE
Enable ignorePropertyDeclaration and ignoreLocalVariableDeclaration by default for MagicNumber

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -676,8 +676,8 @@ style:
       - '1'
       - '2'
     ignoreHashCodeFunction: true
-    ignorePropertyDeclaration: false
-    ignoreLocalVariableDeclaration: false
+    ignorePropertyDeclaration: true
+    ignoreLocalVariableDeclaration: true
     ignoreConstantDeclaration: true
     ignoreCompanionObjectPropertyDeclaration: true
     ignoreAnnotation: false

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/MagicNumber.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/MagicNumber.kt
@@ -85,10 +85,10 @@ class MagicNumber(config: Config) :
     private val ignoreHashCodeFunction: Boolean by config(true)
 
     @Configuration("whether magic numbers in property declarations should be ignored")
-    private val ignorePropertyDeclaration: Boolean by config(false)
+    private val ignorePropertyDeclaration: Boolean by config(true)
 
     @Configuration("whether magic numbers in local variable declarations should be ignored")
-    private val ignoreLocalVariableDeclaration: Boolean by config(false)
+    private val ignoreLocalVariableDeclaration: Boolean by config(true)
 
     @Configuration("whether magic numbers in constant declarations should be ignored")
     private val ignoreConstantDeclaration: Boolean by config(true)


### PR DESCRIPTION
Changes the default values of `ignorePropertyDeclaration` and
`ignoreLocalVariableDeclaration` from `false` to `true` for the
MagicNumber rule, as discussed in #9126.

**Files changed:**
- `detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/MagicNumber.kt` (lines 88, 91): `config(false)` -> `config(true)`
- `detekt-core/src/main/resources/default-detekt-config.yml` (lines 679-680): `false` -> `true`

Property and local variable declarations like `val timeout = 30` are
common and readable without a named constant. The previous defaults
generated noise that pushed users to disable MagicNumber entirely.

Note: I did not have a local JDK to run `./gradlew generateDocumentation`
or the test suite. CI will verify the change, and I expect some test
expectations in MagicNumberSpec.kt may need updating for the new defaults.

Closes #9152

This contribution was developed with AI assistance (Claude Code).