### PR TITLE
UseOrEmpty - Fix AA type leaks

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UseOrEmpty.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UseOrEmpty.kt
@@ -57,7 +57,7 @@ class UseOrEmpty(config: Config) :
         val right = expression.right ?: return
         if (!right.isEmptyElement()) return
 
-        val leftType = analyze(left) {
+        analyze(expression) {
             val leftType = left.expressionType ?: return
             if (!leftType.isMarkedNullable) return
             KtPsiUtil.safeDeparenthesize(left).let {
@@ -66,10 +66,7 @@ class UseOrEmpty(config: Config) :
                     if (called?.isOperator == true && called.typeParameters.isNotEmpty()) return
                 }
             }
-            leftType
-        }
 
-        analyze(right) {
             val rightClassId = right.expressionType?.symbol?.classId ?: return
             if (!leftType.isSubtypeOf(rightClassId)) return
         }


### PR DESCRIPTION
`AvoidLeakingAnalysisApiTypesFromSessions` (#9242) found this issue.

For more context about why this could be an issue: [#9235 (comment)](https://github.com/detekt/detekt/issues/9235#issuecomment-4215648203)