### PR TITLE
Remove console-reports from the yaml config

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -57,7 +57,7 @@ class CliArgs {
     var config: List<Path> = emptyList()
 
     @Parameter(
-        names = ["--config-resource", "-cr"],
+        names = ["--config-resource"],
         converter = ClasspathResourceConverter::class,
         splitter = PathSplitter::class,
         description = "Path to the config resource on detekt's classpath (path/to/config.yml)."
@@ -112,6 +112,17 @@ class CliArgs {
             "e.g. '-r html:reports/detekt.html -r checkstyle:reports/detekt.xml'"
     )
     var reportPaths: List<ReportPath> = emptyList()
+
+    @Parameter(
+        names = ["--console-report", "-cr"],
+        defaultValueDescription = "LiteIssuesReport",
+        description = "Generates a report for given 'report-id' and prints it on the output. " +
+            "Available 'report-id' values: 'ProjectStatisticsReport', 'ComplexityReport', 'NotificationReport', " +
+            "'IssuesReport', 'FileBasedIssuesReport' and 'LiteIssuesReport'. " +
+            "These can also be used in combination with each other " +
+            "e.g. '-cr LiteIssuesReport -cr ComplexityReport'"
+    )
+    var consoleReports: List<String> = listOf("LiteIssuesReport")
 
     @Parameter(
         names = ["--fail-on-severity"],

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -71,6 +71,9 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
             args.reportPaths.forEach {
                 report { it.kind to it.path }
             }
+            args.consoleReports.forEach {
+                consoleReport(it)
+            }
         }
 
         compiler {

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -442,6 +442,37 @@ internal class CliArgsSpec {
             .isThrownBy { parseArguments(arrayOf("--jdk-home", "nonExistent")) }
             .withMessage("Value passed to --jdk-home must be a directory.")
     }
+
+    @Nested
+    inner class `Console report` {
+        @Test
+        fun `default value`() {
+            val spec = parseArguments(emptyArray()).toSpec()
+
+            assertThat(spec.reportsSpec.consoleReports).isEqualTo(listOf("LiteIssuesReport"))
+        }
+
+        @Test
+        fun `no value`() {
+            val spec = parseArguments(arrayOf("--console-report", "")).toSpec()
+
+            assertThat(spec.reportsSpec.consoleReports).isEmpty()
+        }
+
+        @Test
+        fun `single param`() {
+            val spec = parseArguments(arrayOf("--console-report", "foo")).toSpec()
+
+            assertThat(spec.reportsSpec.consoleReports).isEqualTo(listOf("foo"))
+        }
+
+        @Test
+        fun `two param`() {
+            val spec = parseArguments(arrayOf("--console-report", "foo", "--console-report", "bar")).toSpec()
+
+            assertThat(spec.reportsSpec.consoleReports).isEqualTo(listOf("foo", "bar"))
+        }
+    }
 }
 
 private fun CliArgs.toSpec() = createSpec(NullPrintStream(), NullPrintStream())

--- a/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/reporting/OutputFacade.kt
@@ -7,7 +7,6 @@ import dev.detekt.api.Notification.Level
 import dev.detekt.api.OutputReport
 import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.extensions.loadExtensions
-import dev.detekt.core.util.isActiveOrDefault
 import dev.detekt.tooling.api.spec.ReportsSpec
 import java.nio.file.Path
 import kotlin.io.path.createParentDirectories
@@ -65,12 +64,6 @@ private fun OutputReport.write(filePath: Path, detektion: Detektion) {
 }
 
 internal fun loadConsoleReport(settings: ProcessingSettings): List<ConsoleReport> {
-    val config = settings.config.subConfig("console-reports")
-    val isActive = config.isActiveOrDefault(true)
-    return if (!isActive) {
-        emptyList()
-    } else {
-        val excludes = config.valueOrDefault("exclude", emptyList<String>()).toSet()
-        loadExtensions(settings) { it.id !in excludes }
-    }
+    val consoleReports = settings.spec.reportsSpec.consoleReports.toSet()
+    return loadExtensions(settings) { it.id in consoleReports }
 }

--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -20,16 +20,6 @@ processors:
   # - 'ProjectLOCProcessor'
   # - 'ProjectSLOCProcessor'
 
-console-reports:
-  active: true
-  exclude:
-     - 'ProjectStatisticsReport'
-     - 'ComplexityReport'
-     - 'NotificationReport'
-     - 'IssuesReport'
-     - 'FileBasedIssuesReport'
-  #  - 'LiteIssuesReport'
-
 comments:
   active: true
   AbsentOrWrongFileLicense:

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/DefaultDetektConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/DefaultDetektConfigSpec.kt
@@ -9,12 +9,7 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 
 class DefaultDetektConfigSpec {
-
-    private val generalConfigKeys = listOf(
-        "config",
-        "processors",
-        "console-reports",
-    )
+    private val generalConfigKeys = listOf("config", "processors")
 
     private val config: YamlConfig = YamlConfig.load(
         DefaultDetektConfigSpec::class.java.getSafeResourceAsStream("/default-detekt-config.yml")!!.reader()

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputFacadeSpec.kt
@@ -40,6 +40,7 @@ class OutputFacadeSpec {
                 report { "checkstyle" to xmlOutputPath }
                 report { "markdown" to markdownOutputPath }
                 report { "sarif" to sarifOutputPath }
+                consoleReport("NotificationReport")
             }
             logging {
                 outputChannel = printStream
@@ -76,6 +77,7 @@ class OutputFacadeSpec {
                 report { "html" to htmlOutputPath }
                 report { "checkstyle" to htmlOutputPath }
                 report { "markdown" to markdownOutputPath }
+                consoleReport("NotificationReport")
             }
             logging {
                 outputChannel = printStream
@@ -107,6 +109,7 @@ class OutputFacadeSpec {
                 report { "checkstyle" to htmlOutputPath }
                 report { "markdown" to htmlOutputPath }
                 report { "sarif" to sarifOutputPath }
+                consoleReport("NotificationReport")
             }
             logging {
                 outputChannel = printStream

--- a/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputReportsSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/reporting/OutputReportsSpec.kt
@@ -9,7 +9,6 @@ import dev.detekt.core.tooling.withSettings
 import dev.detekt.report.html.HtmlOutputReport
 import dev.detekt.report.markdown.MarkdownOutputReport
 import dev.detekt.report.xml.CheckstyleOutputReport
-import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.tooling.dsl.ReportsSpecBuilder
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Condition
@@ -89,11 +88,7 @@ class OutputReportsSpec {
 
         @Test
         fun `yields empty extension list`() {
-            val spec = createNullLoggingSpec {
-                config {
-                    configPaths = listOf(resourceAsPath("/reporting/disabled-reports.yml"))
-                }
-            }
+            val spec = createNullLoggingSpec {}
 
             val extensions = spec.withSettings { loadConsoleReport(this) }
 

--- a/detekt-core/src/test/resources/common_known_sections.yml
+++ b/detekt-core/src/test/resources/common_known_sections.yml
@@ -2,11 +2,6 @@ config:
   validation: true
   excludes: 'test>.*'
 
-console-reports:
-  active: true
-  exclude:
-    - 'FileBasedFindingsReport'
-
 potential-bugs:
   UnusedUnaryOperator:
     aliases: ['an-alias']

--- a/detekt-core/src/test/resources/config_validation/baseline.yml
+++ b/detekt-core/src/test/resources/config_validation/baseline.yml
@@ -3,8 +3,6 @@ config:
   checkExhaustiveness: false
 processors:
   active: true
-console-reports:
-  active: true
 
 complexity:
   LongMethod:

--- a/detekt-core/src/test/resources/reporting/disabled-reports.yml
+++ b/detekt-core/src/test/resources/reporting/disabled-reports.yml
@@ -1,2 +1,0 @@
-console-reports:
-  active: false

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinter.kt
@@ -12,8 +12,6 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
             emptyLine()
             yaml { defaultProcessorsConfiguration() }
             emptyLine()
-            yaml { defaultConsoleReportsConfiguration() }
-            emptyLine()
 
             item.sortedBy { it.ruleSet.name }
                 .forEach { printRuleSetPage(it) }
@@ -51,18 +49,5 @@ object ConfigPrinter : DocumentationPrinter<List<RuleSetPage>> {
               # - 'ProjectCLOCProcessor'
               # - 'ProjectLOCProcessor'
               # - 'ProjectSLOCProcessor'
-        """.trimIndent()
-
-    private fun defaultConsoleReportsConfiguration(): String =
-        """
-            console-reports:
-              active: true
-              exclude:
-                 - 'ProjectStatisticsReport'
-                 - 'ComplexityReport'
-                 - 'NotificationReport'
-                 - 'IssuesReport'
-                 - 'FileBasedIssuesReport'
-              #  - 'LiteIssuesReport'
         """.trimIndent()
 }

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -9,6 +9,7 @@ public abstract class dev/detekt/gradle/Detekt : org/gradle/api/tasks/SourceTask
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getConsoleReports ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDetektClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
@@ -87,6 +88,7 @@ public abstract interface class dev/detekt/gradle/extensions/DetektExtension {
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getConsoleReports ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;
 	public abstract fun getDisableDefaultRuleSets ()Lorg/gradle/api/provider/Property;
 	public abstract fun getEnableCompilerPlugin ()Lorg/gradle/api/provider/Property;

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/config/detekt/detekt.yml
@@ -13,16 +13,6 @@ processors:
   # - 'ProjectLOCProcessor'
   # - 'ProjectSLOCProcessor'
 
-console-reports:
-  active: true
-  exclude:
-    - 'ProjectStatisticsReport'
-    - 'ComplexityReport'
-    - 'NotificationReport'
-    - 'IssuesReport'
-    - 'FileBasedIssuesReport'
-  #  - 'LiteIssuesReport'
-
 potential-bugs:
   ExitOutsideMain:
     active: true

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -13,6 +13,7 @@ import dev.detekt.gradle.invoke.BuildUponDefaultConfigArgument
 import dev.detekt.gradle.invoke.ClasspathArgument
 import dev.detekt.gradle.invoke.CliArgument
 import dev.detekt.gradle.invoke.ConfigArgument
+import dev.detekt.gradle.invoke.ConsoleReportArgument
 import dev.detekt.gradle.invoke.CustomReportArgument
 import dev.detekt.gradle.invoke.DebugArgument
 import dev.detekt.gradle.invoke.DefaultReportArgument
@@ -157,6 +158,9 @@ abstract class Detekt @Inject constructor(
 
     private val isDryRun = project.providers.gradleProperty(DRY_RUN_PROPERTY)
 
+    @get:Internal
+    abstract val consoleReports: ListProperty<String>
+
     @get:Input
     @get:Incubating
     abstract val freeCompilerArgs: ListProperty<String>
@@ -184,6 +188,7 @@ abstract class Detekt @Inject constructor(
             DefaultReportArgument(reports.html),
             DefaultReportArgument(reports.sarif),
             DefaultReportArgument(reports.markdown),
+            ConsoleReportArgument(consoleReports.get()),
             DebugArgument(debug.get()),
             ParallelArgument(parallel.get()),
             BuildUponDefaultConfigArgument(buildUponDefaultConfig.get()),

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/DetektExtension.kt
@@ -39,6 +39,8 @@ interface DetektExtension {
 
     val autoCorrect: Property<Boolean>
 
+    val consoleReports: ListProperty<String>
+
     /**
      * List of Android build variants for which no detekt task should be created.
      *

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -20,6 +20,7 @@ private const val AUTO_CORRECT_PARAMETER = "--auto-correct"
 private const val FAIL_ON_SEVERITY_PARAMETER = "--fail-on-severity"
 private const val ALL_RULES_PARAMETER = "--all-rules"
 private const val REPORT_PARAMETER = "--report"
+private const val CONSOLE_REPORT_PARAMETER = "--console-report"
 private const val GENERATE_CONFIG_PARAMETER = "--generate-config"
 private const val CREATE_BASELINE_PARAMETER = "--create-baseline"
 private const val CLASSPATH_PARAMETER = "--classpath"
@@ -108,6 +109,11 @@ internal data class DefaultReportArgument(val report: DetektReport) : CliArgumen
 
 internal data class CustomReportArgument(val reportId: String, val file: RegularFile) : CliArgument {
     override fun toArgument() = listOf(REPORT_PARAMETER, "$reportId:${file.asFile.absolutePath}")
+}
+
+internal data class ConsoleReportArgument(val report: List<String>) : CliArgument {
+    override fun toArgument(): List<String> =
+        report.ifEmpty { listOf("") }.flatMap { listOf(CONSOLE_REPORT_PARAMETER, it) }
 }
 
 internal data class FreeArgs(val args: List<String>) : CliArgument {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -48,6 +48,7 @@ class DetektBasePlugin : Plugin<Project> {
                 project.extensions.getByType(ReportingExtension::class.java).baseDirectory.dir("detekt")
             )
             basePath.convention(project.rootProjectDirectoryCompat())
+            consoleReports.convention(listOf("LiteIssuesReport"))
         }
 
         val defaultConfigFile =

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
@@ -159,6 +159,7 @@ class DetektPlugin : Plugin<Project> {
                 report.required.convention(DEFAULT_REPORT_ENABLED_VALUE)
                 report.outputLocation.convention(extension.reportsDir.file("$reportName.xml"))
             }
+            task.consoleReports.convention(extension.consoleReports)
         }
 
         project.tasks.withType(DetektCreateBaselineTask::class.java).configureEach { task ->

--- a/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/DetektSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/DetektSpec.kt
@@ -1,0 +1,91 @@
+package dev.detekt.gradle
+
+import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.plugin.DetektPlugin
+import dev.detekt.gradle.testkit.DslGradleRunner
+import dev.detekt.gradle.testkit.ProjectLayout
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.repositories
+import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class DetektSpec {
+
+    @Nested
+    inner class `Console Report` {
+        @Test
+        fun `default behavior`() {
+            val detektTask = detektTask()
+
+            val arguments = detektTask.arguments
+            val argumentString = arguments.joinToString(" ")
+
+            assertThat(argumentString).contains("--console-report LiteIssuesReport ")
+            assertThat(arguments.count { it == "--console-report" }).isEqualTo(1)
+        }
+
+        @Test
+        fun `no value`() {
+            val detektTask = detektTask {
+                consoleReports.empty()
+            }
+
+            val arguments = detektTask.arguments
+            val argumentString = arguments.joinToString(" ")
+
+            assertThat(argumentString).contains("--console-report  ")
+            assertThat(arguments.count { it == "--console-report" }).isEqualTo(1)
+        }
+
+        @Test
+        fun `single value`() {
+            val detektTask = detektTask {
+                consoleReports.add("foo")
+            }
+
+            val arguments = detektTask.arguments
+            val argumentString = arguments.joinToString(" ")
+
+            assertThat(argumentString).contains("--console-report foo ")
+            assertThat(arguments.count { it == "--console-report" }).isEqualTo(1)
+        }
+
+        @Test
+        fun `two value`() {
+            val detektTask = detektTask {
+                consoleReports.add("foo")
+                consoleReports.add("bar")
+            }
+
+            val arguments = detektTask.arguments
+            val argumentString = arguments.joinToString(" ")
+
+            assertThat(argumentString).contains("--console-report foo ")
+            assertThat(argumentString).contains("--console-report bar ")
+            assertThat(arguments.count { it == "--console-report" }).isEqualTo(2)
+        }
+    }
+}
+
+private fun detektTask(configureExtension: DetektExtension.() -> Unit = {}) =
+    DslGradleRunner(
+        projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
+        buildFileName = "build.gradle.kts",
+        projectScript = {
+            apply<DetektPlugin>()
+            apply<KotlinPluginWrapper>()
+
+            repositories {
+                mavenCentral()
+            }
+
+            configure<DetektExtension>(configureExtension)
+        },
+    )
+        .also(DslGradleRunner::setupProject)
+        .buildProject()
+        .tasks
+        .getByPath("detekt") as Detekt

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -163,6 +163,7 @@ public abstract interface class dev/detekt/tooling/api/spec/ProjectSpec {
 }
 
 public abstract interface class dev/detekt/tooling/api/spec/ReportsSpec {
+	public abstract fun getConsoleReports ()Ljava/util/Collection;
 	public abstract fun getReports ()Ljava/util/Collection;
 }
 
@@ -337,8 +338,11 @@ public final class dev/detekt/tooling/dsl/ReportsSpecBuilder : dev/detekt/toolin
 	public fun <init> ()V
 	public fun build ()Ldev/detekt/tooling/api/spec/ReportsSpec;
 	public synthetic fun build ()Ljava/lang/Object;
+	public final fun consoleReport (Ljava/lang/String;)V
+	public final fun getConsoleReports ()Ljava/util/Collection;
 	public final fun getReports ()Ljava/util/Collection;
 	public final fun report (Lkotlin/jvm/functions/Function0;)V
+	public final fun setConsoleReports (Ljava/util/Collection;)V
 	public final fun setReports (Ljava/util/Collection;)V
 }
 

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/ReportsSpec.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/ReportsSpec.kt
@@ -30,4 +30,9 @@ interface ReportsSpec {
      * Reports to generate for current analysis run.
      */
     val reports: Collection<Report>
+
+    /**
+     * Console reports to generate for current analysis run.
+     */
+    val consoleReports: Collection<String>
 }

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/ReportsSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/ReportsSpecBuilder.kt
@@ -7,15 +7,23 @@ import java.nio.file.Path
 class ReportsSpecBuilder : Builder<ReportsSpec> {
 
     var reports: MutableCollection<ReportsSpec.Report> = mutableListOf()
+    var consoleReports: MutableCollection<String> = mutableListOf()
 
     fun report(init: () -> Pair<String, Path>) {
         reports.add(Report(init()))
     }
 
-    override fun build(): ReportsSpec = ReportsModel(reports)
+    fun consoleReport(consoleReport: String) {
+        consoleReports.add(consoleReport)
+    }
+
+    override fun build(): ReportsSpec = ReportsModel(reports, consoleReports)
 }
 
-private data class ReportsModel(override val reports: Collection<ReportsSpec.Report>) : ReportsSpec
+private data class ReportsModel(
+    override val reports: Collection<ReportsSpec.Report>,
+    override val consoleReports: Collection<String>,
+) : ReportsSpec
 
 private data class Report(override val type: String, override val path: Path) : ReportsSpec.Report {
     constructor(values: Pair<String, Path>) : this(values.first, values.second)

--- a/scripts/compare_releases_config.yml
+++ b/scripts/compare_releases_config.yml
@@ -1,11 +1,3 @@
-console-reports:
-  active: true
-  exclude:
-  # we do not have everything correctly configured
-  # though there may be too many findings in a project
-  # we just look at the diff and manually watch the generated txt report
-    - 'FindingsReport'
-
 # not so interesting findings and easy to spot a failure in the rule
 style:
   MaxLineLength:

--- a/website/docs/introduction/configurations.mdx
+++ b/website/docs/introduction/configurations.mdx
@@ -11,7 +11,6 @@ import { DefaultConfigurationFile } from "./../../src/components/ConfigurationFi
 _detekt_ uses a [YAML style configuration](https://yaml.org/spec/1.2/spec.html) file for various things:
 
 - rule set and rule properties
-- console reports
 - processors
 
 See the <DefaultConfigurationFile /> file for all defined configuration options and their default values. 
@@ -122,35 +121,6 @@ everyone can benefit from it.
 _detekt_ will fail your build if there is at least one issue with a severity of error. You can lower that threshold
 or completely disable build failures by using the `failOnSeverity` setting. Details can be found in the
 [gradle](../gettingstarted/gradle.mdx) and the [cli](../gettingstarted/cli.mdx) sections.
-
-## Console Reports
-
-Uncomment the reports you don't care about.
-
-```yaml
-console-reports:
-  active: true
-  exclude:
-  #  - 'ProjectStatisticsReport'
-  #  - 'ComplexityReport'
-  #  - 'NotificationReport'
-  #  - 'FindingsReport'
-  #  - 'FileBasedFindingsReport'
-  #  - 'LiteFindingsReport'
-```
-
-**ProjectStatisticsReport** contains metrics and statistics concerning the analyzed project sorted by priority.
-
-**ComplexityReport** contains metrics concerning the analyzed code. 
-For instance the source lines of code and the McCabe complexity are calculated.
-
-**NotificationReport** contains notifications reported by the detekt analyzer similar to push notifications. 
-It's simply a way of alerting users to information that they have opted-in to.
-
-**FindingsReport** contains all rule violations in a list format grouped by ruleset.
-
-**FileBasedFindingsReport** is similar to the FindingsReport shown above. 
-The rule violations are grouped by file location.
 
 ## Processors
 

--- a/website/docs/introduction/reporting.md
+++ b/website/docs/introduction/reporting.md
@@ -6,43 +6,72 @@ summary: This page describes each reporting format and explains how to leverage 
 sidebar_position: 4
 ---
 
-## Formats
+Detekt has two different ways to communicate what it found: outputting it to the console or creating report files
+
+## Console reports
+
+## Console Reports
+
+### ProjectStatisticsReport
+It contains metrics and statistics concerning the analyzed project sorted by priority.
+
+### ComplexityReport
+It contains metrics concerning the analyzed code.
+For instance the source lines of code and the McCabe complexity are calculated.
+
+### NotificationReport
+It contains notifications reported by the detekt analyzer similar to push notifications.
+It's simply a way of alerting users to information that they have opted-in to.
+
+### FindingsReport
+It contains all rule violations in a list format grouped by ruleset.
+
+### FileBasedFindingsReport
+It is similar to the FindingsReport shown above.
+The rule violations are grouped by file location.
+
+### LiteFindingsReport
+It contains all rule violations in a compact way. Similar to how the kotlinc reports its errors
+
+## Reports
+
+### Formats
 
 In addition to the CLI output, detekt supports 4 different types of output reporting formats.
 You can refer to [CLI](../gettingstarted/cli.mdx) or [Gradle](../gettingstarted/gradle.mdx) to find
 out how to configure these report formats.
 
-### HTML
+#### HTML
 HTML is a human-readable format that can be open through browser. It includes different metrics
 and complexity reports of this run, in addition to the findings with detailed descriptions and
 report. Check out the example: ![HTML report](/img/tutorial/html.png)
 
-### CHECKSTYLE
+#### CHECKSTYLE
 [Checkstyle](https://checkstyle.sourceforge.io/) is a machine-readable xml format that can be integrated with CI tools.
 
-### SARIF
+#### SARIF
 [SARIF](https://sarifweb.azurewebsites.net/) is a standard format for the output of 
 static analysis tools. It is a JSON format with a defined 
 [schema](https://docs.oasis-open.org/sarif/sarif/v2.0/csprd02/schemas/). It is currently supported
 by GitHub Code Scanning, and we expect more consuming tools will adopt this format in the future.
 
-### MD
+#### MARKDOWN
 Markdown is a lightweight markup language for creating formatted text using a plain-text editor.
 The output structure looks similar to HTML format.
 About [markdown](https://github.github.com/gfm/#what-is-markdown-) on GitHub.
 
-## Relative path
+### Relative path
 In a shared codebase, it is often required to use relative path so that all developers and tooling
 have a consistent view. This can be enabled by CLI option `--base-path` or Gradle as the following:
 
-### Kotlin DSL
+#### Kotlin DSL
 ```kotlin
 detekt {
     basePath.set(projectDir)
 }
 ```
 
-### Groovy DSL
+#### Groovy DSL
 ```groovy
 detekt {
     basePath = projectDir
@@ -52,7 +81,7 @@ detekt {
 Note that this option only affects file paths in those formats for machine consumers,
 namely Checkstyle and SARIF.
 
-## Merging reports
+### Merging reports
 
 :::caution Attention
 
@@ -68,7 +97,7 @@ the merging makes most sense in a multi-module project. In this spirit, only Gra
 At the moment, merging Checkstyle and SARIF are supported. You can refer to the sample build script below and 
 run `./gradlew detekt reportMerge --continue` to execute detekt tasks and merge the corresponding reports.
 
-### Groovy DSL
+#### Groovy DSL
 ```groovy
 tasks.register("reportMerge", dev.detekt.gradle.report.ReportMergeTask) {
   output = project.layout.buildDirectory.file("reports/detekt/merge.xml") // or "reports/detekt/merge.sarif"
@@ -86,7 +115,7 @@ subprojects {
 }
 ```
 
-### Kotlin DSL
+#### Kotlin DSL
 
 ```kotlin
 val reportMerge by tasks.registering(dev.detekt.gradle.report.ReportMergeTask::class) { 
@@ -105,7 +134,7 @@ subprojects {
 }
 ```
 
-## Integration with GitHub Code Scanning
+### Integration with GitHub Code Scanning
 If your repository is hosted on GitHub, you can enable SARIF output in your repository.
 You can follow to the [official documentation](https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/uploading-a-sarif-file-to-github).
 


### PR DESCRIPTION
Part of #2855

Our yaml should have the rules configuration, nothing else. This work of moving things out was done from before 1.x. (#1558 is an example. This is not the PR that removed fail-fast from the config file but the PR that update the documentation to align with that change).

Also, the way we had to configure the `console-reports` on the yaml was really odd. It was opt-out instead of opt-in (#2855)

The new API:
- By default, detekt behaves the same, using `LiteIssuesReport`.
- The cli added a `--console-report` param to define which reports should be executed.
- The gradle plugin added a new `ListProperty` on the extension called `consoleReports` to define which reports should be executed.

I recommend to review this PR commit by commit