### PR TITLE
Don't use paths to read files from `resources/`

### DIFF
--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DefaultDetektConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DefaultDetektConfigSpec.kt
@@ -1,13 +1,12 @@
 package dev.detekt.core.config
 
+import dev.detekt.utils.getSafeResourceAsStream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
-import kotlin.io.path.Path
-import kotlin.io.path.absolute
 
 class DefaultDetektConfigSpec {
 
@@ -18,7 +17,7 @@ class DefaultDetektConfigSpec {
     )
 
     private val config: YamlConfig = YamlConfig.load(
-        Path("../detekt-core/src/main/resources/default-detekt-config.yml").absolute()
+        DefaultDetektConfigSpec::class.java.getSafeResourceAsStream("/default-detekt-config.yml")!!.reader()
     )
 
     private fun ruleSetsNamesToPackage(): List<Arguments> =


### PR DESCRIPTION
Two changes in this PR:

- Rename `DetektYmlConfigSpec` to `DefaultDetektConfigSpec`. This class is only testing that `default-detekt-config.yml` is correct. The old name was a bit missleading to let you think that it was testing `YamlConfig`.
- Use `getSafeResourceAsStream` instead of hardcoding the path of a file inside the `resources/` folder.