### PR TITLE
Enable source set tasks for AGP built-in Kotlin

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -168,7 +168,7 @@ class DetektBasePluginSpec {
             it.setupProject()
         }
 
-        // With built-in Kotlin and disallowKotlinSourceSets, the tasks are registered by Android variant names.
+        // With built-in Kotlin and disallowKotlinSourceSets, the tasks are registered by Android source sets.
         // The release buildType doesn't have test tasks due to `android.onlyEnableUnitTestForTheTestedBuildType`.
         gradleRunner.checkTask("debug", listOf("main", "debug"))
         gradleRunner.checkTask("debugAndroidTest", listOf("androidTest"))

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -169,11 +169,10 @@ class DetektBasePluginSpec {
         }
 
         // With built-in Kotlin and disallowKotlinSourceSets, the tasks are registered by Android source sets.
-        // The release buildType doesn't have test tasks due to `android.onlyEnableUnitTestForTheTestedBuildType`.
-        gradleRunner.checkTask("debug", listOf("main", "debug"))
-        gradleRunner.checkTask("debugAndroidTest", listOf("androidTest"))
-        gradleRunner.checkTask("debugUnitTest", listOf("test"))
-        gradleRunner.checkTask("release", listOf("main"))
+        gradleRunner.checkTask(sourceSetTaskName = "release", kotlinSourceSet = "main")
+        gradleRunner.checkTask(sourceSetTaskName = "debug")
+        gradleRunner.checkTask(sourceSetTaskName = "debugUnitTest", kotlinSourceSet = "test")
+        gradleRunner.checkTask(sourceSetTaskName = "debugAndroidTest", kotlinSourceSet = "androidTest")
     }
 
     @Test
@@ -300,15 +299,10 @@ class DetektBasePluginSpec {
         }
     }
 
