### PR TITLE
Suggest similar property names for misspelled config properties

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidator.kt
@@ -55,7 +55,7 @@ internal class InvalidPropertiesConfigValidator(
         if (!baseline.contains(propertyName)) {
             val ruleName = extractRuleName(propertyName)
             if (ruleName == null || !baseline.contains(ruleName.value)) {
-                return listOf(propertyDoesNotExists(propertyPath))
+                return listOf(propertyDoesNotExists(propertyPath, propertyName, baseline.keys))
             }
         }
         if (configToValidate[propertyName] is String && baseline[propertyName] is List<*>) {
@@ -80,12 +80,31 @@ internal class InvalidPropertiesConfigValidator(
 
     companion object {
 
-        internal fun propertyDoesNotExists(prop: String): Notification =
-            Notification(
-                "Property '$prop' is misspelled or does not exist. " +
-                    "This error may also indicate a detekt plugin is necessary to handle the '$prop' key.",
-                Level.Error
-            )
+        internal fun propertyDoesNotExists(
+            prop: String,
+            misspelledName: String,
+            allowedProperties: Set<String>,
+        ): Notification {
+            val message = buildString {
+                append("Property '$prop' is misspelled or does not exist.")
+                val closestMatch = findClosestMatch(misspelledName, allowedProperties)
+                if (closestMatch != null) {
+                    append(" Did you mean '$closestMatch'?")
+                }
+                append(" Allowed properties: ${allowedProperties.sorted()}.")
+                append(" This error may also indicate a detekt plugin is necessary to handle the '$prop' key.")
+            }
+            return Notification(message, Level.Error)
+        }
+
+        internal fun findClosestMatch(name: String, candidates: Set<String>): String? {
+            val threshold = maxOf(1, name.length / 3)
+            return candidates
+                .map { it to levenshteinDistance(name.lowercase(), it.lowercase()) }
+                .filter { (_, distance) -> distance <= threshold }
+                .minByOrNull { (_, distance) -> distance }
+                ?.first
+        }
 
         internal fun nestedConfigurationExpected(prop: String): Notification =
             Notification("Nested config expected for '$prop'.", Level.Error)
@@ -96,4 +115,17 @@ internal class InvalidPropertiesConfigValidator(
         internal fun propertyShouldBeAnArray(prop: String): Notification =
             Notification("Property '$prop' should be a YAML array instead of a String.", Level.Error)
     }
+}
+
+private fun levenshteinDistance(a: String, b: String): Int {
+    val dp = Array(a.length + 1) { IntArray(b.length + 1) }
+    for (i in 0..a.length) dp[i][0] = i
+    for (j in 0..b.length) dp[0][j] = j
+    for (i in 1..a.length) {
+        for (j in 1..b.length) {
+            val cost = if (a[i - 1] == b[j - 1]) 0 else 1
+            dp[i][j] = minOf(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + cost)
+        }
+    }
+    return dp[a.length][b.length]
 }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/validation/InvalidPropertiesConfigValidatorSpec.kt
@@ -3,6 +3,7 @@ package dev.detekt.core.config.validation
 import dev.detekt.api.Config
 import dev.detekt.api.Notification
 import dev.detekt.core.config.CompositeConfig
+import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.findClosestMatch
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.nestedConfigurationExpected
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.propertyDoesNotExists
 import dev.detekt.core.config.validation.InvalidPropertiesConfigValidator.Companion.unexpectedNestedConfiguration
@@ -47,20 +48,21 @@ internal class InvalidPropertiesConfigValidatorSpec {
     @Test
     fun `reports different rule set name`() {
         val result = subject.validate(yamlConfig("config_validation/other-ruleset-name.yml"))
-        assertThat(result).contains(propertyDoesNotExists("code-smell"))
+        assertThat(result).anySatisfy { notification ->
+            assertThat(notification.message).contains("'code-smell' is misspelled or does not exist")
+        }
     }
 
     @Test
     fun `reports different nested property names`() {
         val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
 
-        assertThat(result).contains(
-            propertyDoesNotExists("complexity>LongLongMethod"),
-            propertyDoesNotExists("complexity>LongParameterList>enabled"),
-            propertyDoesNotExists("complexity>LargeClass>howMany"),
-            propertyDoesNotExists("complexity>InnerMap>InnerKey"),
-            propertyDoesNotExists("complexity>InnerMap>Inner2>nestedActive")
-        )
+        val messages = result.map { it.message }
+        assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongLongMethod'") }
+        assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongParameterList>enabled'") }
+        assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LargeClass>howMany'") }
+        assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>InnerKey'") }
+        assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>Inner2>nestedActive'") }
     }
 
     @Test
@@ -138,12 +140,101 @@ internal class InvalidPropertiesConfigValidatorSpec {
             assertThat(result).contains(
                 nestedConfigurationExpected("complexity"),
                 nestedConfigurationExpected("style>WildcardImport"),
-                propertyDoesNotExists("complexity>LongLongMethod"),
-                propertyDoesNotExists("complexity>LongParameterList>enabled"),
-                propertyDoesNotExists("complexity>LargeClass>howMany"),
-                propertyDoesNotExists("complexity>InnerMap>InnerKey"),
-                propertyDoesNotExists("complexity>InnerMap>Inner2>nestedActive")
             )
+            val messages = result.map { it.message }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongLongMethod'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongParameterList>enabled'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LargeClass>howMany'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>InnerKey'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>Inner2>nestedActive'") }
+        }
+    }
+
+    @Nested
+    inner class `suggests similar property names` {
+
+        @Test
+        fun `suggests similar property name for close matches`() {
+            val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
+            val longLongMethodMessage = result.map { it.message }
+                .first { it.contains("'complexity>LongLongMethod'") }
+
+            assertThat(longLongMethodMessage).contains("Did you mean 'LongMethod'?")
+        }
+
+        @Test
+        fun `lists allowed properties in error message`() {
+            val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
+            val howManyMessage = result.map { it.message }
+                .first { it.contains("'complexity>LargeClass>howMany'") }
+
+            assertThat(howManyMessage).contains("Allowed properties: [active, threshold]")
+        }
+
+        @Test
+        fun `does not suggest when no close match exists`() {
+            val result = subject.validate(yamlConfig("config_validation/other-ruleset-name.yml"))
+            val codeSmellMessage = result.map { it.message }
+                .first { it.contains("'code-smell'") }
+
+            assertThat(codeSmellMessage).doesNotContain("Did you mean")
+        }
+    }
+
+    @Nested
+    inner class `propertyDoesNotExists message format` {
+
+        @Test
+        fun `includes suggestion for close match`() {
+            val notification = propertyDoesNotExists(
+                "complexity>LargeClass>threshhold",
+                "threshhold",
+                setOf("active", "threshold"),
+            )
+            assertThat(notification.message).contains("Did you mean 'threshold'?")
+            assertThat(notification.message).contains("Allowed properties: [active, threshold]")
+        }
+
+        @Test
+        fun `omits suggestion when no close match`() {
+            val notification = propertyDoesNotExists(
+                "complexity>LargeClass>xyz",
+                "xyz",
+                setOf("active", "threshold"),
+            )
+            assertThat(notification.message).doesNotContain("Did you mean")
+            assertThat(notification.message).contains("Allowed properties: [active, threshold]")
+        }
+    }
+
+    @Nested
+    inner class `find closest match` {
+
+        @Test
+        fun `finds closest match for typo`() {
+            val result = findClosestMatch("threshhold", setOf("active", "threshold"))
+            assertThat(result).isEqualTo("threshold")
+        }
+
+        @Test
+        fun `finds closest match case insensitively`() {
+            val result = findClosestMatch("Active", setOf("active", "threshold"))
+            assertThat(result).isEqualTo("active")
+        }
+
+        @Test
+        fun `returns null when no close match`() {
+            val result = findClosestMatch("xyz", setOf("active", "threshold"))
+            assertThat(result).isNull()
+        }
+
+        @Test
+        fun `finds closest match for similar name`() {
+            val result = findClosestMatch(
+                "LongLongMethod",
+                setOf("LongMethod", "LongParameterList", "LargeClass", "InnerMap"),
+            )
+            assertThat(result).isEqualTo("LongMethod")
         }
     }
 
@@ -165,16 +256,13 @@ internal class InvalidPropertiesConfigValidatorSpec {
             val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, patterns(".*>.*>howMany"))
             val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
 
-            assertThat(result).contains(
-                propertyDoesNotExists("complexity>LongLongMethod"),
-                propertyDoesNotExists("complexity>LongParameterList>enabled"),
-                propertyDoesNotExists("complexity>InnerMap>InnerKey"),
-                propertyDoesNotExists("complexity>InnerMap>Inner2>nestedActive")
-            )
+            val messages = result.map { it.message }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongLongMethod'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongParameterList>enabled'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>InnerKey'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>InnerMap>Inner2>nestedActive'") }
 
-            assertThat(result).doesNotContain(
-                propertyDoesNotExists("complexity>LargeClass>howMany")
-            )
+            assertThat(messages).noneSatisfy { assertThat(it).contains("'complexity>LargeClass>howMany'") }
         }
 
         @Test
@@ -183,16 +271,13 @@ internal class InvalidPropertiesConfigValidatorSpec {
             val subject = InvalidPropertiesConfigValidator(baseline, deprecatedProperties, patterns(".*>InnerMap"))
             val result = subject.validate(yamlConfig("config_validation/other-nested-property-names.yml"))
 
-            assertThat(result).contains(
-                propertyDoesNotExists("complexity>LargeClass>howMany"),
-                propertyDoesNotExists("complexity>LongLongMethod"),
-                propertyDoesNotExists("complexity>LongParameterList>enabled")
-            )
+            val messages = result.map { it.message }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LargeClass>howMany'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongLongMethod'") }
+            assertThat(messages).anySatisfy { assertThat(it).contains("'complexity>LongParameterList>enabled'") }
 
-            assertThat(result).doesNotContain(
-                propertyDoesNotExists("complexity>InnerMap>InnerKey"),
-                propertyDoesNotExists("complexity>InnerMap>Inner2>nestedActive")
-            )
+            assertThat(messages).noneSatisfy { assertThat(it).contains("'complexity>InnerMap>InnerKey'") }
+            assertThat(messages).noneSatisfy { assertThat(it).contains("'complexity>InnerMap>Inner2>nestedActive'") }
         }
     }
 }


### PR DESCRIPTION
Fixes: #8892

Adds "Did you mean 'X'?" suggestion and allowed properties list to misspelled config property errors.