### PR TITLE
feat: Add exhaustive option to OutdatedDocumentation rule, also improve error messages

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -53,6 +53,7 @@ comments:
     matchTypeParameters: true
     matchDeclarationsOrder: true
     allowParamOnConstructorProperties: false
+    exhaustive: true
   UndocumentedPublicClass:
     active: false
     excludes: ['**/test/**', '**/androidTest/**', '**/commonTest/**', '**/jvmTest/**', '**/androidUnitTest/**', '**/androidInstrumentedTest/**', '**/jsTest/**', '**/iosTest/**']

--- a/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
+++ b/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
@@ -75,7 +75,9 @@ class OutdatedDocumentation(config: Config) :
     @Configuration("if we allow constructor parameters to be marked as @param instead of @property")
     private val allowParamOnConstructorProperties: Boolean by config(false)
 
-    @Configuration("if true, all parameters must be documented; if false, only documented parameters are validated against the declaration")
+    @Configuration(
+        "if true, all parameters must be documented; if false, only documented parameters are validated against the declaration"
+    )
     private val exhaustive: Boolean by config(true)
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
+++ b/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
@@ -76,7 +76,8 @@ class OutdatedDocumentation(config: Config) :
     private val allowParamOnConstructorProperties: Boolean by config(false)
 
     @Configuration(
-        "if true, all parameters must be documented; if false, only documented parameters are validated against the declaration"
+        "if true, all parameters must be documented; " +
+            "if false, only documented parameters are validated against the declaration"
     )
     private val exhaustive: Boolean by config(true)
 

--- a/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
+++ b/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
@@ -75,7 +75,7 @@ class OutdatedDocumentation(config: Config) :
     @Configuration("if we allow constructor parameters to be marked as @param instead of @property")
     private val allowParamOnConstructorProperties: Boolean by config(false)
 
