### PR TITLE
Fix errors when changing core and executing `detekt`

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/ClassLoaderCache.kt
@@ -2,6 +2,8 @@ package dev.detekt.gradle.internal
 
 import java.io.File
 import java.net.URLClassLoader
+import java.security.MessageDigest
+import java.util.Locale
 import java.util.concurrent.ConcurrentHashMap
 
 internal fun interface ClassLoaderCache {
@@ -10,11 +12,10 @@ internal fun interface ClassLoaderCache {
 }
 
 internal class DefaultClassLoaderCache : ClassLoaderCache {
-
-    private val classpathFilesHashWithLoaders = ConcurrentHashMap<Int, URLClassLoader>()
+    private val classpathFilesHashWithLoaders = ConcurrentHashMap<String, URLClassLoader>()
 
     override fun getOrCreate(classpath: Set<File>): URLClassLoader {
-        val classpathHashCode = classpath.sorted().hashCode()
+        val classpathHashCode = sha1(classpath.sorted())
         return classpathFilesHashWithLoaders.getOrPut(classpathHashCode) {
             URLClassLoader(
                 classpath.map { it.toURI().toURL() }.toTypedArray(),
@@ -25,3 +26,29 @@ internal class DefaultClassLoaderCache : ClassLoaderCache {
 }
 
 internal object GlobalClassLoaderCache : ClassLoaderCache by DefaultClassLoaderCache()
+
+private fun sha1(paths: Collection<File>): String {
+    val digest = MessageDigest.getInstance("SHA-1")
+    val buffer = ByteArray(8192)
+
+    paths
+        .flatMap { file ->
+            if (file.isDirectory) {
+                file.walkTopDown().filter { it.isFile }.sortedBy { it.absolutePath }
+            } else if (file.exists()) {
+                sequenceOf(file)
+            } else {
+                emptySequence()
+            }
+        }
+        .forEach { file ->
+            file.inputStream().use { input ->
+                var bytesRead = input.read(buffer)
+                while (bytesRead != -1) {
+                    digest.update(buffer, 0, bytesRead)
+                    bytesRead = input.read(buffer)
+                }
+            }
+        }
+    return digest.digest().joinToString("") { "%02x".format(Locale.ROOT, it) }
+}

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/ClassLoaderCache.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/ClassLoaderCache.kt
@@ -14,7 +14,7 @@ internal class DefaultClassLoaderCache : ClassLoaderCache {
     private val classpathFilesHashWithLoaders = ConcurrentHashMap<Int, URLClassLoader>()
 
     override fun getOrCreate(classpath: Set<File>): URLClassLoader {
-        val classpathHashCode = HashSet(classpath).hashCode()
+        val classpathHashCode = classpath.sorted().hashCode()
         return classpathFilesHashWithLoaders.getOrPut(classpathHashCode) {
             URLClassLoader(
                 classpath.map { it.toURI().toURL() }.toTypedArray(),


### PR DESCRIPTION
Fixes #2957

We have a `ClassLoader` cache. The problem was that we didn't invalidate the cache correctly. We were just looking at changes in the paths of the classpath. But if the content of any of those paths changes we should invalidate it too. That's what this PR does. Instead of hashing the paths I'm now hashing the content of those paths.

There are two "problems" with this implementation:
1. With this change we "invalidate" the cache more times, so we are going to leak more `ClassLoader`s in that `ConcurrentHashMap`. We had the leak already but this PR makes it even worst.
2. I don't like to sort a classpath. The order in a classpath is important (class shadowing). But the problem is that in the current implementation, at detekt, we are creating 5 `ClassLoaders`. But with my new implementation we create a `ClassLoader` per module. That's bad! But If I sort the classpath that problem goes away.

For the point 1 I propose to use [Caffeine](https://github.com/ben-manes/caffeine). For the point 2 I think that we can assume that class shadowing is something that we don't care (because it should not happen).