### PR TITLE
System-dependent path separators

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -80,7 +80,11 @@ tasks {
         doNotTrackState("The entire root directory is read as the input source.")
         classpath = files(shadowJar)
         workingDir = rootDir
-        args = listOf("@./config/detekt/argsfile", "-p", pluginsJarFiles.files.joinToString(",") { it.path })
+        args = listOf(
+            "@./config/detekt/argsfile",
+            "-p",
+            pluginsJarFiles.files.joinToString(File.pathSeparator) { it.path },
+        )
     }
 
     withType<Jar>().configureEach {

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -62,7 +62,7 @@ class ReportPathConverter : IStringConverter<ReportPath> {
 }
 
 class PathSplitter : IParameterSplitter {
-    override fun split(value: String): List<String> = value.split(',', ';')
+    override fun split(value: String): List<String> = value.split(File.pathSeparatorChar)
 }
 
 class PathValidator : IValueValidator<List<Path>> {
@@ -71,10 +71,6 @@ class PathValidator : IValueValidator<List<Path>> {
             if (!it.exists()) throw ParameterException("Path '$it' passed to $name does not exist.")
         }
     }
-}
-
-class ClassPathSplitter : IParameterSplitter {
-    override fun split(value: String): List<String> = value.split(File.pathSeparatorChar)
 }
 
 class DirectoryValidator : IValueValidator<Path> {

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -20,8 +20,8 @@ class CliArgs {
         converter = PathConverter::class,
         splitter = PathSplitter::class,
         validateValueWith = [PathValidator::class],
-        description = "Input paths to analyze. Multiple paths are separated by comma. If not specified the " +
-            "current working directory is used."
+        description = "Input paths to analyze. Multiple paths are separated by ':' on *nix or ';' on Windows. " +
+            "If not specified the current working directory is used."
     )
     var inputPaths: List<Path> = listOf(Path(System.getProperty("user.dir")))
 
@@ -52,7 +52,7 @@ class CliArgs {
         splitter = PathSplitter::class,
         validateValueWith = [PathValidator::class],
         description = "Path to the config file (path/to/config.yml). " +
-            "Multiple configuration files can be specified with ',' or ';' as separator."
+            "Multiple configuration files can be specified with ':' on *nix or ';' on Windows as separator."
     )
     var config: List<Path> = emptyList()
 
@@ -76,7 +76,7 @@ class CliArgs {
         converter = PathConverter::class,
         splitter = PathSplitter::class,
         validateValueWith = [PathValidator::class],
-        description = "Extra paths to plugin jars separated by ',' or ';'."
+        description = "Extra paths to plugin jars separated by ':' on *nix or ';' on Windows."
     )
     var plugins: List<Path> = emptyList()
 
@@ -188,7 +188,7 @@ class CliArgs {
     @Parameter(
         names = ["--classpath", "-cp"],
         converter = PathConverter::class,
-        splitter = ClassPathSplitter::class,
+        splitter = PathSplitter::class,
         validateValueWith = [PathValidator::class],
         description = "Paths where to find user class files and depending jar files. Used for type resolution."
     )

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
-import org.junit.jupiter.params.provider.ValueSource
+import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
@@ -46,16 +46,14 @@ internal class CliArgsSpec {
             assertThat(spec.projectSpec.inputPaths).contains(pathCliArgsSpec)
         }
 
-        @ParameterizedTest
-        @ValueSource(
-            strings = [
-                "src/main,../detekt-core/src/test,build.gradle.kts",
-                "src/main;../detekt-core/src/test;build.gradle.kts",
-                "src/main,../detekt-core/src/test;build.gradle.kts",
-            ]
-        )
-        fun `when the input is defined it is passed to the spec`(param: String) {
-            val spec = parseArguments(arrayOf("--input", param)).toSpec()
+        @Test
+        fun `when the input is defined it is passed to the spec`() {
+            val spec = parseArguments(
+                arrayOf(
+                    "--input",
+                    "src/main${File.pathSeparator}../detekt-core/src/test${File.pathSeparator}build.gradle.kts",
+                )
+            ).toSpec()
 
             assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
             assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
@@ -85,7 +83,10 @@ internal class CliArgsSpec {
 
         @Nested
         inner class FilterInput {
-            private val input = arrayOf("--input", "src/main/../main/,../detekt-core/src/test,build.gradle.kts")
+            private val input = arrayOf(
+                "--input",
+                "src/main/../main/${File.pathSeparator}../detekt-core/src/test${File.pathSeparator}build.gradle.kts",
+            )
             private val pathMain = Path("src/main/kotlin/dev/detekt/cli/Main.kt").absolute()
 
             @Test

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import java.io.File
 
 class DetektTaskDslSpec {
 
@@ -52,7 +53,9 @@ class DetektTaskDslSpec {
             val file2 = gradleRunner.projectFile("src/test/java/My1Root0Class.kt")
             val file3 = gradleRunner.projectFile("src/main/kotlin/My2Root0Class.kt")
             val file4 = gradleRunner.projectFile("src/test/kotlin/My3Root0Class.kt")
-            assertThat(result.output).contains("--input $file1,$file2,$file3,$file4 ")
+            assertThat(result.output).contains(
+                "--input $file1${File.pathSeparator}$file2${File.pathSeparator}$file3${File.pathSeparator}$file4 "
+            )
         }
     }
 
@@ -72,7 +75,7 @@ class DetektTaskDslSpec {
             val firstConfig = gradleRunner.projectFile("firstConfig.yml")
             val secondConfig = gradleRunner.projectFile("secondConfig.yml")
 
-            val expectedConfigParam = "--config $firstConfig,$secondConfig"
+            val expectedConfigParam = "--config $firstConfig${File.pathSeparator}$secondConfig"
             assertThat(result.output).contains(expectedConfigParam)
         }
     }
@@ -145,7 +148,7 @@ class DetektTaskDslSpec {
         fun `sets input parameter to absolute filenames of all source files`() {
             val file1 = gradleRunner.projectFile("$customSrc1/My0Root0Class.kt")
             val file2 = gradleRunner.projectFile("$customSrc2/My1Root0Class.kt")
-            val expectedInputParam = "--input $file1,$file2"
+            val expectedInputParam = "--input $file1${File.pathSeparator}$file2"
             assertThat(result.output).contains(expectedInputParam)
         }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -51,7 +51,8 @@ internal data class GenerateConfigArgument(val file: RegularFile) : CliArgument 
 }
 
 internal data class InputArgument(val fileCollection: FileCollection) : CliArgument {
-    override fun toArgument() = listOf(INPUT_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
+    override fun toArgument() =
+        listOf(INPUT_PARAMETER, fileCollection.joinToString(File.pathSeparator) { it.absolutePath })
 }
 
 internal data class ClasspathArgument(val fileCollection: FileCollection) : CliArgument {
@@ -136,12 +137,11 @@ internal data class FailOnSeverityArgument(val ignoreFailures: Boolean, val minS
 }
 
 internal data class ConfigArgument(val files: FileCollection) : CliArgument {
-
     override fun toArgument() =
         if (files.isEmpty) {
             emptyList()
         } else {
-            listOf(CONFIG_PARAMETER, files.joinToString(",") { it.absolutePath })
+            listOf(CONFIG_PARAMETER, files.joinToString(File.pathSeparator) { it.absolutePath })
         }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -117,10 +117,7 @@ internal data class FreeArgs(val args: List<String>) : CliArgument {
 internal data class FriendPathArgs(val fileCollection: FileCollection) : CliArgument {
     override fun toArgument() =
         if (!fileCollection.isEmpty) {
-            listOf(
-                FRIEND_PATHS_PARAMETER,
-                fileCollection.joinToString(",") { it.absolutePath }
-            )
+            listOf(FRIEND_PATHS_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
         } else {
             emptyList()
         }
@@ -169,10 +166,7 @@ internal data class AutoCorrectArgument(override val value: Boolean) : BoolCliAr
 internal data class OptInArguments(val list: List<String>) : CliArgument {
     override fun toArgument() =
         if (list.isNotEmpty()) {
-            listOf(
-                OPT_IN_PARAMETER,
-                list.joinToString(",")
-            )
+            listOf(OPT_IN_PARAMETER, list.joinToString(","))
         } else {
             emptyList()
         }


### PR DESCRIPTION
This is part of #1253. That issue covers 3 different topics this PR only handles the first bullet point.

Use `File.pathSeparator` to split the paths instead of `,` and `;`. This change applies to these arguments: `--input`, `--plugin`, `--config` & `--config-resource`

~Blocked by:~
- ~#9202~