### PR TITLE
UnnecessaryLet: fix false positives when the receiver is used inside `let`

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryLet.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryLet.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSafeQualifiedExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * `let` expressions are used extensively in our code for null-checking and chaining functions,
@@ -122,18 +123,17 @@ private fun KtExpression?.getRootExpression(): KtExpression? {
 
 private fun KtLambdaExpression.countLambdaParameterReference(): Int {
     val bodyExpression = bodyExpression ?: return 0
+    val receiver = this.getStrictParentOfType<KtQualifiedExpression>()?.receiverExpression
     return analyze(this) {
-        if (valueParameters.isNotEmpty()) {
-            valueParameters.first().destructuringDeclaration?.symbol?.entries ?: listOf(firstParameterOrNull())
-        } else {
-            // implicit it param
-            listOf(firstParameterOrNull())
+        val parameters = buildList {
+            val destructuringDeclaration = valueParameters.singleOrNull()?.destructuringDeclaration
+            addAll(destructuringDeclaration?.symbol?.entries ?: listOfNotNull(firstParameterOrNull()))
+            receiver?.mainReference?.resolveToSymbol()?.let { add(it) }
         }
-            .filterNotNull()
-            .sumOf { variableSymbol ->
-                bodyExpression.collectDescendantsOfType<KtSimpleNameExpression> {
-                    it.mainReference.resolveToSymbol() == variableSymbol
-                }.count()
-            }
+        parameters.sumOf { variableSymbol ->
+            bodyExpression.collectDescendantsOfType<KtSimpleNameExpression> {
+                it.mainReference.resolveToSymbol() == variableSymbol
+            }.count()
+        }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryLetSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryLetSpec.kt
@@ -612,6 +612,34 @@ class UnnecessaryLetSpec(val env: KotlinEnvironmentContainer) {
             assertThat(findings).hasSize(2)
         }
     }
+
+    @Test
+    fun `when let uses the it`() {
+        val content = """
+            fun some(value: Int) = value
+            fun test(value: Int?) {
+                value?.let {
+                    some(it)
+                }
+            }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, content)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `when let uses the variable`() {
+        val content = """
+            fun some(value: Int) = value
+            fun test(value: Int?) {
+                value?.let {
+                    some(value)
+                }
+            }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, content)
+        assertThat(findings).isEmpty()
+    }
 }
 
 private const val MESSAGE_OMIT_LET = "let expression can be omitted"


### PR DESCRIPTION
Fixes #7767