### PR TITLE
Deprecation - Fix AA type leaks

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/Deprecation.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/Deprecation.kt
@@ -38,7 +38,7 @@ class Deprecation(config: Config) :
             report(
                 Finding(
                     if (element is KtNamedDeclaration) Entity.atName(element) else Entity.from(element),
-                    """${element.text} is deprecated with message "${diagnostic.message}""""
+                    """${element.text} is deprecated with message "$diagnostic""""
                 )
             )
         }
@@ -46,10 +46,11 @@ class Deprecation(config: Config) :
     }
 
     @OptIn(KaExperimentalApi::class)
-    private fun deprecationDiagnostic(element: KtElement): KaFirDiagnostic.Deprecation? =
+    private fun deprecationDiagnostic(element: KtElement): String? =
         analyze(element) {
             element
                 .diagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS)
                 .firstNotNullOfOrNull { it as? KaFirDiagnostic.Deprecation }
+                ?.message
         }
 }


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: [#9235 (comment)](https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203)

