### PR TITLE
Replace Gradle delegated properties with direct assignments

### DIFF
--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -16,9 +16,9 @@ nexusPublishing {
     }
 }
 
-val releaseArtifacts: Configuration by configurations.dependencyScope("releaseArtifacts")
-val releaseAssetFiles by configurations.resolvable("releaseAssetFiles") {
-    extendsFrom(releaseArtifacts)
+val releaseArtifacts = configurations.dependencyScope("releaseArtifacts")
+val releaseAssetFiles = configurations.resolvable("releaseAssetFiles") {
+    extendsFrom(releaseArtifacts.get())
 }
 
 val version = Versions.currentOrSnapshot()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ dependencyAnalysis {
     }
 }
 
-val detektReportMergeSarif by tasks.registering(ReportMergeTask::class) {
+val detektReportMergeSarif = tasks.register<ReportMergeTask>("detektReportMergeSarif") {
     output = layout.buildDirectory.file("reports/detekt/merge.sarif.json")
 }
 

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -8,12 +8,12 @@ application {
     mainClass = "dev.detekt.cli.Main"
 }
 
-val pluginsJar by configurations.dependencyScope("pluginsJar") {
+val pluginsJar = configurations.dependencyScope("pluginsJar") {
     isTransitive = false
 }
 
-val pluginsJarFiles by configurations.resolvable("pluginsJarFiles") {
-    extendsFrom(pluginsJar)
+val pluginsJarFiles = configurations.resolvable("pluginsJarFiles") {
+    extendsFrom(pluginsJar.get())
 }
 
 dependencies {
@@ -68,13 +68,13 @@ tasks {
     distZip { enabled = false }
     distTar { enabled = false }
 
-    val runWithHelpFlag by registering(JavaExec::class) {
+    val runWithHelpFlag = register<JavaExec>("runWithHelpFlag") {
         outputs.upToDateWhen { true }
         classpath = files(shadowJar)
         args = listOf("--help")
     }
 
-    val runWithArgsFile by registering(JavaExec::class) {
+    val runWithArgsFile = register<JavaExec>("runWithArgsFile") {
         // The task generating these jar files run first.
         inputs.files(pluginsJarFiles)
         doNotTrackState("The entire root directory is read as the input source.")
@@ -83,7 +83,7 @@ tasks {
         args = listOf(
             "@./config/detekt/argsfile",
             "-p",
-            pluginsJarFiles.files.joinToString(File.pathSeparator) { it.path },
+            pluginsJarFiles.get().files.joinToString(File.pathSeparator) { it.path },
         )
     }
 
@@ -99,5 +99,5 @@ tasks {
     }
 }
 
-val shadowDist: Configuration by configurations.consumable("shadowDist")
+val shadowDist = configurations.consumable("shadowDist")
 artifacts.add(shadowDist.name, tasks.shadowDistZip)

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -49,19 +49,19 @@ tasks.shadowJar {
     }
 }
 
-val downloadKotlinCompiler by tasks.registering(Download::class) {
+val downloadKotlinCompiler = tasks.register<Download>("downloadKotlinCompiler") {
     src("https://github.com/JetBrains/kotlin/releases/download/v$kotlinVersion/kotlin-compiler-$kotlinVersion.zip")
     dest(file("$rootDir/build/kotlinc/kotlin-compiler-$kotlinVersion.zip"))
     overwrite(false)
 }
 
-val unzipKotlinCompiler by tasks.registering(Copy::class) {
+val unzipKotlinCompiler = tasks.register<Copy>("unzipKotlinCompiler") {
     dependsOn(downloadKotlinCompiler)
     from(zipTree(downloadKotlinCompiler.get().dest))
     into(file("$rootDir/build/kotlinc/$kotlinVersion"))
 }
 
-val testPluginKotlinc by tasks.registering(Task::class) {
+val testPluginKotlinc = tasks.register<Task>("testPluginKotlinc") {
     enabled = false
 
     val outputDir = layout.buildDirectory.dir("tmp/kotlinc")

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -10,9 +10,9 @@ application {
     mainClass = "dev.detekt.generator.Main"
 }
 
-val detektCli by configurations.dependencyScope("detektCli")
-val detektCliClasspath by configurations.resolvable("detektCliClasspath") {
-    extendsFrom(detektCli)
+val detektCli = configurations.dependencyScope("detektCli")
+val detektCliClasspath = configurations.resolvable("detektCliClasspath") {
+    extendsFrom(detektCli.get())
 }
 
 dependencies {
@@ -28,8 +28,8 @@ dependencies {
     testImplementation(libs.assertj.core)
 }
 
-val generateCliOptions by tasks.registering(JavaExec::class) {
-    classpath = detektCliClasspath
+val generateCliOptions = tasks.register<JavaExec>("generateCliOptions") {
+    classpath = files(detektCliClasspath)
     mainClass = "dev.detekt.cli.Main"
     args = listOf("--help")
 
@@ -64,7 +64,7 @@ tasks.register("generateWebsite") {
     )
 }
 
-val generateDocumentation by tasks.registering(JavaExec::class) {
+val generateDocumentation = tasks.register<JavaExec>("generateDocumentation") {
     dependsOn(
         ":detekt-rules-libraries:sourcesJar",
         ":detekt-rules-ruleauthors:sourcesJar",
@@ -105,10 +105,10 @@ val generateDocumentation by tasks.registering(JavaExec::class) {
     )
 }
 
-val generatedKtlintWrapperConfig by configurations.consumable("generatedKtlintWrapperConfig")
-val generatedLibrariesConfig by configurations.consumable("generatedLibrariesConfig")
-val generatedRuleauthorsConfig by configurations.consumable("generatedRuleauthorsConfig")
-val generatedCoreConfig by configurations.consumable("generatedCoreConfig")
+val generatedKtlintWrapperConfig = configurations.consumable("generatedKtlintWrapperConfig")
+val generatedLibrariesConfig = configurations.consumable("generatedLibrariesConfig")
+val generatedRuleauthorsConfig = configurations.consumable("generatedRuleauthorsConfig")
+val generatedCoreConfig = configurations.consumable("generatedCoreConfig")
 
 artifacts {
     add(generatedKtlintWrapperConfig.name, file(ktlintWrapperConfigFile)) {
@@ -128,7 +128,7 @@ artifacts {
     }
 }
 
-val verifyGeneratorOutput by tasks.registering(Exec::class) {
+val verifyGeneratorOutput = tasks.register<Exec>("verifyGeneratorOutput") {
     dependsOn(generateDocumentation)
     description = "Verifies that generated config files are up-to-date"
     commandLine = listOf(

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -137,8 +137,8 @@ kotlin {
     }
 }
 
-val testKitRuntimeOnly by configurations.registering
-val testKitGradleMinVersionRuntimeOnly by configurations.registering
+val testKitRuntimeOnly = configurations.register("testKitRuntimeOnly")
+val testKitGradleMinVersionRuntimeOnly = configurations.register("testKitGradleMinVersionRuntimeOnly")
 
 dependencies {
     compileOnly(libs.android.gradleApi)

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     id("module")
 }
 
-val extraDepsToPackage by configurations.registering
+val extraDepsToPackage = configurations.register("extraDepsToPackage")
 
 dependencies {
     compileOnly(projects.detektApi)

--- a/detekt-sample-extensions/build.gradle.kts
+++ b/detekt-sample-extensions/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
 
 testing {
     suites {
-        val test by getting(JvmTestSuite::class) {
+        named<JvmTestSuite>("test") {
             useJUnitJupiter()
         }
     }


### PR DESCRIPTION
Use of Kotlin delegated properties (the `by` keyword) in build scripts will be deprecated from Gradle 9.6. See gradle/gradle#37555.