### PR TITLE
Don't explicitly enable Kotlin compilation with build tools API

### DIFF
--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -1,4 +1,3 @@
 kotlin.stdlib.default.dependency=false
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
-kotlin.compiler.runViaBuildToolsApi=true
 dependency.analysis.print.build.health=true


### PR DESCRIPTION
This is already the default in 2.3.20 and raises a warning from 2.4.0-Beta2

https://kotlinlang.org/docs/whatsnew2320.html#kotlin-jvm-compilation-uses-build-tools-api-by-default

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
