### PR TITLE
Compile DGP with Gradle's experimental public API artifact

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -77,7 +77,7 @@ testing {
             dependencies {
                 implementation(libs.assertj.core)
                 implementation(libs.kotlin.gradle.plugin)
-                implementation(gradleKotlinDsl())
+                runtimeOnly(gradleKotlinDsl())
             }
         }
         register<JvmTestSuite>("functionalTest") {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -115,9 +115,15 @@ testing {
     }
 }
 
+val kotlinCompilerVersion = "2.1.21"
+
 kotlin {
     @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
-    compilerVersion = "2.1.21"
+    compilerVersion = kotlinCompilerVersion
+
+    // Pin the kotlin-stdlib (and friends) added by the Kotlin Gradle plugin to match compilerVersion,
+    // so DGP's compile classpath does not receive stdlib 2.3 metadata that Kotlin 2.1 cannot read.
+    coreLibrariesVersion = kotlinCompilerVersion
 
     compilerOptions {
         suppressWarnings = true
@@ -139,6 +145,27 @@ kotlin {
 
 val testKitRuntimeOnly by configurations.registering
 val testKitGradleMinVersionRuntimeOnly by configurations.registering
+
+// Replace Kotlin JARs from Gradle distribution with versions that match the pinned compiler version. The versions in
+// the Gradle distribution carry Kotlin metadata (2.3 at time of writing) that is too new for the pinned compiler (2.1
+// at time of writing) to read.
+configurations.configureEach {
+    withDependencies {
+        filterIsInstance<FileCollectionDependency>().forEach { dependency ->
+            val filteredFiles = files(
+                dependency.files.filter { file ->
+                    !file.name.startsWith("kotlin-stdlib") && !file.name.startsWith("kotlin-reflect")
+                }
+            )
+            if (dependency.files != filteredFiles) {
+                remove(dependency)
+                add(project.dependencies.create(filteredFiles))
+                add(project.dependencies.create("org.jetbrains.kotlin:kotlin-stdlib:$kotlinCompilerVersion"))
+                add(project.dependencies.create("org.jetbrains.kotlin:kotlin-reflect:$kotlinCompilerVersion"))
+            }
+        }
+    }
+}
 
 dependencies {
     compileOnly(libs.android.gradleApi)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -143,10 +143,22 @@ val testKitGradleMinVersionRuntimeOnly by configurations.registering
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
+    compileOnly(libs.gradle.publicApi) {
+        capabilities {
+            // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
     compileOnly(libs.jetbrains.annotations)
 
     implementation(libs.sarif4k)
     testFixturesCompileOnly(libs.jetbrains.annotations)
+    testFixturesCompileOnlyApi(libs.gradle.publicApi) {
+        capabilities {
+            // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
 
     testKitRuntimeOnly(libs.kotlin.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.plugin)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -143,6 +143,12 @@ val testKitGradleMinVersionRuntimeOnly = configurations.register("testKitGradleM
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
+    compileOnlyApi(libs.gradle.publicApi) {
+        capabilities {
+            // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
     compileOnly(libs.jetbrains.annotations)
 
     implementation(libs.sarif4k)

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -7,6 +7,7 @@ import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import org.jetbrains.kotlin.buildtools.api.ExperimentalBuildToolsApi
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 plugins {
     id("module")
@@ -217,6 +218,30 @@ signing {
 }
 
 tasks {
+    /*
+     * Ignore metadata version checks for tests. Gradle API is on the classpath which includes stdlib and reflect libs
+     * that have Kotlin metadata too new for the Kotlin compiler version used in this build to read. This affects test
+     * compilations only. The suppress-gradle-api system property set for this build does not affect test compilations
+     * at this stage, so replacing the Gradle API with the separately published Gradle API is not currently possible.
+     */
+    named<KotlinJvmCompile>("compileFunctionalTestKotlin") {
+        compilerOptions {
+            freeCompilerArgs.add("-Xskip-metadata-version-check")
+        }
+    }
+
+    named<KotlinJvmCompile>("compileTestFixturesKotlin") {
+        compilerOptions {
+            freeCompilerArgs.add("-Xskip-metadata-version-check")
+        }
+    }
+
+    named<KotlinJvmCompile>("compileFunctionalTestMinSupportedGradleKotlin") {
+        compilerOptions {
+            freeCompilerArgs.add("-Xskip-metadata-version-check")
+        }
+    }
+
     // Manually inject dependency to gradle-testkit since the default injected plugin classpath is from `main.runtime`.
     pluginUnderTestMetadata {
         pluginClasspath.from(testKitRuntimeOnly)

--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -2,3 +2,4 @@ kotlin.stdlib.default.dependency=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 kotlin.compiler.runViaBuildToolsApi=true
 dependency.analysis.print.build.health=true
+org.gradle.unsafe.suppress-gradle-api=true

--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -1,3 +1,5 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 dependency.analysis.print.build.health=true
+# Don't add Gradle API dependency to compileOnlyApi configuration. See https://github.com/gradle/gradle/blob/v9.5.0/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L174-L182
+systemProp.org.gradle.unsafe.suppress-gradle-api=true

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -17,6 +17,14 @@ dependencyResolutionManagement {
                 includeGroup("com.google.testing.platform")
             }
         }
+        exclusiveContent {
+            forRepository {
+                maven("https://repo.gradle.org/artifactory/libs-releases/")
+            }
+            filter {
+                includeModule("org.gradle.experimental", "gradle-public-api")
+            }
+        }
         mavenCentral()
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,12 @@ kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", v
 # This should be set to an 8.x version, however DGP checks android.enableKotlin DSL property which is only in AGP 9 API
 android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "9.0.0" }
 
+# Gradle's experimental public API publication (see https://github.com/gradle/gradle/issues/29483).
+# Pinned so DGP compiles against a fixed Gradle API version, independent of the build-time Gradle.
+# This should be set to the oldest Gradle version supported by KGP, but 8.14.3 is the earliest published Gradle API, so
+# we need to be on a newer version until KGP minimum version gets bumped higher (https://youtrack.jetbrains.com/issue/KT-84114)
+gradle-publicApi = { module = "org.gradle.experimental:gradle-public-api", version = "8.14.3" }
+
 # This represents the oldest JUnit version supported by detekt-test-junit.
 # This should only be updated when updating the minimum version supported by detekt-test-junit.
 junit-jupiterApi = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.1.0" }


### PR DESCRIPTION
Decouple the version of the Gradle API that DGP compiles against from the version of Gradle used to run the build.

Unblocks #9113