### PR TITLE
ForbiddenNamedParam - Fix AA type leaks

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenNamedParam.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenNamedParam.kt
@@ -76,9 +76,7 @@ class ForbiddenNamedParam(config: Config) :
                     yield(it.symbol)
                     yieldAll(it.symbol.allOverriddenSymbols)
                 }
-            }
-        }
-            ?.forEach { symbol ->
+            }?.forEach { symbol ->
                 methods.find { it.value.match(symbol) }?.let { matchingMethod ->
                     val message = if (matchingMethod.reason != null) {
                         "The method `${matchingMethod.value}` has been forbidden from using named " +
@@ -90,5 +88,6 @@ class ForbiddenNamedParam(config: Config) :
                     report(Finding(Entity.from(expression), message))
                 }
             }
+        }
     }
 }


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: [#9235 (comment)](https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203)