-    @Configuration("if all parameters should be documented")
+    @Configuration("if true, all parameters must be documented; if false, only documented parameters are validated against the declaration")
     private val exhaustive: Boolean by config(true)
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
+++ b/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
@@ -21,13 +21,15 @@ import org.jetbrains.kotlin.psi.psiUtil.PsiChildRange
 import org.jetbrains.kotlin.psi.psiUtil.allChildren
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
-import org.jetbrains.kotlin.utils.addToStdlib.ifTrue
 
 /**
  * This rule will report any class, function or constructor with KDoc that does not match the declaration signature.
  * If KDoc is not present or does not contain any @param or @property tags, rule violation will not be reported.
  * By default, both type and value parameters need to be matched and declarations orders must be preserved. You can
  * turn off these features using configuration options.
+ *
+ * Set `exhaustive` to `false` to only check that documented parameters are valid without requiring all
+ * parameters to be documented. This is useful when documentation is used sparingly and only where it is really needed.
  *
  * <noncompliant>
  * /**
@@ -73,36 +75,35 @@ class OutdatedDocumentation(config: Config) :
     @Configuration("if we allow constructor parameters to be marked as @param instead of @property")
     private val allowParamOnConstructorProperties: Boolean by config(false)
 
+    @Configuration("if all parameters should be documented")
+    private val exhaustive: Boolean by config(true)
+
     override fun visitClass(klass: KtClass) {
         super.visitClass(klass)
         val classDeclarations = getClassDeclarations(klass)
-        (
-            isDocumentationOutdated(klass) { classDeclarations } &&
-                (
-                    // checking below only if constructor in internal or private
-                    isInternalOrPrivate(klass.primaryConstructor).not() ||
-                        isDocumentationOutdated(klass) {
-                            // case when only property can be documented
-                            classDeclarations.filterNot { it.type == DeclarationType.PARAM }
-                        }
-                    )
-            )
-            .ifTrue {
-                reportFinding(klass)
-            }
+        val reason = findDocumentationMismatch(klass) { classDeclarations }
+        if (reason != null && (
+                isInternalOrPrivate(klass.primaryConstructor).not() ||
+                    findDocumentationMismatch(klass) {
+                        classDeclarations.filterNot { it.type == DeclarationType.PARAM }
+                    } != null
+                )
+        ) {
+            reportFinding(klass, reason)
+        }
     }
 
     override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
         super.visitSecondaryConstructor(constructor)
-        isDocumentationOutdated(constructor) { getSecondaryConstructorDeclarations(constructor) }.ifTrue {
-            reportFinding(constructor)
+        findDocumentationMismatch(constructor) { getSecondaryConstructorDeclarations(constructor) }?.let {
+            reportFinding(constructor, it)
         }
     }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
-        isDocumentationOutdated(function) { getFunctionDeclarations(function) }.ifTrue {
-            reportFinding(function)
+        findDocumentationMismatch(function) { getFunctionDeclarations(function) }?.let {
+            reportFinding(function, it)
         }
     }
 
@@ -173,18 +174,15 @@ class OutdatedDocumentation(config: Config) :
         }
     }
 
-    private fun isDocumentationOutdated(
+    private fun findDocumentationMismatch(
         element: KtNamedDeclaration,
         elementDeclarationsProvider: () -> List<Declaration>,
-    ): Boolean {
-        val doc = element.docComment ?: return false
+    ): String? {
+        val doc = element.docComment ?: return null
         val docDeclarations = getDocDeclarations(doc)
-        return if (docDeclarations.isNotEmpty()) {
-            val elementDeclarations = elementDeclarationsProvider()
-            !declarationsMatch(docDeclarations, elementDeclarations)
-        } else {
-            false
-        }
+        if (docDeclarations.isEmpty()) return null
+        val elementDeclarations = elementDeclarationsProvider()
+        return findMismatchReason(docDeclarations, elementDeclarations)
     }
 
     private fun isInternalOrPrivate(primaryConstructor: KtPrimaryConstructor?): Boolean {
@@ -192,28 +190,53 @@ class OutdatedDocumentation(config: Config) :
         return primaryConstructor.isInternal() || primaryConstructor.isPrivate()
     }
 
-    private fun declarationsMatch(doc: List<Declaration>, element: List<Declaration>): Boolean {
-        if (doc.size != element.size) {
-            return false
+    private fun findMismatchReason(doc: List<Declaration>, element: List<Declaration>): String? {
+        val invalidDocs = doc.filter { docDecl ->
+            element.none { elementDecl -> declarationMatches(docDecl, elementDecl) }
         }
 
-        val zippedElements = if (matchDeclarationsOrder) {
-            doc.zip(element)
+        val orderMismatch = matchDeclarationsOrder && doc.map { docDecl ->
+            element.indexOfFirst { elementDecl -> declarationMatches(docDecl, elementDecl) }
+        }.zipWithNext().any { (a, b) -> a >= b }
+
+        val undocumented = if (exhaustive && doc.size != element.size) {
+            element.filter { elementDecl ->
+                doc.none { docDecl -> declarationMatches(docDecl, elementDecl) }
+            }
         } else {
-            doc.sortedBy { it.name }.zip(element.sortedBy { it.name })
+            emptyList()
         }
 
-        return zippedElements.all { (docItr, elementItr) -> declarationMatches(docItr, elementItr) }
+        return when {
+            invalidDocs.isNotEmpty() -> {
+                val names = invalidDocs.joinToString {
+                    "'${it.name}'"
+                }
+                "documented parameters $names are not present in the declaration"
+            }
+
+            orderMismatch ->
+                "order of documented parameters does not match the declaration order"
+
+            undocumented.isNotEmpty() -> {
+                val names = undocumented.joinToString {
+                    "'${it.name}'"
+                }
+                "parameters $names are not documented"
+            }
+
+            else -> null
+        }
     }
 
     private fun declarationMatches(doc: Declaration, element: Declaration): Boolean =
         element.name == doc.name && (element.type == DeclarationType.ANY || element.type == doc.type)
 
-    private fun reportFinding(element: KtNamedDeclaration) {
+    private fun reportFinding(element: KtNamedDeclaration, reason: String) {
         report(
             Finding(
                 Entity.atName(element),
-                "Documentation of ${element.nameAsSafeName} is outdated"
+                "Documentation of ${element.nameAsSafeName} is outdated: $reason"
             )
         )
     }

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
@@ -2,8 +2,8 @@ package dev.detekt.rules.comments
 
 import dev.detekt.api.Config
 import dev.detekt.test.TestConfig
+import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.lint
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -53,7 +53,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectParamName)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someParam' are not present in the declaration"
+                )
         }
 
         @Test
@@ -65,7 +68,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectListOfParams)).hasSize(1)
+            assertThat(subject.lint(incorrectListOfParams)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someSecondParam' are not present in the declaration"
+                )
         }
 
         @Test
@@ -77,7 +83,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String, someParam: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectParamOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectParamOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: order of documented parameters does not match the declaration order"
+                )
         }
 
         @Test
@@ -101,7 +110,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val otherProp: String)
             """.trimIndent()
-            assertThat(subject.lint(correctParamIncorrectProp)).hasSize(1)
+            assertThat(subject.lint(correctParamIncorrectProp)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someProp' are not present in the declaration"
+                )
         }
 
         @Test
@@ -113,7 +125,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(otherParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectParamCorrectProp)).hasSize(1)
+            assertThat(subject.lint(incorrectParamCorrectProp)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someParam' are not present in the declaration"
+                )
         }
 
         @Test
@@ -126,7 +141,23 @@ class OutdatedDocumentationSpec {
                     constructor(otherParam: String)
                 }
             """.trimIndent()
-            assertThat(subject.lint(incorrectConstructorDoc)).hasSize(1)
+            assertThat(subject.lint(incorrectConstructorDoc)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someParam' are not present in the declaration"
+                )
+        }
+
+        @Test
+        fun `should not report when doc match constructor params`() {
+            val correctConstructorDoc = """
+                class MyClass {
+                    /**
+                     * @param someParam
+                     */
+                    constructor(someParam: String)
+                }
+            """.trimIndent()
+            assertThat(subject.lint(correctConstructorDoc)).isEmpty()
         }
 
         @Test
@@ -138,7 +169,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.lint(propertyAsParam)).hasSize(1)
+            assertThat(subject.lint(propertyAsParam)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'someParam', 'someProp' are not present in the declaration"
+                )
         }
 
         @Test
@@ -150,7 +184,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass(someParam: String, val someProp: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: order of documented parameters does not match the declaration order"
+                )
         }
 
         @Test
@@ -163,6 +200,18 @@ class OutdatedDocumentationSpec {
                 class A internal constructor(val b: String)
             """.trimIndent()
             assertThat(subject.lint(incorrectDeclarationsOrder)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when only property is documented and param is undocumented in internal constructor`() {
+            val code = """
+                /**
+                 * Doc
+                 * @property b desc
+                 */
+                class A internal constructor(a: String, val b: String)
+            """.trimIndent()
+            assertThat(subject.lint(code)).isEmpty()
         }
 
         @Test
@@ -202,7 +251,10 @@ class OutdatedDocumentationSpec {
                  */
                 class A internal constructor(val a: String, val b: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: parameters 'b' are not documented"
+                )
         }
 
         @Test
@@ -215,7 +267,10 @@ class OutdatedDocumentationSpec {
                  */
                 class A internal constructor(val a: String, val b: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: order of documented parameters does not match the declaration order"
+                )
         }
 
         @Test
@@ -232,7 +287,10 @@ class OutdatedDocumentationSpec {
                     c: Int,
                 )
             """.trimIndent()
-            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: parameters 'c' are not documented"
+                )
         }
 
         @Test
@@ -248,7 +306,10 @@ class OutdatedDocumentationSpec {
                     c: Int,
                 )
             """.trimIndent()
-            assertThat(subject.lint(incorrectDeclarationsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectDeclarationsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: parameters 'b', 'c' are not documented"
+                )
         }
 
         @Test
@@ -262,7 +323,10 @@ class OutdatedDocumentationSpec {
                     private val a: String,
                 )
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: documented parameters 'a' are not present in the declaration"
+                )
         }
 
         @Test
@@ -331,7 +395,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>(someParam: String)
             """.trimIndent()
-            assertThat(subject.lint(missingTypeParam)).hasSize(1)
+            assertThat(subject.lint(missingTypeParam)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: parameters 'T' are not documented"
+                )
         }
 
         @Test
@@ -343,7 +410,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T>(someParam: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectTypeParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamName)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'S' are not present in the declaration"
+                )
         }
 
         @Test
@@ -355,7 +425,10 @@ class OutdatedDocumentationSpec {
                  */
                 class MyClass<T, S>(someParam: String)
             """.trimIndent()
-            assertThat(subject.lint(incorrectTypeParamList)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamList)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: parameters 'S' are not documented"
+                )
         }
     }
 
@@ -381,7 +454,10 @@ class OutdatedDocumentationSpec {
                  */
                 fun myFun(otherParam: String) {}
             """.trimIndent()
-            assertThat(subject.lint(incorrectParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectParamName)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: documented parameters 'someParam' are not present in the declaration"
+                )
         }
     }
 
@@ -408,7 +484,10 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.lint(missingTypeParam)).hasSize(1)
+            assertThat(subject.lint(missingTypeParam)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: parameters 'T' are not documented"
+                )
         }
 
         @Test
@@ -420,7 +499,10 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.lint(incorrectTypeParamName)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamName)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: documented parameters 'S' are not present in the declaration"
+                )
         }
 
         @Test
@@ -432,7 +514,10 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.lint(incorrectTypeParamList)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamList)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: parameters 'S' are not documented"
+                )
         }
 
         @Test
@@ -445,7 +530,10 @@ class OutdatedDocumentationSpec {
                  */
                 fun <T, S> myFun(someParam: String) {}
             """.trimIndent()
-            assertThat(subject.lint(incorrectTypeParamsOrder)).hasSize(1)
+            assertThat(subject.lint(incorrectTypeParamsOrder)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: order of documented parameters does not match the declaration order"
+                )
         }
     }
 
@@ -640,7 +728,164 @@ class OutdatedDocumentationSpec {
                     private val a: String,
                 )
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of A is outdated: documented parameters 'a' are not present in the declaration"
+                )
+        }
+    }
+
+    @Nested
+    inner class `configuration exhaustive off` {
+        private val configuredSubject =
+            OutdatedDocumentation(TestConfig("exhaustive" to false))
+
+        @Test
+        fun `should not report when not all params are documented`() {
+            val code = """
+                /**
+                 * @param someParam Description of param
+                 */
+                fun myFun(someParam: String, otherParam: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when not all class params are documented`() {
+            val code = """
+                /**
+                 * @param someParam Description of param
+                 */
+                class MyClass(someParam: String, otherParam: Int)
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when not all properties are documented`() {
+            val code = """
+                /**
+                 * @property someProp Description of property
+                 */
+                class MyClass(val someProp: String, val otherProp: Int)
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should report when documented param does not exist`() {
+            val code = """
+                /**
+                 * @param baz the argument to print
+                 */
+                fun foo(bar: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of foo is outdated: documented parameters 'baz' are not present in the declaration"
+                )
+        }
+
+        @Test
+        fun `should report when documented property does not exist`() {
+            val code = """
+                /**
+                 * @property missing Description
+                 */
+                class MyClass(val actual: String)
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of MyClass is outdated: documented parameters 'missing' are not present in the declaration"
+                )
+        }
+
+        @Test
+        fun `should report when documented param order does not match declaration order`() {
+            val code = """
+                /**
+                 * @param b Description
+                 * @param a Description
+                 */
+                fun myFun(a: String, b: Int, c: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: order of documented parameters does not match the declaration order"
+                )
+        }
+
+        @Test
+        fun `should not report when documented param order matches declaration order`() {
+            val code = """
+                /**
+                 * @param a Description
+                 * @param c Description
+                 */
+                fun myFun(a: String, b: Int, c: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when not all type params are documented`() {
+            val code = """
+                /**
+                 * @param T Description of type param
+                 * @param someParam Description of param
+                 */
+                fun <T, S> myFun(someParam: String) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `should report when documented type param does not exist`() {
+            val code = """
+                /**
+                 * @param X Description of type param
+                 * @param someParam Description of param
+                 */
+                fun <T> myFun(someParam: String) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).singleElement()
+                .hasMessage(
+                    "Documentation of myFun is outdated: documented parameters 'X' are not present in the declaration"
+                )
+        }
+
+        @Test
+        fun `should not report when doc is empty and params exist`() {
+            val code = """
+                /**
+                 * Some description
+                 */
+                fun myFun(someParam: String, otherParam: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `configuration exhaustive off and matchDeclarationsOrder off` {
+        private val configuredSubject = OutdatedDocumentation(
+            TestConfig(
+                "exhaustive" to false,
+                "matchDeclarationsOrder" to false,
+            )
+        )
+
+        @Test
+        fun `should not report when documented param order does not match declaration order`() {
+            val code = """
+                /**
+                 * @param b Description
+                 * @param a Description
+                 */
+                fun myFun(a: String, b: Int, c: Int) {}
+            """.trimIndent()
+            assertThat(configuredSubject.lint(code)).isEmpty()
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/9243

Adds an `exhaustive` (default `true`) to the `OutdatedDocumentation` rule.
When unset, it will not fail if there are missing parameters or properties, just if there are wrong ones.
Also wires up a clear error message since there are many failure modes now, updating the tests.