### PR TITLE
Excluding generated sources by default

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
@@ -622,6 +622,126 @@ class DetektAndroidSpec {
             }
         }
     }
+
+    @Nested
+    inner class `excludes generated source sets by default` {
+        val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+            addSubmodule(
+                name = "app",
+                numberOfSourceFilesPerSourceDir = 0,
+                buildFileContent = joinGradleBlocks(
+                    APP_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    """
+                        kotlin {
+                            sourceSets {
+                                debug {
+                                    val generatedDir = project.layout.buildDirectory.dir("generated/debug")
+                                    generatedKotlin.srcDir(generatedDir)
+                                }
+                            }
+                        }
+                    """.trimIndent(),
+                ),
+                srcDirs = listOf("src/main/java"),
+            )
+        }
+
+        val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, dryRun = true).also {
+            it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent)
+            it.writeProjectFile(
+                filename = "app/build/generated/debug/GeneratedClass.kt",
+                content = """
+                    package generated
+                    class GeneratedClass
+                """.trimIndent()
+            )
+            it.writeProjectFile(
+                filename = "app/src/main/java/MainActivity.kt",
+                content = """
+                    import generated.GeneratedClass
+                    class MainActivity {
+                        val generated = GeneratedClass()
+                    }
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        @DisplayName("task app:detektDebug")
+        fun appDetektDebug() {
+            gradleRunner.runTasksAndCheckResult(":app:detektDebug") { result ->
+                assertThat(result.output).containsPattern(
+                    """--input \S*[/\\]app[/\\]src[/\\]main[/\\]java"""
+                )
+                assertThat(result.output).doesNotContainPattern(
+                    """--input \S*[/\\]app[/\\]build"""
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class `allows adding generated source sets to detekt sources` {
+        val projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 0).apply {
+            addSubmodule(
+                name = "app",
+                numberOfSourceFilesPerSourceDir = 0,
+                buildFileContent = joinGradleBlocks(
+                    APP_PLUGIN_BLOCK,
+                    ANDROID_BLOCK,
+                    """
+                        kotlin {
+                            sourceSets {
+                                debug {
+                                    val generatedDir = project.layout.buildDirectory.dir("generated/debug")
+                                    generatedKotlin.srcDir(generatedDir)
+                                }
+                            }
+                        }
+                        
+                        tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
+                            source(project.layout.buildDirectory.dir("generated/debug"))
+                        }
+                    """.trimIndent(),
+                ),
+                srcDirs = listOf("src/main/java"),
+            )
+        }
+
+        val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, dryRun = true).also {
+            it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent)
+            it.writeProjectFile(
+                filename = "app/build/generated/debug/GeneratedClass.kt",
+                content = """
+                    package generated
+                    class GeneratedClass
+                """.trimIndent()
+            )
+            it.writeProjectFile(
+                filename = "app/src/main/java/MainActivity.kt",
+                content = """
+                    import generated.GeneratedClass
+                    class MainActivity {
+                        val generated = GeneratedClass()
+                    }
+                """.trimIndent()
+            )
+        }
+
+        @Test
+        @DisplayName("task app:detektDebug")
+        fun appDetektDebug() {
+            gradleRunner.runTasksAndCheckResult(":app:detektDebug") { result ->
+                assertThat(result.output).containsPattern(
+                    """--input \S*[/\\]app[/\\]src[/\\]main[/\\]java"""
+                )
+                assertThat(result.output).containsPattern(
+                    """--input \S*[/\\]app[/\\]build"""
+                )
+            }
+        }
+    }
 }
 
 /**

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -390,6 +390,138 @@ class DetektMultiplatformSpec {
             }
         }
     }
+
+    @Nested
+    inner class `multiplatform projects - excludes generated sources by default` {
+        val gradleRunner =
+            setupProject {
+                addSubmodule(
+                    name = "shared",
+                    numberOfSourceFilesPerSourceDir = 1,
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                        kotlin {
+                            jvm()
+                            sourceSets {
+                                jvmMain {
+                                    val generatedDir = project.layout.buildDirectory.dir("generated/jvmMain")
+                                    generatedKotlin.srcDir(generatedDir)
+                                }
+                            }
+                        }
+                        """.trimIndent(),
+                    ),
+                    srcDirs = listOf(
+                        "src/commonMain/kotlin",
+                        "src/jvmMain/kotlin",
+                    ),
+                )
+            }.also {
+                it.writeProjectFile(
+                    "shared/build/generated/jvmMain/GeneratedClass.kt",
+                    """
+                        package generated
+                        class GeneratedClass
+                    """.trimIndent()
+                )
+            }
+
+        @Test
+        fun `detektMainJvm configures sources`() {
+            gradleRunner.runTasksAndCheckResult(":shared:detektMainJvm") {
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]jvmMain[/\\]kotlin"""
+                )
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]commonMain[/\\]kotlin"""
+                )
+                assertThat(it.output).doesNotContainPattern(
+                    """--input \S*[/\\]shared[/\\]build"""
+                )
+            }
+        }
+
+        @Test
+        fun `detektCommonMain configures sources`() {
+            gradleRunner.runTasksAndCheckResult(":shared:detektCommonMain") {
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]commonMain[/\\]kotlin"""
+                )
+                assertThat(it.output).doesNotContainPattern(
+                    """--input \S*[/\\]shared[/\\]build"""
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class `multiplatform projects - allows adding generated source sets to detekt sources` {
+        val gradleRunner =
+            setupProject {
+                addSubmodule(
+                    name = "shared",
+                    numberOfSourceFilesPerSourceDir = 1,
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                        kotlin {
+                            jvm()
+                            sourceSets {
+                                jvmMain {
+                                    val generatedDir = project.layout.buildDirectory.dir("generated/jvmMain")
+                                    generatedKotlin.srcDir(generatedDir)
+                                }
+                            }
+                        }
+                        
+                        tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
+                            source(project.layout.buildDirectory.dir("generated/jvmMain"))
+                        }
+                        """.trimIndent(),
+                    ),
+                    srcDirs = listOf(
+                        "src/commonMain/kotlin",
+                        "src/jvmMain/kotlin",
+                    ),
+                )
+            }.also {
+                it.writeProjectFile(
+                    "shared/build/generated/jvmMain/GeneratedClass.kt",
+                    """
+                        package generated
+                        class GeneratedClass
+                    """.trimIndent()
+                )
+            }
+
+        @Test
+        fun `detektMainJvm configures sources`() {
+            gradleRunner.runTasksAndCheckResult(":shared:detektMainJvm") {
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]jvmMain[/\\]kotlin"""
+                )
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]commonMain[/\\]kotlin"""
+                )
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]build"""
+                )
+            }
+        }
+
+        @Test
+        fun `detektCommonMain configures sources`() {
+            gradleRunner.runTasksAndCheckResult(":shared:detektCommonMain") {
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]src[/\\]commonMain[/\\]kotlin"""
+                )
+                assertThat(it.output).containsPattern(
+                    """--input \S*[/\\]shared[/\\]build"""
+                )
+            }
+        }
+    }
 }
 
 private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner =

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -1,6 +1,7 @@
 package dev.detekt.gradle.plugin.internal
 
 import com.android.build.api.variant.AndroidComponentsExtension
