### PR TITLE
UnnecessaryNotNullOperator - Fix AA type leaks

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/UnnecessaryNotNullOperator.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/UnnecessaryNotNullOperator.kt
@@ -40,17 +40,16 @@ class UnnecessaryNotNullOperator(config: Config) :
 
         if (expression.operationToken != KtTokens.EXCLEXCL) return
 
-        val compilerReports = analyze(expression) {
-            expression.diagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS)
-        }
-        if (compilerReports.any { it is KaFirDiagnostic.UnnecessaryNotNullAssertion }) {
-            report(
-                Finding(
-                    Entity.from(expression),
-                    "${expression.text} contains an unnecessary " +
-                        "not-null (!!) operators"
+        analyze(expression) {
+            val compilerReports = expression.diagnostics(KaDiagnosticCheckerFilter.ONLY_COMMON_CHECKERS)
+            if (compilerReports.any { it is KaFirDiagnostic.UnnecessaryNotNullAssertion }) {
+                report(
+                    Finding(
+                        Entity.from(expression),
+                        "${expression.text} contains an unnecessary not-null (!!) operators"
+                    )
                 )
-            )
+            }
         }
     }
 }


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: [#9235 (comment)](https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203)