### PR TITLE
Move `FileProcessListenerExtensions` to `:detekt-test`

### DIFF
--- a/detekt-metrics/build.gradle.kts
+++ b/detekt-metrics/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(projects.detektApi)
     api(libs.kotlin.compiler)
     compileOnly(projects.detektPsiUtils)
+    testImplementation(projects.detektTest)
     testImplementation(projects.detektTestUtils)
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.assertj.core)

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ClassCountProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ClassCountProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.api.ProjectMetric
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/FunctionCountProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/FunctionCountProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.api.ProjectMetric
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/KtFileCountProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/KtFileCountProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.api.ProjectMetric
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/PackageCountProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/PackageCountProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.api.ProjectMetric
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCLOCProcessorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCognitiveComplexityProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCognitiveComplexityProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.metrics.CognitiveComplexity
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCyclomaticComplexityProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectCyclomaticComplexityProcessorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLLOCProcessorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectLOCProcessorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectSLOCProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/ProjectSLOCProcessorSpec.kt
@@ -1,5 +1,6 @@
 package dev.detekt.metrics.processors
 
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/PropertyCountProcessorSpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/processors/PropertyCountProcessorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.metrics.processors
 
 import dev.detekt.api.ProjectMetric
+import dev.detekt.test.invoke
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -3,6 +3,11 @@ public final class dev/detekt/test/FakeLanguageVersionSettingsKt {
 	public static synthetic fun FakeLanguageVersionSettings$default (Lorg/jetbrains/kotlin/config/ExplicitApiMode;ILjava/lang/Object;)Lorg/jetbrains/kotlin/config/LanguageVersionSettingsImpl;
 }
 
+public final class dev/detekt/test/FileProcessListenerExtensionsKt {
+	public static final fun invoke (Ldev/detekt/api/FileProcessListener;Ljava/util/List;)Ldev/detekt/api/Detektion;
+	public static final fun invoke (Ldev/detekt/api/FileProcessListener;[Lorg/jetbrains/kotlin/psi/KtFile;)Ldev/detekt/api/Detektion;
+}
+
 public final class dev/detekt/test/FindingExtensionsKt {
 	public static final fun getLocation (Ldev/detekt/api/Finding;)Ldev/detekt/api/Location;
 }

--- a/detekt-test/api/detekt-test.api
+++ b/detekt-test/api/detekt-test.api
@@ -4,8 +4,10 @@ public final class dev/detekt/test/FakeLanguageVersionSettingsKt {
 }
 
 public final class dev/detekt/test/FileProcessListenerExtensionsKt {
-	public static final fun invoke (Ldev/detekt/api/FileProcessListener;Ljava/util/List;)Ldev/detekt/api/Detektion;
-	public static final fun invoke (Ldev/detekt/api/FileProcessListener;[Lorg/jetbrains/kotlin/psi/KtFile;)Ldev/detekt/api/Detektion;
+	public static final fun invoke (Ldev/detekt/api/FileProcessListener;Ljava/util/List;Ldev/detekt/api/Detektion;Ljava/util/List;)Ldev/detekt/api/Detektion;
+	public static final fun invoke (Ldev/detekt/api/FileProcessListener;[Lorg/jetbrains/kotlin/psi/KtFile;Ldev/detekt/api/Detektion;Ljava/util/List;)Ldev/detekt/api/Detektion;
+	public static synthetic fun invoke$default (Ldev/detekt/api/FileProcessListener;Ljava/util/List;Ldev/detekt/api/Detektion;Ljava/util/List;ILjava/lang/Object;)Ldev/detekt/api/Detektion;
+	public static synthetic fun invoke$default (Ldev/detekt/api/FileProcessListener;[Lorg/jetbrains/kotlin/psi/KtFile;Ldev/detekt/api/Detektion;Ljava/util/List;ILjava/lang/Object;)Ldev/detekt/api/Detektion;
 }
 
 public final class dev/detekt/test/FindingExtensionsKt {

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api(projects.detektApi)
+    implementation(testFixtures(projects.detektApi))
     api(projects.detektTestUtils)
     api(libs.kotlin.compiler)
     implementation(libs.kotlin.reflect)

--- a/detekt-test/src/main/kotlin/dev/detekt/test/FileProcessListenerExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/FileProcessListenerExtensions.kt
@@ -1,4 +1,4 @@
-package dev.detekt.metrics.processors
+package dev.detekt.test
 
 import dev.detekt.api.Detektion
 import dev.detekt.api.FileProcessListener

--- a/detekt-test/src/main/kotlin/dev/detekt/test/FileProcessListenerExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/FileProcessListenerExtensions.kt
@@ -2,17 +2,25 @@ package dev.detekt.test
 
 import dev.detekt.api.Detektion
 import dev.detekt.api.FileProcessListener
+import dev.detekt.api.Issue
 import dev.detekt.api.testfixtures.TestDetektion
 import org.jetbrains.kotlin.psi.KtFile
 
-fun FileProcessListener.invoke(vararg files: KtFile) = invoke(files.toList())
+fun FileProcessListener.invoke(
+    vararg files: KtFile,
+    detektion: Detektion = TestDetektion(),
+    issues: List<Issue> = emptyList(),
+) = invoke(files.toList(), detektion, issues)
 
-fun FileProcessListener.invoke(files: List<KtFile>): Detektion {
-    val result = TestDetektion()
+fun FileProcessListener.invoke(
+    files: List<KtFile>,
+    detektion: Detektion = TestDetektion(),
+    issues: List<Issue> = emptyList(),
+): Detektion {
     onStart(files)
     files.forEach {
         onProcess(it)
-        onProcessComplete(it, emptyList())
+        onProcessComplete(it, issues)
     }
-    return onFinish(files, result)
+    return onFinish(files, detektion)
 }


### PR DESCRIPTION
This class is the same idea of `RuleExtensions` but instead of `lint` to execute a rule it has `invoke` to execute a `FileProcessListenerExtensions` so it have sense to have both classes near.

Also, I plan to use this class in multiple modules soon (not only on detekt-metrics).