### PR TITLE
Add Nested annotations to BuiltInKotlin test classes

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
@@ -26,7 +26,8 @@ class DetektAndroidBuiltInKotlinSpec {
         true, false"""
     )
     @ParameterizedClass
-    class BuiltInKotlinEnabled {
+    @Nested
+    inner class BuiltInKotlinEnabled {
 
         @Parameter(0)
         var propertyEnabled: Boolean = false
@@ -663,7 +664,8 @@ class DetektAndroidBuiltInKotlinSpec {
         true, true, false"""
     )
     @ParameterizedClass
-    class BuiltInKotlinDisabled {
+    @Nested
+    inner class BuiltInKotlinDisabled {
         @Parameter(0)
         var propertyEnabled: Boolean = false
 


### PR DESCRIPTION
Missing annotation meant the EnabledIf check on the outer class wasn't being run on internal classes, so tests would run and fail when the Android SDK wasn't available in the test environment.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
