### PR TITLE
SuspendFunSwallowedCancellation - Fix AA type leaks

### DIFF
--- a/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NestedScopeFunctions.kt
+++ b/detekt-rules-complexity/src/main/kotlin/dev/detekt/rules/complexity/NestedScopeFunctions.kt
@@ -9,6 +9,7 @@ import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.FunctionMatcher
+import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
@@ -111,10 +112,11 @@ class NestedScopeFunctions(config: Config) :
         }
 
         private fun KtCallExpression.isScopeFunction(): Boolean =
-            callableSymbols()?.any { it.matchesScopeFunction() } ?: false
+            analyze(this) { callableSymbols()?.any { it.matchesScopeFunction() } ?: false }
 
+        context(session: KaSession)
         private fun KtCallExpression.callableSymbols() =
-            analyze(this) {
+            with(session) {
                 resolveToCall()?.singleFunctionCallOrNull()?.let {
                     sequence {
                         yield(it.symbol)

--- a/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
+++ b/detekt-rules-coroutines/src/main/kotlin/dev/detekt/rules/coroutines/SuspendFunSwallowedCancellation.kt
@@ -203,33 +203,28 @@ class SuspendFunSwallowedCancellation(config: Config) :
     private fun shouldTraverseInsideImpl(element: PsiElement): Boolean =
         when (element) {
             is KtCallExpression -> {
-                val functionSymbol = analyze(element) {
-                    element.resolveToCall()
+                analyze(element) {
+                    val functionSymbol = element.resolveToCall()
                         ?.successfulFunctionCallOrNull()
                         ?.symbol
                         as? KaNamedFunctionSymbol
-                }
 
-                functionSymbol?.callableId != RUN_CATCHING_CALLABLE_ID && functionSymbol?.isInline == true
+                    functionSymbol?.callableId != RUN_CATCHING_CALLABLE_ID && functionSymbol?.isInline == true
+                }
             }
 
             is KtValueArgument -> {
                 val parentCallExpression = element.getParentOfType<KtCallExpression>(true) ?: return false
-                val valueSymbol = analyze(parentCallExpression) {
-                    val elementArgument = element.getArgumentExpression()
-
-                    parentCallExpression.resolveToCall()
+                val elementArgument = element.getArgumentExpression()
+                analyze(parentCallExpression) {
+                    val valueSymbol = parentCallExpression.resolveToCall()
                         ?.successfulFunctionCallOrNull()
                         ?.argumentMapping
                         ?.get(elementArgument)
                         ?.symbol
-                }
 
-                valueSymbol
-                    ?.let {
-                        it.isCrossinline.not() && it.isNoinline.not()
-                    }
-                    ?: false
+                    valueSymbol?.let { it.isCrossinline.not() && it.isNoinline.not() } ?: false
+                }
             }
 
             else -> true
@@ -238,11 +233,11 @@ class SuspendFunSwallowedCancellation(config: Config) :
     private fun KtExpression.hasSuspendCalls(): Boolean =
         when (this) {
             is KtForExpression -> {
-                val loopRangeReferences = analyze(this) {
-                    mainReference?.resolveToSymbols()
-                        ?.filterIsInstance<KaNamedFunctionSymbol>()
-                }.orEmpty()
-                loopRangeReferences.any { it.isSuspend }
+                analyze(this) {
+                    mainReference?.resolveToSymbols()?.filterIsInstance<KaNamedFunctionSymbol>()
+                        .orEmpty()
+                        .any { it.isSuspend }
+                }
             }
 
             is KtCallExpression, is KtOperationExpression -> {
@@ -254,13 +249,8 @@ class SuspendFunSwallowedCancellation(config: Config) :
                         ?.signature
                         ?.symbol
                         ?.isSuspend
-
-                        ?: (
-                            resolveToCall()
-                                ?.successfulFunctionCallOrNull()
-                                ?.symbol as? KaNamedFunctionSymbol
-                            )?.isSuspend
-
+                        ?: (resolveToCall()?.successfulFunctionCallOrNull()?.symbol as? KaNamedFunctionSymbol)
+                            ?.isSuspend
                         ?: false
                 }
             }


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203