### PR TITLE
Add support of `indent_style` in ktlint `Indention` rule

### DIFF
--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
@@ -69,7 +69,10 @@ abstract class KtlintRule(config: Config, description: String) : Rule(config, de
 
         usesEditorConfigProperties[CODE_STYLE_PROPERTY] = codeStyle
 
-        usesEditorConfigProperties[INDENT_STYLE_PROPERTY] = "space"
+        usesEditorConfigProperties[INDENT_STYLE_PROPERTY] = usesEditorConfigProperties.getOrDefault(
+            INDENT_STYLE_PROPERTY,
+            "space",
+        )
 
         val properties = buildMap {
             usesEditorConfigProperties.forEach { (editorConfigProperty, defaultValue) ->

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
@@ -2,6 +2,7 @@ package dev.detekt.rules.ktlintwrapper.wrappers
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
+import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule.Companion.INDENT_WHEN_ARROW_ON_NEW_LINE
 import dev.detekt.api.ActiveByDefault
@@ -23,12 +24,16 @@ class Indentation(config: Config) : KtlintRule(config, "Reports mis-indented cod
     @Configuration("indentation size")
     private val indentSize by config(4)
 
+    @Configuration("indentation style (space or tab)")
+    private val indentStyle by config("space")
+
     @Configuration("indent when arrow on new line")
     private val indentWhenArrowOnNewLine by config(false)
 
     override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
         mapOf(
             INDENT_SIZE_PROPERTY to indentSize.toString(),
+            INDENT_STYLE_PROPERTY to indentStyle,
             INDENT_WHEN_ARROW_ON_NEW_LINE to indentWhenArrowOnNewLine.toString(),
         )
 }

--- a/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
+++ b/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
@@ -140,6 +140,7 @@ ktlint:
     active: true
     autoCorrect: true
     indentSize: 4
+    indentStyle: 'space'
     indentWhenArrowOnNewLine: false
   Kdoc:
     active: true

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.rules.ktlintwrapper
 
 import dev.detekt.api.Config
+import dev.detekt.api.Finding
 import dev.detekt.rules.ktlintwrapper.wrappers.Indentation
 import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
@@ -44,6 +45,34 @@ class IndentationSpec {
             val config = TestConfig("indentSize" to 1)
             assertThat(Indentation(config).lint(code)).isEmpty()
         }
+
+        @Test
+        fun `does not report when using an indentation level config of 1 and style of tab`() {
+            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
+            val code = """
+                fun main() {
+                ${TAB}println()
+                }
+            """.trimIndent()
+            assertThat(Indentation(config).lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports usage of space when using an indentation level config of 1 and style of tab`() {
+            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
+            val code = """
+                fun main() {
+                  println()
+                }
+            """.trimIndent()
+            assertThat(Indentation(config).lint(code))
+                .hasSize(2)
+                .extracting<String>(Finding::message)
+                .contains(
+                    "Unexpected space character(s)",
+                    "Unexpected indentation (2) (should be 1)"
+                )
+        }
     }
 
     @Test
@@ -71,5 +100,9 @@ class IndentationSpec {
             val config = TestConfig("indentSize" to 1)
             assertThat(Indentation(config).lint(code)).isEmpty()
         }
+    }
+
+    companion object {
+        private const val TAB = "${'\t'}"
     }
 }


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/9162
