### PR TITLE
Remove `LicenseHeaderLoaderExtension` from the list of processors

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -20,7 +20,6 @@ processors:
   # - 'ProjectCLOCProcessor'
   # - 'ProjectLOCProcessor'
   # - 'ProjectSLOCProcessor'
-  # - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -52,7 +52,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
               # - 'ProjectCLOCProcessor'
               # - 'ProjectLOCProcessor'
               # - 'ProjectSLOCProcessor'
-              # - 'LicenseHeaderLoaderExtension'
         """.trimIndent()
 
     private fun defaultConsoleReportsConfiguration(): String =

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
@@ -13,7 +13,6 @@ processors:
   # - 'ProjectCLOCProcessor'
   # - 'ProjectLOCProcessor'
   # - 'ProjectSLOCProcessor'
-  # - 'LicenseHeaderLoaderExtension'
 
 console-reports:
   active: true


### PR DESCRIPTION
I removed  the processor `LicenseHeaderLoaderExtension` at #8969. But I didn't remove this from our config.