-    private fun DslGradleRunner.checkTask(
-        sourceSetTaskName: String,
-        expectedSourceDirs: List<String> = listOf(sourceSetTaskName),
-    ) {
+    private fun DslGradleRunner.checkTask(sourceSetTaskName: String, kotlinSourceSet: String = sourceSetTaskName) {
         runTasksAndCheckResult(":detekt${sourceSetTaskName}SourceSet") { buildResult ->
-            expectedSourceDirs.forEach { dir ->
-                assertThat(buildResult.output)
-                    .containsPattern("""--input \S*[/\\]src[/\\]$dir[/\\]kotlin""")
-            }
+            assertThat(buildResult.output)
+                    .containsPattern("""--input \S*[/\\]src[/\\]$kotlinSourceSet[/\\]kotlin""")
             val checkstyleReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.xml")
             val sarifReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.sarif")
             assertThat(buildResult.output).contains("--report checkstyle:$checkstyleReportFile")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -302,7 +302,7 @@ class DetektBasePluginSpec {
     private fun DslGradleRunner.checkTask(sourceSetTaskName: String, kotlinSourceSet: String = sourceSetTaskName) {
         runTasksAndCheckResult(":detekt${sourceSetTaskName}SourceSet") { buildResult ->
             assertThat(buildResult.output)
-                    .containsPattern("""--input \S*[/\\]src[/\\]$kotlinSourceSet[/\\]kotlin""")
+                .containsPattern("""--input \S*[/\\]src[/\\]$kotlinSourceSet[/\\]kotlin""")
             val checkstyleReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.xml")
             val sarifReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.sarif")
             assertThat(buildResult.output).contains("--report checkstyle:$checkstyleReportFile")

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -131,6 +131,52 @@ class DetektBasePluginSpec {
     }
 
     @Test
+    fun `generates source set tasks for Android project (disallowKotlinSourceSets=true)`() {
+        val gradleRunner = DslGradleRunner(
+            projectLayout = ProjectLayout(
+                numberOfSourceFilesInRootPerSourceDir = 1,
+                srcDirs = listOf(
+                    "src/main/kotlin",
+                    "src/debug/kotlin",
+                    "src/test/kotlin",
+                    "src/androidTest/kotlin",
+                ),
+            ),
+            buildFileName = "build.gradle.kts",
+            mainBuildFileContent = """
+                plugins {
+                    id("com.android.application")
+                    id("dev.detekt")
+                }
+
+                repositories {
+                    mavenLocal()
+                    mavenCentral()
+                    google()
+                }
+
+                android {
+                    compileSdk = 34
+                    namespace = "dev.detekt.gradle.plugin.app"
+                }
+            """.trimIndent(),
+            gradleProperties = mapOf(
+                "android.disallowKotlinSourceSets" to "true",
+            ),
+            dryRun = true,
+        ).also {
+            it.setupProject()
+        }
+
+        // With built-in Kotlin and disallowKotlinSourceSets, the tasks are registered by Android variant names.
+        // The release buildType doesn't have test tasks due to `android.onlyEnableUnitTestForTheTestedBuildType`.
+        gradleRunner.checkTask("debug", listOf("main", "debug"))
+        gradleRunner.checkTask("debugAndroidTest", listOf("androidTest"))
+        gradleRunner.checkTask("debugUnitTest", listOf("test"))
+        gradleRunner.checkTask("release", listOf("main"))
+    }
+
+    @Test
     fun `generates source set tasks when multiple plugins of type KotlinBasePlugin are applied #8613`() {
         val gradleRunner = DslGradleRunner(
             projectLayout = ProjectLayout(
@@ -254,10 +300,15 @@ class DetektBasePluginSpec {
         }
     }
 
-    private fun DslGradleRunner.checkTask(sourceSetTaskName: String) {
+    private fun DslGradleRunner.checkTask(
+        sourceSetTaskName: String,
+        expectedSourceDirs: List<String> = listOf(sourceSetTaskName),
+    ) {
         runTasksAndCheckResult(":detekt${sourceSetTaskName}SourceSet") { buildResult ->
-            assertThat(buildResult.output)
-                .containsPattern("""--input \S*[/\\]src[/\\]$sourceSetTaskName[/\\]kotlin""")
+            expectedSourceDirs.forEach { dir ->
+                assertThat(buildResult.output)
+                    .containsPattern("""--input \S*[/\\]src[/\\]$dir[/\\]kotlin""")
+            }
             val checkstyleReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.xml")
             val sarifReportFile = projectFile("build/reports/detekt/${sourceSetTaskName}SourceSet.sarif")
             assertThat(buildResult.output).contains("--report checkstyle:$checkstyleReportFile")

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -1,26 +1,17 @@
 package dev.detekt.gradle.plugin
 
 import dev.detekt.detekt_gradle_plugin.BuildConfig
-import dev.detekt.gradle.Detekt
-import dev.detekt.gradle.DetektCreateBaselineTask
 import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.extensions.FailOnSeverity
-import dev.detekt.gradle.internal.addVariantName
-import dev.detekt.gradle.internal.existingVariantOrBaseFile
 import dev.detekt.gradle.internal.setCreateBaselineTaskDefaults
 import dev.detekt.gradle.internal.setDetektTaskDefaults
-import dev.detekt.gradle.plugin.internal.mapExplicitArgMode
 import dev.detekt.gradle.plugin.internal.rootProjectDirectoryCompat
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.ReportingBasePlugin
 import org.gradle.api.reporting.ReportingExtension
-import org.jetbrains.kotlin.gradle.plugin.KotlinBasePlugin
-import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 
 class DetektBasePlugin : Plugin<Project> {
-    private var sourceSetListenerConfigured = false
-
     override fun apply(project: Project) {
         project.pluginManager.apply(ReportingBasePlugin::class.java)
 
@@ -65,61 +56,11 @@ class DetektBasePlugin : Plugin<Project> {
         }
 
         project.setTaskDefaults(extension)
-        project.registerSourceSetTasks(extension)
     }
 
     private fun Project.setTaskDefaults(extension: DetektExtension) {
         setDetektTaskDefaults(extension)
         setCreateBaselineTaskDefaults(extension)
-    }
-
-    private fun Project.registerSourceSetTasks(extension: DetektExtension) {
-        project.plugins.withType(KotlinBasePlugin::class.java) {
-            if (sourceSetListenerConfigured) return@withType
-
-            project.extensions.findByType(KotlinSourceSetContainer::class.java)
-                ?.sourceSets
-                ?.configureEach { sourceSet ->
-                    val taskName = "${DetektPlugin.DETEKT_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
-                    tasks.register(taskName, Detekt::class.java) { detektTask ->
-                        detektTask.source = sourceSet.kotlin
-                        detektTask.baseline.convention(
-                            project.layout.file(
-                                extension.baseline.flatMap {
-                                    providers.provider {
-                                        it.asFile.existingVariantOrBaseFile("${sourceSet.name}SourceSet")
-                                    }
-                                }
-                            )
-                        )
-                        if (sourceSet.name == "main") {
-                            detektTask.explicitApi.convention(mapExplicitArgMode())
-                        }
-                        detektTask.description = "Run detekt analysis for ${sourceSet.name} source set"
-                    }
-
-                    val baseLineTaskName = "${DetektPlugin.BASELINE_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
-                    tasks.register(baseLineTaskName, DetektCreateBaselineTask::class.java) { createBaselineTask ->
-                        createBaselineTask.source = sourceSet.kotlin
-
-                        createBaselineTask.baseline.convention(
-                            project.layout.file(
-                                extension.baseline.flatMap {
-                                    providers.provider { it.asFile.addVariantName("${sourceSet.name}SourceSet") }
-                                }
-                            )
-                        )
-
-                        if (sourceSet.name == "main") {
-                            createBaselineTask.explicitApi.convention(mapExplicitArgMode())
-                        }
-                        createBaselineTask.description = "Creates detekt baseline for ${sourceSet.name} source set"
-                    }
-                }
-                ?: return@withType
-
-            sourceSetListenerConfigured = true
-        }
     }
 
     internal companion object {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
@@ -15,6 +15,7 @@ import dev.detekt.gradle.plugin.internal.DetektAndroidCompilations
 import dev.detekt.gradle.plugin.internal.DetektJvmCompilations
 import dev.detekt.gradle.plugin.internal.DetektKmpJvmCompilations
 import dev.detekt.gradle.plugin.internal.conventionCompat
+import dev.detekt.gradle.plugin.internal.registerSourceSetTasks
 import org.gradle.api.Incubating
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -39,6 +40,8 @@ class DetektPlugin : Plugin<Project> {
                 .toBoolean()
         if (enableAndroidTasks) {
             project.registerDetektAndroidTasks(extension)
+        } else {
+            project.registerSourceSetTasks(extension)
         }
         val enableMppTasks =
             !project.providers
@@ -47,6 +50,8 @@ class DetektPlugin : Plugin<Project> {
                 .toBoolean()
         if (enableMppTasks) {
             project.registerDetektMultiplatformTasks(extension)
+        } else {
+            project.registerSourceSetTasks(extension)
         }
         project.registerGenerateConfigTask(extension)
     }
@@ -54,12 +59,14 @@ class DetektPlugin : Plugin<Project> {
     private fun Project.registerDetektJvmTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.jvm") {
             DetektJvmCompilations.registerTasks(project, extension)
+            registerSourceSetTasks(extension)
         }
     }
 
     private fun Project.registerDetektMultiplatformTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.multiplatform") {
             DetektKmpJvmCompilations.registerTasks(project, extension)
+            registerSourceSetTasks(extension)
         }
     }
 
@@ -81,6 +88,7 @@ class DetektPlugin : Plugin<Project> {
             if (builtInGradlePropertyEnabled() && agp9() && enableKotlinDslEnabled()) {
                 DetektAndroidCompilations.registerTasks(project, extension)
                 DetektAndroidCompilations.linkTasks(project, extension)
+                DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = true)
             }
 
             // Enabling built-in Kotlin with the plugin (only available in AGP 9 and higher)
@@ -88,6 +96,7 @@ class DetektPlugin : Plugin<Project> {
                 if (!builtInGradlePropertyEnabled() && enableKotlinDslEnabled()) {
                     DetektAndroidCompilations.registerTasks(project, extension)
                     DetektAndroidCompilations.linkTasks(project, extension)
+                    DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = true)
                 }
             }
 
@@ -95,6 +104,7 @@ class DetektPlugin : Plugin<Project> {
             plugins.withId("kotlin-android") {
                 DetektAndroidCompilations.registerTasks(project, extension)
                 DetektAndroidCompilations.linkTasks(project, extension)
+                DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = false)
             }
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
@@ -15,7 +15,7 @@ import dev.detekt.gradle.plugin.internal.DetektAndroidCompilations
 import dev.detekt.gradle.plugin.internal.DetektJvmCompilations
 import dev.detekt.gradle.plugin.internal.DetektKmpJvmCompilations
 import dev.detekt.gradle.plugin.internal.conventionCompat
-import dev.detekt.gradle.plugin.internal.registerSourceSetTasks
+import dev.detekt.gradle.plugin.internal.registerKotlinSourceSetTasks
 import org.gradle.api.Incubating
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -41,7 +41,7 @@ class DetektPlugin : Plugin<Project> {
         if (enableAndroidTasks) {
             project.registerDetektAndroidTasks(extension)
         } else {
-            project.registerSourceSetTasks(extension)
+            project.registerKotlinSourceSetTasks(extension)
         }
         val enableMppTasks =
             !project.providers
@@ -51,7 +51,7 @@ class DetektPlugin : Plugin<Project> {
         if (enableMppTasks) {
             project.registerDetektMultiplatformTasks(extension)
         } else {
-            project.registerSourceSetTasks(extension)
+            project.registerKotlinSourceSetTasks(extension)
         }
         project.registerGenerateConfigTask(extension)
     }
@@ -59,14 +59,14 @@ class DetektPlugin : Plugin<Project> {
     private fun Project.registerDetektJvmTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.jvm") {
             DetektJvmCompilations.registerTasks(project, extension)
-            registerSourceSetTasks(extension)
+            registerKotlinSourceSetTasks(extension)
         }
     }
 
     private fun Project.registerDetektMultiplatformTasks(extension: DetektExtension) {
         plugins.withId("org.jetbrains.kotlin.multiplatform") {
             DetektKmpJvmCompilations.registerTasks(project, extension)
-            registerSourceSetTasks(extension)
+            registerKotlinSourceSetTasks(extension)
         }
     }
 
@@ -88,7 +88,7 @@ class DetektPlugin : Plugin<Project> {
             if (builtInGradlePropertyEnabled() && agp9() && enableKotlinDslEnabled()) {
                 DetektAndroidCompilations.registerTasks(project, extension)
                 DetektAndroidCompilations.linkTasks(project, extension)
-                DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = true)
+                DetektAndroidCompilations.registerAndroidSourceSetTasks(project, extension)
             }
 
             // Enabling built-in Kotlin with the plugin (only available in AGP 9 and higher)
@@ -96,7 +96,7 @@ class DetektPlugin : Plugin<Project> {
                 if (!builtInGradlePropertyEnabled() && enableKotlinDslEnabled()) {
                     DetektAndroidCompilations.registerTasks(project, extension)
                     DetektAndroidCompilations.linkTasks(project, extension)
-                    DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = true)
+                    DetektAndroidCompilations.registerAndroidSourceSetTasks(project, extension)
                 }
             }
 
@@ -104,7 +104,7 @@ class DetektPlugin : Plugin<Project> {
             plugins.withId("kotlin-android") {
                 DetektAndroidCompilations.registerTasks(project, extension)
                 DetektAndroidCompilations.linkTasks(project, extension)
-                DetektAndroidCompilations.handleKotlinSourceSets(project, extension, builtInKotlin = false)
+                registerKotlinSourceSetTasks(extension)
             }
         }
     }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -73,19 +73,18 @@ internal object DetektAndroidCompilations {
         }
     }
 
-    fun handleKotlinSourceSets(project: Project, extension: DetektExtension, builtInKotlin: Boolean) {
+    fun registerAndroidSourceSetTasks(project: Project, extension: DetektExtension) {
         val disallowKotlinSourceSets = project.providers
             .gradleProperty("android.disallowKotlinSourceSets")
             .getOrElse("true")
             .toBooleanStrict()
 
-        // Fallback to using Kotlin sourceSets if either of these are false.
-        if (!builtInKotlin || !disallowKotlinSourceSets) {
-            project.registerSourceSetTasks(extension)
+        // Fallback to registration by Kotlin source sets.
+        if (!disallowKotlinSourceSets) {
+            project.registerKotlinSourceSetTasks(extension)
             return
         }
 
-        // Resolve Kotlin source sets per variant.
         project.extensions.findByType(AndroidComponentsExtension::class.java)
             ?.onVariants { variant ->
                 val kotlin = variant.sources.kotlin?.all ?: return@onVariants

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -72,4 +72,38 @@ internal object DetektAndroidCompilations {
             }
         }
     }
+
+    fun handleKotlinSourceSets(project: Project, extension: DetektExtension, builtInKotlin: Boolean) {
+        val disallowKotlinSourceSets = project.providers
+            .gradleProperty("android.disallowKotlinSourceSets")
+            .getOrElse("true")
+            .toBooleanStrict()
+
+        // Fallback to using Kotlin sourceSets if either of these are false.
+        if (!builtInKotlin || !disallowKotlinSourceSets) {
+            project.registerSourceSetTasks(extension)
+            return
+        }
+
+        // Resolve Kotlin source sets per variant.
+        project.extensions.findByType(AndroidComponentsExtension::class.java)
+            ?.onVariants { variant ->
+                val kotlin = variant.sources.kotlin?.all ?: return@onVariants
+                project.registerSourceSetTask(
+                    sourceSetName = variant.name,
+                    sourceSet = project.objects.fileCollection().from(kotlin),
+                    extension = extension,
+                )
+
+                @Suppress("UnstableApiUsage")
+                variant.nestedComponents.forEach { nested ->
+                    val nestedKotlin = nested.sources.kotlin?.all ?: return@forEach
+                    project.registerSourceSetTask(
+                        sourceSetName = nested.name,
+                        sourceSet = project.objects.fileCollection().from(nestedKotlin),
+                        extension = extension,
+                    )
+                }
+            }
+    }
 }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -135,7 +135,7 @@ internal fun Project.mapExplicitArgMode(): Provider<String> =
         }
     }
 
-internal fun Project.registerSourceSetTasks(extension: DetektExtension) {
+internal fun Project.registerKotlinSourceSetTasks(extension: DetektExtension) =
     extensions.findByType(KotlinSourceSetContainer::class.java)
         ?.sourceSets
         ?.configureEach { sourceSet ->
@@ -145,7 +145,6 @@ internal fun Project.registerSourceSetTasks(extension: DetektExtension) {
                 extension = extension,
             )
         }
-}
 
 internal fun Project.registerSourceSetTask(
     sourceSetName: String,

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -7,10 +7,12 @@ import dev.detekt.gradle.internal.addVariantName
 import dev.detekt.gradle.internal.existingVariantOrBaseFile
 import dev.detekt.gradle.plugin.DetektPlugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetContainer
 import org.jetbrains.kotlin.gradle.plugin.KotlinTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
@@ -132,3 +134,57 @@ internal fun Project.mapExplicitArgMode(): Provider<String> =
             else -> null
         }
     }
+
+internal fun Project.registerSourceSetTasks(extension: DetektExtension) {
+    extensions.findByType(KotlinSourceSetContainer::class.java)
+        ?.sourceSets
+        ?.configureEach { sourceSet ->
+            registerSourceSetTask(
+                sourceSetName = sourceSet.name,
+                sourceSet = objects.fileCollection().from(sourceSet.kotlin),
+                extension = extension,
+            )
+        }
+}
+
+internal fun Project.registerSourceSetTask(
+    sourceSetName: String,
+    sourceSet: ConfigurableFileCollection,
+    extension: DetektExtension,
+) {
+    val taskName = "${DetektPlugin.DETEKT_TASK_NAME}${sourceSetName.capitalize()}SourceSet"
+    tasks.register(taskName, Detekt::class.java) { detektTask ->
+        detektTask.setSource(sourceSet)
+        detektTask.baseline.convention(
+            project.layout.file(
+                extension.baseline.flatMap {
+                    providers.provider {
+                        it.asFile.existingVariantOrBaseFile("${sourceSetName}SourceSet")
+                    }
+                }
+            )
+        )
+        if (sourceSetName == "main") {
+            detektTask.explicitApi.convention(mapExplicitArgMode())
+        }
+        detektTask.description = "Run detekt analysis for $sourceSetName source set"
+    }
+
+    val baseLineTaskName = "${DetektPlugin.BASELINE_TASK_NAME}${sourceSetName.capitalize()}SourceSet"
+    tasks.register(baseLineTaskName, DetektCreateBaselineTask::class.java) { createBaselineTask ->
+        createBaselineTask.setSource(sourceSet)
+
+        createBaselineTask.baseline.convention(
+            project.layout.file(
+                extension.baseline.flatMap {
+                    providers.provider { it.asFile.addVariantName("${sourceSetName}SourceSet") }
+                }
+            )
+        )
+
+        if (sourceSetName == "main") {
+            createBaselineTask.explicitApi.convention(mapExplicitArgMode())
+        }
+        createBaselineTask.description = "Creates detekt baseline for $sourceSetName source set"
+    }
+}


### PR DESCRIPTION
Closes #9198 

Registering these tasks in the `pluginManager.withId` callbacks was the best solution I could come up with, otherwise the single method for all platforms would get messy since we would have to guard against specific Android scenarios.

The `registerAndroidSourcetTasks` method follows Android's kgpUtils [handleKotlinSourceSets](https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:build-system/gradle-core/src/main/java/com/android/build/gradle/internal/utils/kgpUtils.kt;l=307-328) where we fallback to the old way if `disallowKotlinSourceSets` is false. Otherwise it uses Android's newDsl for registering these source sets.

~One area I need to look into a bit more is why the test cases didn't generate `detektMainSourceSet` and `detektTestSourceSet`, but this does occur in my NIA fork. Guessing maybe the lack of real files in the test cases plays a part, but I'll look into this more.~

Edit: I forgot to set `disallowKotlinSourceSets=false` when comparing main and my branch. Interestingly main and my branch both produce the same output when running `./gradlew tasks --group "verification"`. The only difference between main and my branch is now those source sets aren't empty.

<details>
<summary>Source set task diff with my NIA fork (disallowKotlinSourceSets=false vs true)</summary>

```diff
- detektAndroidTestBenchmarkReleaseSourceSet
- detektAndroidTestDebugSourceSet
- detektAndroidTestDemoDebugSourceSet
- detektAndroidTestDemoSourceSet
- detektAndroidTestNonMinifiedReleaseSourceSet
- detektAndroidTestProdDebugSourceSet
- detektAndroidTestProdSourceSet
- detektAndroidTestReleaseSourceSet
- detektAndroidTestSourceSet
- detektBaselineAndroidTestBenchmarkReleaseSourceSet
- detektBaselineAndroidTestDebugSourceSet
- detektBaselineAndroidTestDemoDebugSourceSet
- detektBaselineAndroidTestDemoSourceSet
- detektBaselineAndroidTestNonMinifiedReleaseSourceSet
- detektBaselineAndroidTestProdDebugSourceSet
- detektBaselineAndroidTestProdSourceSet
- detektBaselineAndroidTestReleaseSourceSet
- detektBaselineAndroidTestSourceSet
- detektBaselineBenchmarkReleaseSourceSet
  detektBaselineDebugAndroidTestSourceSet
  detektBaselineDebugSourceSet
  detektBaselineDebugUnitTestSourceSet
  detektBaselineDemoBenchmarkReleaseSourceSet
  detektBaselineDemoDebugAndroidTestSourceSet
  detektBaselineDemoDebugSourceSet
  detektBaselineDemoDebugUnitTestSourceSet
  detektBaselineDemoNonMinifiedReleaseSourceSet
  detektBaselineDemoReleaseSourceSet
- detektBaselineDemoSourceSet
  detektBaselineMainSourceSet
- detektBaselineNonMinifiedReleaseSourceSet
  detektBaselineProdBenchmarkReleaseSourceSet
  detektBaselineProdDebugAndroidTestSourceSet
  detektBaselineProdDebugSourceSet
  detektBaselineProdDebugUnitTestSourceSet
  detektBaselineProdNonMinifiedReleaseSourceSet
  detektBaselineProdReleaseSourceSet
- detektBaselineProdSourceSet
  detektBaselineReleaseSourceSet
- detektBaselineTestBenchmarkReleaseSourceSet
- detektBaselineTestDebugSourceSet
- detektBaselineTestDemoDebugSourceSet
- detektBaselineTestDemoSourceSet
- detektBaselineTestFixturesBenchmarkReleaseSourceSet
- detektBaselineTestFixturesDebugSourceSet
- detektBaselineTestFixturesDemoSourceSet
- detektBaselineTestFixturesNonMinifiedReleaseSourceSet
- detektBaselineTestFixturesProdSourceSet
- detektBaselineTestFixturesReleaseSourceSet
- detektBaselineTestFixturesSourceSet
- detektBaselineTestNonMinifiedReleaseSourceSet
- detektBaselineTestProdDebugSourceSet
- detektBaselineTestProdSourceSet
- detektBaselineTestReleaseSourceSet
  detektBaselineTestSourceSet
- detektBenchmarkReleaseSourceSet
  detektDebugAndroidTestSourceSet
  detektDebugSourceSet
  detektDebugUnitTestSourceSet
  detektDemoBenchmarkReleaseSourceSet
  detektDemoDebugAndroidTestSourceSet
  detektDemoDebugSourceSet
  detektDemoDebugUnitTestSourceSet
  detektDemoNonMinifiedReleaseSourceSet
  detektDemoReleaseSourceSet
- detektDemoSourceSet
  detektMainSourceSet
- detektNonMinifiedReleaseSourceSet
  detektProdBenchmarkReleaseSourceSet
  detektProdDebugAndroidTestSourceSet
  detektProdDebugSourceSet
  detektProdDebugUnitTestSourceSet
  detektProdNonMinifiedReleaseSourceSet
  detektProdReleaseSourceSet
- detektProdSourceSet
  detektReleaseSourceSet
- detektTestBenchmarkReleaseSourceSet
- detektTestDebugSourceSet
- detektTestDemoDebugSourceSet
- detektTestDemoSourceSet
- detektTestFixturesBenchmarkReleaseSourceSet
- detektTestFixturesDebugSourceSet
- detektTestFixturesDemoSourceSet
- detektTestFixturesNonMinifiedReleaseSourceSet
- detektTestFixturesProdSourceSet
- detektTestFixturesReleaseSourceSet
- detektTestFixturesSourceSet
- detektTestNonMinifiedReleaseSourceSet
- detektTestProdDebugSourceSet
- detektTestProdSourceSet
- detektTestReleaseSourceSet
  detektTestSourceSet
```

</details>