+import com.android.build.api.variant.Component
 import com.android.build.api.variant.Variant
 import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.plugin.DetektPlugin
@@ -9,12 +10,37 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidExtension
 
 internal object DetektAndroidCompilations {
     fun registerTasks(project: Project, extension: DetektExtension) {
-        project.extensions.getByType(
-            KotlinAndroidExtension::class.java
-        ).target.compilations.configureEach { compilation ->
-            project.registerJvmCompilationDetektTask(extension, compilation)
-            project.registerJvmCompilationCreateBaselineTask(extension, compilation)
+        val kotlinAndroid = project.extensions.getByType(KotlinAndroidExtension::class.java)
+        project.extensions.findByType(AndroidComponentsExtension::class.java)?.onVariants { variant ->
+            variant.registerDetektTasks(project, extension, kotlinAndroid)
+
+            @Suppress("UnstableApiUsage")
+            variant.nestedComponents.forEach { nested ->
+                nested.registerDetektTasks(project, extension, kotlinAndroid)
+            }
         }
+    }
+
+    private fun Component.registerDetektTasks(
+        project: Project,
+        extension: DetektExtension,
+        kotlinAndroid: KotlinAndroidExtension,
+    ) {
+        val kotlin = sources.kotlin?.all ?: return
+        val source = project.objects.fileCollection().from(kotlin)
+        kotlinAndroid.target.compilations.matching { it.name == name }
+            .configureEach { compilation ->
+                project.registerJvmCompilationDetektTask(
+                    extension = extension,
+                    compilation = compilation,
+                    source = source,
+                )
+                project.registerJvmCompilationCreateBaselineTask(
+                    extension = extension,
+                    compilation = compilation,
+                    source = source,
+                )
+            }
     }
 
     private fun DetektExtension.matchesIgnoredConfiguration(variant: Variant): Boolean =

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -7,6 +7,7 @@ import dev.detekt.gradle.internal.addVariantName
 import dev.detekt.gradle.internal.existingVariantOrBaseFile
 import dev.detekt.gradle.plugin.DetektPlugin
 import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
@@ -18,12 +19,13 @@ internal fun Project.registerJvmCompilationDetektTask(
     extension: DetektExtension,
     compilation: KotlinCompilation<*>,
     target: KotlinTarget? = null,
+    source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
     val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
     tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
-        detektTask.setSource(siblingTask.map { it.sources })
+        detektTask.source(source)
         detektTask.classpath.conventionCompat(
             compilation.output.classesDirs,
             siblingTask.map { it.libraries }
@@ -71,6 +73,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     extension: DetektExtension,
     compilation: KotlinCompilation<*>,
     target: KotlinTarget? = null,
+    source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
     val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
     tasks.register(
@@ -79,7 +82,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
-        createBaselineTask.setSource(siblingTask.map { it.sources })
+        createBaselineTask.source(source)
         createBaselineTask.classpath.conventionCompat(
             compilation.output.classesDirs,
             siblingTask.map { it.libraries }
@@ -132,3 +135,10 @@ internal fun Project.mapExplicitArgMode(): Provider<String> =
             else -> null
         }
     }
+
+internal fun Project.sourceProvider(compilation: KotlinCompilation<*>): ConfigurableFileCollection =
+    objects.fileCollection().from(
+        provider {
+            compilation.allKotlinSourceSets.map { it.kotlin.sourceDirectories }
+        }
+    )

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -136,7 +136,7 @@ internal fun Project.mapExplicitArgMode(): Provider<String> =
         }
     }
 
-internal fun Project.sourceProvider(compilation: KotlinCompilation<*>): ConfigurableFileCollection =
+private fun Project.sourceProvider(compilation: KotlinCompilation<*>): ConfigurableFileCollection =
     objects.fileCollection().from(
         provider {
             compilation.allKotlinSourceSets.map { it.kotlin.sourceDirectories }


### PR DESCRIPTION
Closes #8933 

Circling back to this logic as this is what I initially tried to help with a few months ago, but now that AGP 9 support is here, the logic is a lot simpler.

Using the KotlinJvmCompile sources is what includes everything as a source to the Detekt tasks when Detekt's sources should be the Kotlin (or Android) source sets. For non-Android this is simple as we use `allKotlinSourceSets.map { it.kotlin.sourceDirectories }`, this is also what Detekt [1.23.8 uses](https://github.com/detekt/detekt/blob/v1.23.8/detekt-gradle-plugin/src/main/kotlin/io/gitlab/arturbosch/detekt/internal/DetektJvm.kt#L14-L16).

Android makes this more difficult as they now empty this source set, but Detekt needs all the other metadata from the KotlinJvmCompile class. Using Android's newDsl onVariants logic with `matching` and `configureEach` will allow us to pair the source set required from Android along with the KotlinJvmCompile data.

One other simple change was using `task.source` instead of `task.setSource` as the `setSource` replaces any previously applied sources, while the `task.source` is additive. This is what allows a user to still provide additional sources like generated ones if they want, which is demonstrated in the test cases.

