### PR TITLE
[Docs] Remove items that the yaml config doesn't cofigure now

### DIFF
--- a/website/docs/introduction/configurations.mdx
+++ b/website/docs/introduction/configurations.mdx
@@ -11,9 +11,7 @@ import { DefaultConfigurationFile } from "./../../src/components/ConfigurationFi
 _detekt_ uses a [YAML style configuration](https://yaml.org/spec/1.2/spec.html) file for various things:
 
 - rule set and rule properties
-- build failure
 - console reports
-- output reports
 - processors
 
 See the <DefaultConfigurationFile /> file for all defined configuration options and their default values. 


### PR DESCRIPTION
These two things are no longer configurable by the `yaml`.