### PR TITLE
MagicNumber DslGradleRunner test fix

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CreateBaselineTaskDslSpec.kt
@@ -24,6 +24,7 @@ class CreateBaselineTaskDslSpec {
                 )
             )
             .withDetektConfig(detektConfig)
+            .withConfigFile("config/detekt/detekt.yml")
             .build()
 
         gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
@@ -47,6 +48,7 @@ class CreateBaselineTaskDslSpec {
                 )
             )
             .withDetektConfig(detektConfig)
+            .withConfigFile("config/detekt/detekt.yml")
             .build()
 
         gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektReportMergeSpec.kt
@@ -53,6 +53,7 @@ class DetektReportMergeSpec {
             buildFileContent,
             settingsFile,
             disableIP = true,
+            configFileOrNone = "config/detekt/detekt.yml",
         )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "sarifReportMerge", "--continue") { result ->
@@ -124,6 +125,7 @@ class DetektReportMergeSpec {
             buildFileContent,
             settingsFile,
             disableIP = true,
+            configFileOrNone = "config/detekt/detekt.yml",
         )
         gradleRunner.setupProject()
         gradleRunner.runTasksAndExpectFailure("detekt", "checkstyleReportMerge", "--continue") { result ->

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskSpec.kt
@@ -60,6 +60,7 @@ class DetektTaskSpec {
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithIssues)
             .withDetektConfig(config)
+            .withConfigFile("config/detekt/detekt.yml")
             .build()
 
         gradleRunner.runDetektTaskAndExpectFailure { result ->
@@ -78,6 +79,7 @@ class DetektTaskSpec {
         val gradleRunner = DslTestBuilder.kotlin()
             .withProjectLayout(projectLayoutWithIssues)
             .withDetektConfig(config)
+            .withConfigFile("config/detekt/detekt.yml")
             .build()
 
         gradleRunner.runDetektTaskAndExpectFailure { result ->

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -44,6 +44,7 @@ constructor(
         style:
           MagicNumber:
             active: true
+            ignorePropertyDeclaration: false
     """.trimIndent()
 
     /**
@@ -55,7 +56,7 @@ constructor(
             internal class $className(
                 val randomDefaultValue: String = "$randomString"
             ) {
-                fun smellyMethod(): Int = ${if (withFinding) "11" else "0"}
+                val smellyConstant: Int = ${if (withFinding) "11" else "0"}
             }
             
         """.trimIndent() // Last line empty to prevent NewLineAtEndOfFile.

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -55,7 +55,7 @@ constructor(
             internal class $className(
                 val randomDefaultValue: String = "$randomString"
             ) {
-                val smellyConstant: Int = ${if (withFinding) "11" else "0"}
+                fun smellyMethod(): Int = ${if (withFinding) "11" else "0"}
             }
             
         """.trimIndent() // Last line empty to prevent NewLineAtEndOfFile.


### PR DESCRIPTION
This was easy to miss with changing the default of `ignorePropertyDeclaration` from false to true, but some of these Gradle tests rely on expecting this `smellyConstant` to continue being a code smell which isn't the case anymore by default. ~Changed it to a method so that it should report when withFinding is true.~

Edit: Changing it to a method caused other issues, so the easiest fix I can think of for now is converting back to a constant and setting `ignorePropertyDeclaration` to false since this is what these test cases expected. Updated those test cases to make sure it uses the configFileContent by passing a file name through `withConfigFile`.

