### PR TITLE
Do not report IgnoredReturnValue on lambda invocation that returns Unit

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -20,9 +20,11 @@ import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
+import org.jetbrains.kotlin.analysis.api.symbols.name
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.load.java.JavaClassFinderImpl
 import org.jetbrains.kotlin.name.CallableId
@@ -116,8 +118,9 @@ class IgnoredReturnValue(config: Config) :
         super.visitCallExpression(expression)
 
         analyze(expression) {
-            val symbol = expression.resolveToCall()?.singleFunctionCallOrNull()?.symbol ?: return
-            val returnType = symbol.returnType
+            val functionCall = expression.resolveToCall()?.singleFunctionCallOrNull() ?: return
+            val symbol = functionCall.symbol
+            val returnType = functionCall.signature.returnType
             if (returnType.isUnitType || returnType.isNothingType) return
 
             if (ignoreFunctionCall.any { it.match(symbol) }) return

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -20,11 +20,9 @@ import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaDeclarationSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
-import org.jetbrains.kotlin.analysis.api.symbols.name
 import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaFunctionType
 import org.jetbrains.kotlin.analysis.api.types.KaType
-import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.load.java.JavaClassFinderImpl
 import org.jetbrains.kotlin.name.CallableId

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValueSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValueSpec.kt
@@ -1067,10 +1067,35 @@ class IgnoredReturnValueSpec {
         }
 
         @Test
+        fun `does not report when an anonymous function returns Unit`() {
+            val code = """
+                fun foo(bar: (Int) -> Unit) {
+                    bar(42)
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
         fun `does not report when a function returns Nothing`() {
             val code = """
                 fun foo() {
                     TODO("tbd")
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `does not report when an anonymous function returns Nothing`() {
+            val code = """
+                fun foo() {
+                    val bar: (String) -> Nothing = {
+                        TODO("tbd")
+                    }
+                    bar("Hello")
                 }
             """.trimIndent()
             val findings = subject.lintWithContext(env, code)


### PR DESCRIPTION
Closes https://github.com/detekt/detekt/issues/9183

Check the return type from the function call's signature rather than from the symbol to remove false positives of `IgnoredReturnValue` on lambda invocations that return `Unit`.

This is because the symbol's `returnType` is `R` because the symbol itself is the `invoke` method, but the signature holds the actual lambda's signature and therefore correctly identified `Unit` as the return type.