### PR TITLE
Don't forbid use of java.lang.annotation.Inherited annotation by default

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -616,8 +616,6 @@ style:
         value: 'java.lang.annotation.Retention'
       - reason: 'it is a java annotation. Use `kotlin.annotation.Repeatable` instead.'
         value: 'java.lang.annotation.Repeatable'
-      - reason: 'Kotlin does not support @Inherited annotation, see https://youtrack.jetbrains.com/issue/KT-22265'
-        value: 'java.lang.annotation.Inherited'
   ForbiddenComment:
     active: true
     comments:

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenAnnotation.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenAnnotation.kt
@@ -52,8 +52,6 @@ class ForbiddenAnnotation(config: Config) :
             "java.lang.annotation.Target" to "it is a java annotation. Use `kotlin.annotation.Target` instead.",
             "java.lang.annotation.Retention" to "it is a java annotation. Use `kotlin.annotation.Retention` instead.",
             "java.lang.annotation.Repeatable" to "it is a java annotation. Use `kotlin.annotation.Repeatable` instead.",
-            "java.lang.annotation.Inherited" to "Kotlin does not support @Inherited annotation, " +
-                "see https://youtrack.jetbrains.com/issue/KT-22265",
         )
     ) { list ->
         list.associateBy { it.value }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -40,7 +40,6 @@ class ForbiddenAnnotationSpec(val env: KotlinEnvironmentContainer) {
             import java.lang.annotation.Documented
             import java.lang.annotation.Target
             import java.lang.annotation.Repeatable
-            import java.lang.annotation.Inherited
             import java.lang.annotation.RetentionPolicy
             import java.lang.annotation.ElementType
             import java.lang.Deprecated
@@ -49,7 +48,6 @@ class ForbiddenAnnotationSpec(val env: KotlinEnvironmentContainer) {
             @Retention(RetentionPolicy.RUNTIME)
             @Target(ElementType.TYPE)
             @Repeatable(value = SomeClass::class)
-            @Inherited
             annotation class SomeClass(val value: Array<SomeClass>)
         """.trimIndent()
         val findings = ForbiddenAnnotation(Config.empty).lintWithContext(env, code)
@@ -59,7 +57,6 @@ class ForbiddenAnnotationSpec(val env: KotlinEnvironmentContainer) {
             { assertThat(it).hasTextLocation("@Retention") },
             { assertThat(it).hasTextLocation("@Target") },
             { assertThat(it).hasTextLocation("@Repeatable") },
-            { assertThat(it).hasTextLocation("@Inherited") },
         )
     }
 


### PR DESCRIPTION
This was forbidden by default because the annotation was not supported in Kotlin. This was fixed in Kotlin 2.3.20.

https://youtrack.jetbrains.com/issue/KT-22265