### PR TITLE
Replace get calls with indexing operators

### DIFF
--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCompilerPluginRegistrar.kt
@@ -15,17 +15,17 @@ class DetektCompilerPluginRegistrar : CompilerPluginRegistrar() {
     override val pluginId = "dev.detekt"
 
     override fun ExtensionStorage.registerExtensions(configuration: CompilerConfiguration) {
-        if (configuration.get(Keys.IS_ENABLED) == false) {
+        if (configuration[Keys.IS_ENABLED] == false) {
             return
         }
 
-        val messageCollector = configuration.get(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE)
+        val messageCollector = configuration[CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY, MessageCollector.NONE]
 
         AnalysisHandlerExtension.registerExtension(
             DetektAnalysisExtension(
                 messageCollector,
                 configuration.toSpec(messageCollector),
-                configuration.get(Keys.ROOT_PATH, Path(System.getProperty("user.dir"))),
+                configuration[Keys.ROOT_PATH, Path(System.getProperty("user.dir"))],
                 configuration.getList(Keys.EXCLUDES)
             )
         )


### PR DESCRIPTION
These cause violations when running detekt after upgrade to Kotlin 2.4

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
