### PR TITLE
Compiler plugin support for AA

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -195,6 +195,15 @@ class CliArgs {
     var classpath: List<Path> = emptyList()
 
     @Parameter(
+        names = ["--compiler-plugin-classpath"],
+        converter = PathConverter::class,
+        splitter = ClassPathSplitter::class,
+        validateValueWith = [PathValidator::class],
+        description = "Paths to Kotlin compiler plugin class files and jar files."
+    )
+    var compilerPluginClasspath: List<Path> = emptyList()
+
+    @Parameter(
         names = ["--api-version"],
         converter = ApiVersionConverter::class,
         description = "Kotlin API version used by the code under analysis. Some rules use this " +

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -80,6 +80,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             classpath = args.classpath
             jdkHome = args.jdkHome
             freeCompilerArgs = args.freeCompilerArgs
+            compilerPluginClasspath = args.compilerPluginClasspath
         }
     }
 }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -32,6 +32,7 @@ fun createCompilerConfiguration(
     jvmTarget: String,
     jdkHome: Path?,
     freeCompilerArgs: List<String>,
+    jvmCompilerArguments: K2JVMCompilerArguments,
     printStream: PrintStream,
 ): CompilerConfiguration {
     val javaFiles = pathsToAnalyze.flatMap { path ->
@@ -48,8 +49,6 @@ fun createCompilerConfiguration(
     }
 
     val classpathFiles = classpath.map(Path::toFile)
-
-    val jvmCompilerArguments = K2JVMCompilerArguments()
 
     val args = buildList {
         if (apiVersion != null) {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -11,12 +11,16 @@ import dev.detekt.tooling.api.spec.LoggingSpec
 import dev.detekt.tooling.api.spec.ProjectSpec
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.projectStructure.KaSourceModule
+import org.jetbrains.kotlin.analysis.api.standalone.StandaloneAnalysisAPISessionBuilder
 import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISession
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.config.kotlinSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.jvmClasspathRoots
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JvmTarget
@@ -29,6 +33,8 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.OutputStream
 import java.io.PrintStream
+import java.nio.file.Path
+import kotlin.collections.orEmpty
 import kotlin.io.path.Path
 
 interface EnvironmentAware {
@@ -45,15 +51,18 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
     // This lateinit var can be changed to val if https://github.com/JetBrains/kotlin/pull/5703 is merged
     private lateinit var sourceModule: KaSourceModule
 
+    private val jvmCompilerArguments = K2JVMCompilerArguments()
+
     private val configuration: CompilerConfiguration = createCompilerConfiguration(
-        projectSpec.inputPaths.toList(),
-        compilerSpec.classpath,
-        compilerSpec.apiVersion,
-        compilerSpec.languageVersion,
-        compilerSpec.jvmTarget,
-        compilerSpec.jdkHome,
-        compilerSpec.freeCompilerArgs,
-        printStream,
+        pathsToAnalyze = projectSpec.inputPaths.toList(),
+        classpath = compilerSpec.classpath,
+        apiVersion = compilerSpec.apiVersion,
+        languageVersion = compilerSpec.languageVersion,
+        jvmTarget = compilerSpec.jvmTarget,
+        jdkHome = compilerSpec.jdkHome,
+        freeCompilerArgs = compilerSpec.freeCompilerArgs,
+        jvmCompilerArguments = jvmCompilerArguments,
+        printStream = printStream,
     )
 
     private val disposable: Disposable = Disposer.newDisposable()
@@ -67,6 +76,13 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
 
     init {
         buildStandaloneAnalysisAPISession(disposable) {
+            loadCompilerPlugins(
+                sessionBuilder = this,
+                compilerConfiguration = configuration,
+                compilerPluginClasspath = compilerSpec.compilerPluginClasspath,
+                jvmCompilerArguments = jvmCompilerArguments,
+                parentDisposable = disposable,
+            )
             // Required for autocorrect support
             registerProjectService(TreeAspect::class.java)
             registerProjectService(PomModel::class.java, DetektPomModel(project))
@@ -148,4 +164,24 @@ private fun Appendable.asPrintStream(): PrintStream {
             }
         )
     }
+}
+
+private fun loadCompilerPlugins(
+    sessionBuilder: StandaloneAnalysisAPISessionBuilder,
+    compilerConfiguration: CompilerConfiguration,
+    compilerPluginClasspath: List<Path>,
+    jvmCompilerArguments: K2JVMCompilerArguments,
+    parentDisposable: Disposable,
+) {
+    if (compilerPluginClasspath.isEmpty()) return
+
+    PluginCliParser.loadPluginsSafe(
+        pluginClasspaths = compilerPluginClasspath.map(Path::toString),
+        pluginOptions = jvmCompilerArguments.pluginOptions?.asList().orEmpty(),
+        pluginConfigurations = jvmCompilerArguments.pluginConfigurations?.asList().orEmpty(),
+        pluginOrderConstraints = jvmCompilerArguments.pluginOrderConstraints?.asList().orEmpty(),
+        configuration = compilerConfiguration,
+        parentDisposable = parentDisposable,
+    ).takeIf { it == ExitCode.OK }
+        ?.also { sessionBuilder.registerCompilerPluginServices(compilerConfiguration) }
 }

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -8,6 +8,7 @@ public abstract class dev/detekt/gradle/Detekt : org/gradle/api/tasks/SourceTask
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getCompilerPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -39,6 +40,7 @@ public abstract class dev/detekt/gradle/DetektCreateBaselineTask : org/gradle/ap
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getCompilerPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -151,6 +151,7 @@ dependencies {
     testKitRuntimeOnly(libs.kotlin.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.builtInKotlin.plugin)
+    testKitRuntimeOnly(libs.kotlinx.serialization.gradle.plugin)
     testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle.plugin) {
         attributes {
             // Set this value to the minimum Gradle version tested in testKitGradleMinVersionRuntimeOnly source set

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
@@ -14,12 +14,14 @@ class JvmSpec {
             .withArguments("detektMain")
             .buildAndFail()
 
-        assertThat(result.output).contains("failed with 4 issues.")
+        assertThat(result.output).doesNotContain("unresolved reference")
+        assertThat(result.output).contains("failed with 5 issues.")
         assertThat(result.output.normalizePaths()).contains(
             "src/main/kotlin/Errors.kt:7:9 Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
             "src/main/kotlin/Errors.kt:12:16 Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
-            "src/main/kotlin/Caller.kt:5:18 The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in the detekt config. [ForbiddenMethodCall]",
-            "src/main/kotlin/Caller.kt:6:9 Callee()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
+            "src/main/kotlin/Caller.kt:7:18 The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in the detekt config. [ForbiddenMethodCall]",
+            "src/main/kotlin/Caller.kt:8:9 Callee()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
+            "src/main/kotlin/Caller.kt:9:9 Book.serializer()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
         )
     }
 

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -1,11 +1,16 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("dev.detekt")
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+detekt {
+    debug = true
 }
 
 tasks.detektMain {
@@ -21,4 +26,9 @@ kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
+    detektCompilerPlugin("org.jetbrains.kotlin:kotlin-serialization-compiler-plugin:${kotlin.coreLibrariesVersion}")
 }

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
@@ -1,8 +1,14 @@
 package jvm.src.main.kotlin
 
+import kotlinx.serialization.Serializable
+
 class Caller {
     fun method() {
         Callee().forbiddenMethod()
-        Callee()?.toString() // Callee class is excluded but AA still knows that Callee() returns non-nulltable
+        Callee()?.toString() // Callee class is excluded but AA still knows that Callee() returns non-nullable
+        Book.serializer()?.toString() // serializer() is created by compiler plugin but AA still knows that serializer() returns non-nullable
     }
 }
+
+@Serializable
+data class Book(val name: String, val author: String)

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -12,6 +12,7 @@ import dev.detekt.gradle.invoke.BaselineArgumentOrEmpty
 import dev.detekt.gradle.invoke.BuildUponDefaultConfigArgument
 import dev.detekt.gradle.invoke.ClasspathArgument
 import dev.detekt.gradle.invoke.CliArgument
+import dev.detekt.gradle.invoke.CompilerPluginClasspathArgument
 import dev.detekt.gradle.invoke.ConfigArgument
 import dev.detekt.gradle.invoke.CustomReportArgument
 import dev.detekt.gradle.invoke.DebugArgument
@@ -87,6 +88,10 @@ abstract class Detekt @Inject constructor(
     @get:Classpath
     @get:Optional
     abstract val classpath: ConfigurableFileCollection
+
+    @get:Classpath
+    @get:Optional
+    abstract val compilerPluginClasspath: ConfigurableFileCollection
 
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
@@ -174,6 +179,7 @@ abstract class Detekt @Inject constructor(
         get() = listOf(
             InputArgument(source),
             ClasspathArgument(classpath),
+            CompilerPluginClasspathArgument(compilerPluginClasspath),
             ApiVersionArgument(apiVersion.orNull),
             LanguageVersionArgument(languageVersion.orNull),
             JvmTargetArgument(jvmTarget.orNull),

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
@@ -8,6 +8,7 @@ import dev.detekt.gradle.invoke.BaselineArgument
 import dev.detekt.gradle.invoke.BuildUponDefaultConfigArgument
 import dev.detekt.gradle.invoke.ClasspathArgument
 import dev.detekt.gradle.invoke.CliArgument
+import dev.detekt.gradle.invoke.CompilerPluginClasspathArgument
 import dev.detekt.gradle.invoke.ConfigArgument
 import dev.detekt.gradle.invoke.CreateBaselineArgument
 import dev.detekt.gradle.invoke.DebugArgument
@@ -80,6 +81,10 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     @get:Classpath
     @get:Optional
     abstract val classpath: ConfigurableFileCollection
+
+    @get:Classpath
+    @get:Optional
+    abstract val compilerPluginClasspath: ConfigurableFileCollection
 
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
@@ -154,6 +159,7 @@ abstract class DetektCreateBaselineTask @Inject constructor(
         get() = listOf(
             CreateBaselineArgument,
             ClasspathArgument(classpath),
+            CompilerPluginClasspathArgument(compilerPluginClasspath),
             ApiVersionArgument(apiVersion.orNull),
             LanguageVersionArgument(languageVersion.orNull),
             JvmTargetArgument(jvmTarget.orNull),

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -23,6 +23,7 @@ private const val REPORT_PARAMETER = "--report"
 private const val GENERATE_CONFIG_PARAMETER = "--generate-config"
 private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
 private const val CLASSPATH_PARAMETER = "--classpath"
+private const val COMPILER_PLUGIN_CLASSPATH_PARAMETER = "--compiler-plugin-classpath"
 private const val API_VERSION_PARAMETER = "--api-version"
 private const val LANGUAGE_VERSION_PARAMETER = "--language-version"
 private const val JVM_TARGET_PARAMETER = "--jvm-target"
@@ -65,6 +66,18 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
             )
         } else {
             listOf(ANALYSIS_MODE, "light")
+        }
+}
+
+internal data class CompilerPluginClasspathArgument(val fileCollection: FileCollection) : CliArgument {
+    override fun toArgument() =
+        if (!fileCollection.isEmpty) {
+            listOf(
+                COMPILER_PLUGIN_CLASSPATH_PARAMETER,
+                fileCollection.files.filter(File::exists).joinToString(File.pathSeparator) { it.absolutePath },
+            )
+        } else {
+            emptyList()
         }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -9,7 +9,9 @@ import dev.detekt.gradle.internal.addVariantName
 import dev.detekt.gradle.internal.existingVariantOrBaseFile
 import dev.detekt.gradle.internal.setCreateBaselineTaskDefaults
 import dev.detekt.gradle.internal.setDetektTaskDefaults
+import dev.detekt.gradle.plugin.internal.declarableCompat
 import dev.detekt.gradle.plugin.internal.mapExplicitArgMode
+import dev.detekt.gradle.plugin.internal.resolvableCompat
 import dev.detekt.gradle.plugin.internal.rootProjectDirectoryCompat
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -66,6 +68,7 @@ class DetektBasePlugin : Plugin<Project> {
 
         project.setTaskDefaults(extension)
         project.registerSourceSetTasks(extension)
+        project.registerCompilerPluginConfigurations()
     }
 
     private fun Project.setTaskDefaults(extension: DetektExtension) {
@@ -122,6 +125,20 @@ class DetektBasePlugin : Plugin<Project> {
         }
     }
 
+    private fun Project.registerCompilerPluginConfigurations() {
+        val detektCompilerPlugin = configurations.declarableCompat(CONFIGURATION_DETEKT_COMPILER_PLUGIN) {
+            description = "Compiler plugins to load for detekt analysis."
+        }
+
+        configurations.resolvableCompat(
+            name = CONFIGURATION_DETEKT_COMPILER_PLUGIN_CLASSPATH,
+            declarable = detektCompilerPlugin,
+        ) {
+            isTransitive = false
+            description = "Resolved classpath of compiler plugins for detekt analysis."
+        }
+    }
+
     internal companion object {
         internal const val DETEKT_EXTENSION = "detekt"
         internal const val CONFIG_DIR_NAME = "config/detekt"
@@ -146,3 +163,5 @@ class DetektBasePlugin : Plugin<Project> {
 }
 
 internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"
+internal const val CONFIGURATION_DETEKT_COMPILER_PLUGIN = "detektCompilerPlugin"
+internal const val CONFIGURATION_DETEKT_COMPILER_PLUGIN_CLASSPATH = "detektCompilerPluginClasspath"

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
@@ -138,6 +138,9 @@ class DetektPlugin : Plugin<Project> {
         project.tasks.withType(Detekt::class.java).configureEach { task ->
             task.detektClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT))
             task.pluginClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT_PLUGINS))
+            task.compilerPluginClasspath.conventionCompat(
+                project.configurations.named(CONFIGURATION_DETEKT_COMPILER_PLUGIN_CLASSPATH)
+            )
             val reportName = if (task.name.startsWith(DETEKT_TASK_NAME) && task.name != DETEKT_TASK_NAME) {
                 task.name.removePrefix(DETEKT_TASK_NAME).decapitalize()
             } else {
@@ -164,6 +167,9 @@ class DetektPlugin : Plugin<Project> {
         project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach { task ->
             task.detektClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT))
             task.pluginClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT_PLUGINS))
+            task.compilerPluginClasspath.conventionCompat(
+                project.configurations.named(CONFIGURATION_DETEKT_COMPILER_PLUGIN_CLASSPATH)
+            )
         }
 
         project.tasks.withType(DetektGenerateConfigTask::class.java).configureEach { task ->

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/GradleCompat.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/GradleCompat.kt
@@ -1,7 +1,10 @@
 package dev.detekt.gradle.plugin.internal
 
 import org.gradle.api.GradleException
+import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ConfigurationContainer
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.Directory
 import org.gradle.api.tasks.VerificationException
@@ -36,4 +39,42 @@ internal inline fun verificationExceptionCompat(message: String, cause: Throwabl
         VerificationException(message, cause)
     } else {
         VerificationException(message)
+    }
+
+@Suppress("UnstableApiUsage")
+internal fun ConfigurationContainer.declarableCompat(
+    name: String,
+    configure: Configuration.() -> Unit = {},
+): NamedDomainObjectProvider<out Configuration> =
+    when {
+        GradleVersion.current() >= GradleVersion.version("8.5") -> dependencyScope(name, configure)
+
+        else -> register(name) { config ->
+            config.isCanBeResolved = false
+            config.isCanBeConsumed = false
+            configure(config)
+        }
+    }
+
+@Suppress("UnstableApiUsage")
+internal fun ConfigurationContainer.resolvableCompat(
+    name: String,
+    declarable: NamedDomainObjectProvider<out Configuration>,
+    configure: Configuration.() -> Unit = {},
+): NamedDomainObjectProvider<out Configuration> =
+    when {
+        GradleVersion.current() >= GradleVersion.version("8.5") -> resolvable(name) { config ->
+            config.extendsFrom(declarable.get())
+            configure(config)
+        }
+
+        else -> register(name) { config ->
+            config.extendsFrom(declarable.get())
+            if (GradleVersion.current() >= GradleVersion.version("8.2")) {
+                config.isCanBeDeclared = false
+            }
+            config.isCanBeResolved = true
+            config.isCanBeConsumed = false
+            configure(config)
+        }
     }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -104,6 +104,7 @@ public abstract interface class dev/detekt/tooling/api/spec/BaselineSpec {
 public abstract interface class dev/detekt/tooling/api/spec/CompilerSpec {
 	public abstract fun getApiVersion ()Ljava/lang/String;
 	public abstract fun getClasspath ()Ljava/util/List;
+	public abstract fun getCompilerPluginClasspath ()Ljava/util/List;
 	public abstract fun getFreeCompilerArgs ()Ljava/util/List;
 	public abstract fun getJdkHome ()Ljava/nio/file/Path;
 	public abstract fun getJvmTarget ()Ljava/lang/String;
@@ -242,12 +243,14 @@ public final class dev/detekt/tooling/dsl/CompilerSpecBuilder : dev/detekt/tooli
 	public synthetic fun build ()Ljava/lang/Object;
 	public final fun getApiVersion ()Ljava/lang/String;
 	public final fun getClasspath ()Ljava/util/List;
+	public final fun getCompilerPluginClasspath ()Ljava/util/List;
 	public final fun getFreeCompilerArgs ()Ljava/util/List;
 	public final fun getJdkHome ()Ljava/nio/file/Path;
 	public final fun getJvmTarget ()Ljava/lang/String;
 	public final fun getLanguageVersion ()Ljava/lang/String;
 	public final fun setApiVersion (Ljava/lang/String;)V
 	public final fun setClasspath (Ljava/util/List;)V
+	public final fun setCompilerPluginClasspath (Ljava/util/List;)V
 	public final fun setFreeCompilerArgs (Ljava/util/List;)V
 	public final fun setJdkHome (Ljava/nio/file/Path;)V
 	public final fun setJvmTarget (Ljava/lang/String;)V

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/CompilerSpec.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/CompilerSpec.kt
@@ -37,4 +37,9 @@ interface CompilerSpec {
      * Options to pass to the Kotlin compiler.
      */
     val freeCompilerArgs: List<String>
+
+    /**
+     * Paths to Kotlin compiler plugins class files and jars.
+     */
+    val compilerPluginClasspath: List<Path>
 }

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -12,9 +12,18 @@ class CompilerSpecBuilder : Builder<CompilerSpec> {
     var classpath: List<Path> = emptyList()
     var jdkHome: Path? = null
     var freeCompilerArgs: List<String> = emptyList()
+    var compilerPluginClasspath: List<Path> = emptyList()
 
     override fun build(): CompilerSpec =
-        CompilerModel(jvmTarget, languageVersion, apiVersion, classpath, jdkHome, freeCompilerArgs)
+        CompilerModel(
+            jvmTarget = jvmTarget,
+            languageVersion = languageVersion,
+            apiVersion = apiVersion,
+            classpath = classpath,
+            jdkHome = jdkHome,
+            freeCompilerArgs = freeCompilerArgs,
+            compilerPluginClasspath = compilerPluginClasspath,
+        )
 }
 
 private data class CompilerModel(
@@ -24,4 +33,5 @@ private data class CompilerModel(
     override val classpath: List<Path>,
     override val jdkHome: Path?,
     override val freeCompilerArgs: List<String>,
+    override val compilerPluginClasspath: List<Path>,
 ) : CompilerSpec

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.grad
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlinx-serialization-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 
 # This represents the oldest AGP 9 version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.


### PR DESCRIPTION
Closes #7531 

This is still a WIP, but opening as a Draft PR for some early feedback. I tried to figure out a way to get `KotlinTaskConfigs.pluginClasspath` to work, but it seems to be unusable for Detekt's purpose. Nearly all of Kotlin's common compiler plugins break the analysis engine since Kotlin exposes their `-embeddable` plugins through this field, and all of these embeddable compiler plugins relocate `com.intellij` to `org.jetbrains.kotlin.com.intellij`.

I got some hack approaches to work where I would create a `detachedConfiguration` and replace any `org.jetbrains.kotlin...-embeddable` plugins with their non-embeddable version, but this is obviously fragile and would be a future liability.

Creating a separate `detektCompilerPlugin` declarable configuration was the best approach I could think of. So for example, if a user was having issues with the kotlinx serialization compiler plugin like the one outlined in #7531, all they would have to do is add the following in the relevant project's dependencies block:

```gradle
dependencies {
  …
  detektCompilerPlugin(libs.kotlinx.serialization.compilerPlugin)
}
```
And add the non-embeddable compiler plugin to their libs.versions.toml:
```toml
# Use the kotlin version and not the kotlinxSerialization version
[libraries]
kotlinx-serialization-compilerPlugin = { module = "org.jetbrains.kotlin:kotlin-serialization-compiler-plugin", version.ref = "kotlin" }
```

While I would have liked to figure out a way to automate this from `KotlinTaskConfigs.pluginClasspath`, I do think this has several advantages:

- Users have to opt-in by adding `detektCompilerPlugin`s, so existing users shouldn't experience any change. The Detekt/CreateBaselineTask `compilerPluginClasspath` will be empty, so no attempt to call `PluginsCliParser.loadPluginsSafe` will be made.
- We avoid any ClassNotFoundException headaches with relocated embeddable plugins. 
- Users have flexibility to add/remove whichever compiler plugin they want. I have a number of projects with kotlinx serialization and compose, but I would probably only want this for compose.

I think this could especially be useful for Compose where existing rules could have type resolution of composable functions rather than relying on string-based annotation matching. For example, I made this throwaway method in one of my sample projects:
```kotlin
@Composable
private fun DetektUnusedSample(
  onClick: () -> Unit,
  content: @Composable () -> Unit,
) = Unit
```
And added a log in UnusedPrivateFunction to print a parameters `typeReference.type`, and this is the output without loading the compose compiler:
```console
DetektUnusedSample param=onClick type=() -> kotlin/Unit
DetektUnusedSample param=content type=() -> kotlin/Unit
```
Vs loading the compose compiler:
```console
DetektUnusedSample param=onClick type=() -> kotlin/Unit
DetektUnusedSample param=content type=@R|androidx/compose/runtime/Composable|()  androidx/compose/runtime/internal/ComposableFunction0<kotlin/Unit>
```

