### PR TITLE
Cli filters

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -78,3 +78,18 @@ class DirectoryValidator : IValueValidator<Path> {
         if (!value.isDirectory()) throw ParameterException("Value passed to $name must be a directory.")
     }
 }
+
+class FilterSplitter : IParameterSplitter {
+    override fun split(value: String): List<String> = value.split(',', ';')
+}
+
+class FilterValidator : IValueValidator<List<String>> {
+    override fun validate(name: String, value: List<String>) {
+        if (value.any { it.isBlank() }) {
+            throw ParameterException("Value passed to $name contain empty globs.")
+        }
+        if (value.any { it.trim() != it }) {
+            throw ParameterException("Value passed to $name contain globs that start or end with space.")
+        }
+    }
+}

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -86,10 +86,10 @@ class FilterSplitter : IParameterSplitter {
 class FilterValidator : IValueValidator<List<String>> {
     override fun validate(name: String, value: List<String>) {
         if (value.any { it.isBlank() }) {
-            throw ParameterException("Value passed to $name contain empty globs.")
+            throw ParameterException("Value passed to $name contains empty globs.")
         }
         if (value.any { it.trim() != it }) {
-            throw ParameterException("Value passed to $name contain globs that start or end with space.")
+            throw ParameterException("Value passed to $name contains globs that start or end with space.")
         }
     }
 }

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -35,16 +35,20 @@ class CliArgs {
 
     @Parameter(
         names = ["--includes", "-in"],
+        splitter = FilterSplitter::class,
+        validateValueWith = [FilterValidator::class],
         description = "Globbing patterns describing paths to include in the analysis. " +
             "Useful in combination with 'excludes' patterns."
     )
-    var includes: String? = null
+    var includes: List<String> = emptyList()
 
     @Parameter(
         names = ["--excludes", "-ex"],
+        splitter = FilterSplitter::class,
+        validateValueWith = [FilterValidator::class],
         description = "Globbing patterns describing paths to exclude from the analysis."
     )
-    var excludes: String? = null
+    var excludes: List<String> = emptyList()
 
     @Parameter(
         names = ["--config", "-c"],

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -24,10 +24,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         project {
             basePath = args.basePath.absolute()
-            val pathFilters = PathFilters.of(
-                includes = args.includes?.let(::asPatterns).orEmpty(),
-                excludes = args.excludes?.let(::asPatterns).orEmpty(),
-            )
+            val pathFilters = PathFilters.of(includes = args.includes, excludes = args.excludes)
             val absoluteBasePath = basePath.absolute()
             inputPaths = args.inputPaths.walk()
                 .filter { path -> path.isKotlinFile() }
@@ -89,13 +86,6 @@ private fun Iterable<Path>.walk(): Sequence<Path> = asSequence().flatMap { it.wa
 private fun Path.isKotlinFile() = extension in KT_ENDINGS
 
 private val KT_ENDINGS = setOf("kt", "kts")
-
-private fun asPatterns(rawValue: String): List<String> =
-    rawValue.trim()
-        .splitToSequence(",", ";")
-        .filter { it.isNotBlank() }
-        .map { it.trim() }
-        .toList()
 
 private fun CliArgs.toRunPolicy(): RulesSpec.RunPolicy {
     val parts = runRule?.split(":")

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -17,10 +17,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.params.Parameter
+import org.junit.jupiter.params.ParameterizedClass
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
-import java.nio.file.Path
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
 
@@ -233,40 +235,36 @@ internal class CliArgsSpec {
                 assertThat(spec.projectSpec.inputPaths).isEmpty()
             }
 
-            @Test
-            fun `parse excludes correctly`() {
-                val paths: List<Collection<Path>> = listOf(
-                    "**/main/**,**/detekt-core/**,**/build.gradle.kts",
-                    "**/main/**;**/detekt-core/**;**/build.gradle.kts",
-                    "**/main/** ,**/detekt-core/**, **/build.gradle.kts",
-                    "**/main/** ;**/detekt-core/**; **/build.gradle.kts",
-                    "**/main/**,**/detekt-core/**;**/build.gradle.kts",
-                    "**/main/** ,**/detekt-core/**; **/build.gradle.kts",
-                    " ,,**/main/**,**/detekt-core/**,**/build.gradle.kts",
-                ).map {
-                    val spec = parseArguments(input + arrayOf("--excludes", it)).toSpec()
-                    spec.projectSpec.inputPaths
+            @Nested
+            @ParameterizedClass
+            @ValueSource(strings = ["--excludes", "--includes"])
+            inner class Validate {
+                @Parameter
+                lateinit var arg: String
+
+                @Test
+                fun spaceEnd() {
+                    assertThatExceptionOfType(HandledArgumentViolation::class.java)
+                        .isThrownBy { parseArguments(input + arrayOf(arg, "**/main/** ")) }
                 }
 
-                assertThat(paths.distinct()).hasSize(1)
-            }
-
-            @Test
-            fun `parse includes correctly`() {
-                val paths: List<Collection<Path>> = listOf(
-                    "**/main/**,**/detekt-core/**,**/build.gradle.kts",
-                    "**/main/**;**/detekt-core/**;**/build.gradle.kts",
-                    "**/main/** ,**/detekt-core/**, **/build.gradle.kts",
-                    "**/main/** ;**/detekt-core/**; **/build.gradle.kts",
-                    "**/main/**,**/detekt-core/**;**/build.gradle.kts",
-                    "**/main/** ,**/detekt-core/**; **/build.gradle.kts",
-                    " ,,**/main/**,**/detekt-core/**,**/build.gradle.kts",
-                ).map {
-                    val spec = parseArguments(input + arrayOf("--includes", it)).toSpec()
-                    spec.projectSpec.inputPaths
+                @Test
+                fun spaceStart() {
+                    assertThatExceptionOfType(HandledArgumentViolation::class.java)
+                        .isThrownBy { parseArguments(input + arrayOf(arg, " **/main/**")) }
                 }
 
-                assertThat(paths.distinct()).hasSize(1)
+                @Test
+                fun empty() {
+                    assertThatExceptionOfType(HandledArgumentViolation::class.java)
+                        .isThrownBy { parseArguments(input + arrayOf(arg, "")) }
+                }
+
+                @Test
+                fun blank() {
+                    assertThatExceptionOfType(HandledArgumentViolation::class.java)
+                        .isThrownBy { parseArguments(input + arrayOf(arg, " ")) }
+                }
             }
         }
     }

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -109,11 +109,33 @@ internal class CliArgsSpec {
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathAnalyzer)
             }
 
+            @ParameterizedTest
+            @ValueSource(strings = ["**/test/**,*.kts", "**/test/**;*.kts"])
+            fun `multiples excludes in path`(filter: String) {
+                val spec = parseArguments(input + arrayOf("--excludes", filter)).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).contains(pathMain)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathAnalyzer)
+            }
+
             @Test
             fun `includes in path`() {
                 val spec = parseArguments(input + arrayOf("--includes", "**/test/**")).toSpec()
 
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathBuildGradle)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
+                assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
+                assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
+            }
+
+            @ParameterizedTest
+            @ValueSource(strings = ["**/test/**,*.kts", "**/test/**;*.kts"])
+            fun `multiples includes in path`(filter: String) {
+                val spec = parseArguments(input + arrayOf("--includes", filter)).toSpec()
+
+                assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathCliArgs)
                 assertThat(spec.projectSpec.inputPaths).doesNotContain(pathMain)
                 assertThat(spec.projectSpec.inputPaths).contains(pathAnalyzer)
@@ -192,10 +214,10 @@ internal class CliArgsSpec {
                 assertThat(spec.projectSpec.inputPaths).isEmpty()
             }
 
-            @Test
-            fun `doesn't take into account absolute path`() {
-                val spec =
-                    parseArguments(input + arrayOf("--excludes", "/home/**,/Users/**")).toSpec()
+            @ParameterizedTest
+            @ValueSource(strings = ["/home/**", "/Users/**"])
+            fun `doesn't take into account absolute path`(glob: String) {
+                val spec = parseArguments(input + arrayOf("--excludes", glob)).toSpec()
 
                 assertThat(spec.projectSpec.inputPaths).contains(pathBuildGradle)
                 assertThat(spec.projectSpec.inputPaths).contains(pathCliArgs)


### PR DESCRIPTION
Right now we accept `--excludes` like this: `foo.kt, ,,  bar.kt`. This PR changes that. Now the excludes and includes can't be empty, blank or contain spaces at the start or end. Before we were just filtering out those cases. With this PR we don't make any magic. If you pass a value like this we fail with a message error.

Related with #1253. This will simplify its implementation.