### PR TITLE
MaxChainedCallsOnSameLine - Fix AA type leaks

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/MaxChainedCallsOnSameLine.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/MaxChainedCallsOnSameLine.kt
@@ -81,8 +81,10 @@ class MaxChainedCallsOnSameLine(config: Config) :
     private fun KtExpression.isReferenceToPackageOrClass(): Boolean {
         val selectorOrThis = (this as? KtQualifiedExpression)?.selectorExpression ?: this
         if (selectorOrThis !is KtReferenceExpression) return false
-        val symbol = analyze(selectorOrThis) { selectorOrThis.mainReference.resolveToSymbol() }
-        return symbol is KaPackageSymbol || symbol is KaClassSymbol
+        return analyze(selectorOrThis) {
+            val symbol = selectorOrThis.mainReference.resolveToSymbol()
+            symbol is KaPackageSymbol || symbol is KaClassSymbol
+        }
     }
 
     private fun KtQualifiedExpression.callOnNewLine(): Boolean {


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: [#9235 (comment)](https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203)