### PR TITLE
Improve repackaging of Analysis API dependencies

### DIFF
--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -18,7 +18,9 @@ val detektCliClasspath by configurations.resolvable("detektCliClasspath") {
 dependencies {
     implementation(libs.kotlin.compiler)
     implementation(projects.detektApi)
-    implementation(projects.detektKotlinAnalysisApi)
+    implementation(projects.detektKotlinAnalysisApi) {
+        targetConfiguration = "shadow"
+    }
     implementation(projects.detektKotlinAnalysisApiStandalone)
     detektCli(projects.detektCli)
     implementation(projects.detektUtils)

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -10,8 +10,25 @@ dependencies {
     api(libs.kotlin.analysisApiStandalone) { isTransitive = false }
 }
 
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier = "sources"
+
+    from(
+        configurations.runtimeClasspath.map {
+            it.incoming.artifactView {
+                withVariantReselection()
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
+                }
+            }.files.map { jar -> zipTree(jar) }
+        }
+    )
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
+    withSourcesJar()
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -5,9 +5,14 @@ plugins {
     id("com.gradleup.shadow") version "9.4.1"
 }
 
+val aaDependency = configurations.dependencyScope("aaDependency")
+val aaDependencies = configurations.resolvable("aaDependencies") {
+    extendsFrom(aaDependency.get())
+}
+
 dependencies {
     // Exclude transitive dependencies due to https://youtrack.jetbrains.com/issue/KT-61639
-    api(libs.kotlin.analysisApiStandalone) { isTransitive = false }
+    aaDependency(libs.kotlin.analysisApiStandalone) { isTransitive = false }
 }
 
 val defaultJarClassifier = "default-jar"
@@ -30,13 +35,14 @@ configurations.apiElements {
 
 tasks.shadowJar {
     archiveClassifier = ""
+    configurations = aaDependencies.map { listOf(it) }
 }
 
 val sourcesJar = tasks.register<Jar>("sourcesJar") {
     archiveClassifier = "sources"
 
     from(
-        configurations.runtimeClasspath.map {
+        aaDependencies.map {
             it.incoming.artifactView {
                 withVariantReselection()
                 attributes {

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -32,8 +32,25 @@ tasks.shadowJar {
     archiveClassifier = ""
 }
 
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier = "sources"
+
+    from(
+        configurations.runtimeClasspath.map {
+            it.incoming.artifactView {
+                withVariantReselection()
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
+                }
+            }.files.map { jar -> zipTree(jar) }
+        }
+    )
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
+    withSourcesJar()
 }
 
 shadow {

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -10,14 +10,32 @@ dependencies {
     api(libs.kotlin.analysisApiStandalone) { isTransitive = false }
 }
 
+val defaultJarClassifier = "default-jar"
+
+tasks.jar {
+    archiveClassifier = defaultJarClassifier
+}
+
+configurations.runtimeElements {
+    outgoing.artifacts.removeIf { it.classifier == defaultJarClassifier && it.extension == "jar" }
+    outgoing.artifact(tasks.shadowJar)
+}
+
+configurations.apiElements {
+    outgoing.variants.removeIf { it.name == "classes" }
+
+    outgoing.artifacts.removeIf { it.classifier == defaultJarClassifier && it.extension == "jar" }
+    outgoing.artifact(tasks.shadowJar)
+}
+
+tasks.shadowJar {
+    archiveClassifier = ""
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-val javaComponent = components["java"] as AdhocComponentWithVariants
-javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
-    skip()
-}
-javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) {
-    skip()
+shadow {
+    addShadowVariantIntoJavaComponent = false
 }

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -14,15 +14,15 @@ dependencies {
     implementation(libs.kotlin.analysisApiPlatformInterface) { isTransitive = false }
     implementation(libs.kotlin.lowLevelApiFir) { isTransitive = false }
     implementation(libs.kotlin.symbolLightClasses) { isTransitive = false }
-    implementation(libs.caffeine) {
+    shadow(libs.caffeine) {
         attributes {
             // https://github.com/ben-manes/caffeine/issues/716
             // Remove on upgrade to Caffeine 3.x or if https://youtrack.jetbrains.com/issue/KT-73751 is fixed
             attribute(Bundling.BUNDLING_ATTRIBUTE, named(Bundling.EXTERNAL))
         }
     }
-    implementation(libs.kotlinx.serializationCore)
-    runtimeOnly(libs.kotlinx.coroutinesCore.intellij)
+    shadow(libs.kotlinx.serializationCore)
+    shadow(libs.kotlinx.coroutinesCore.intellij)
 }
 
 java {

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -5,15 +5,20 @@ plugins {
     id("com.gradleup.shadow") version "9.4.1"
 }
 
+val aaDependency = configurations.dependencyScope("aaDependency")
+val aaDependencies = configurations.resolvable("aaDependencies") {
+    extendsFrom(aaDependency.get())
+}
+
 dependencies {
     // Exclude transitive dependencies due to https://youtrack.jetbrains.com/issue/KT-61639
-    api(libs.kotlin.analysisApi) { isTransitive = false }
-    api(libs.kotlin.analysisApiK2) { isTransitive = false }
+    aaDependency(libs.kotlin.analysisApi) { isTransitive = false }
+    aaDependency(libs.kotlin.analysisApiK2) { isTransitive = false }
 
-    implementation(libs.kotlin.analysisApiImplBase) { isTransitive = false }
-    implementation(libs.kotlin.analysisApiPlatformInterface) { isTransitive = false }
-    implementation(libs.kotlin.lowLevelApiFir) { isTransitive = false }
-    implementation(libs.kotlin.symbolLightClasses) { isTransitive = false }
+    aaDependency(libs.kotlin.analysisApiImplBase) { isTransitive = false }
+    aaDependency(libs.kotlin.analysisApiPlatformInterface) { isTransitive = false }
+    aaDependency(libs.kotlin.lowLevelApiFir) { isTransitive = false }
+    aaDependency(libs.kotlin.symbolLightClasses) { isTransitive = false }
     runtimeOnly(libs.caffeine) {
         attributes {
             // https://github.com/ben-manes/caffeine/issues/716
@@ -23,6 +28,10 @@ dependencies {
     }
     runtimeOnly(libs.kotlinx.serializationCore)
     runtimeOnly(libs.kotlinx.coroutinesCore.intellij)
+}
+
+tasks.shadowJar {
+    configurations = aaDependencies.map { listOf(it) }
 }
 
 java {

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -14,14 +14,14 @@ dependencies {
     implementation(libs.kotlin.analysisApiPlatformInterface) { isTransitive = false }
     implementation(libs.kotlin.lowLevelApiFir) { isTransitive = false }
     implementation(libs.kotlin.symbolLightClasses) { isTransitive = false }
-    implementation(libs.caffeine) {
+    runtimeOnly(libs.caffeine) {
         attributes {
             // https://github.com/ben-manes/caffeine/issues/716
             // Remove on upgrade to Caffeine 3.x or if https://youtrack.jetbrains.com/issue/KT-73751 is fixed
             attribute(Bundling.BUNDLING_ATTRIBUTE, named(Bundling.EXTERNAL))
         }
     }
-    implementation(libs.kotlinx.serializationCore)
+    runtimeOnly(libs.kotlinx.serializationCore)
     runtimeOnly(libs.kotlinx.coroutinesCore.intellij)
 }
 

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -25,8 +25,25 @@ dependencies {
     shadow(libs.kotlinx.coroutinesCore.intellij)
 }
 
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier = "sources"
+
+    from(
+        configurations.runtimeClasspath.map {
+            it.incoming.artifactView {
+                withVariantReselection()
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
+                }
+            }.files.map { jar -> zipTree(jar) }
+        }
+    )
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
+    withSourcesJar()
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -53,8 +53,25 @@ tasks.shadowJar {
     configurations = aaDependencies.map { listOf(it) }
 }
 
+val sourcesJar = tasks.register<Jar>("sourcesJar") {
+    archiveClassifier = "sources"
+
+    from(
+        aaDependencies.map {
+            it.incoming.artifactView {
+                withVariantReselection()
+                attributes {
+                    attribute(Category.CATEGORY_ATTRIBUTE, named(Category.DOCUMENTATION))
+                    attribute(DocsType.DOCS_TYPE_ATTRIBUTE, named(DocsType.SOURCES))
+                }
+            }.files.map { jar -> zipTree(jar) }
+        }
+    )
+}
+
 java {
     targetCompatibility = JavaVersion.VERSION_1_8
+    withSourcesJar()
 }
 
 shadow {

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -30,7 +30,26 @@ dependencies {
     runtimeOnly(libs.kotlinx.coroutinesCore.intellij)
 }
 
+val defaultJarClassifier = "default-jar"
+
+tasks.jar {
+    archiveClassifier = defaultJarClassifier
+}
+
+configurations.runtimeElements {
+    outgoing.artifacts.removeIf { it.classifier == defaultJarClassifier && it.extension == "jar" }
+    outgoing.artifact(tasks.shadowJar)
+}
+
+configurations.apiElements {
+    outgoing.variants.removeIf { it.name == "classes" }
+
+    outgoing.artifacts.removeIf { it.classifier == defaultJarClassifier && it.extension == "jar" }
+    outgoing.artifact(tasks.shadowJar)
+}
+
 tasks.shadowJar {
+    archiveClassifier = ""
     configurations = aaDependencies.map { listOf(it) }
 }
 
@@ -38,10 +57,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-val javaComponent = components["java"] as AdhocComponentWithVariants
-javaComponent.withVariantsFromConfiguration(configurations["apiElements"]) {
-    skip()
-}
-javaComponent.withVariantsFromConfiguration(configurations["runtimeElements"]) {
-    skip()
+shadow {
+    addShadowVariantIntoJavaComponent = false
 }


### PR DESCRIPTION
* Excludes dependencies that are available on Maven Central from being packaged into the detekt-kotlin-analysis-api and detekt-kotlin-analysis-api-standalone JAR files. Fixes #9184.
* Publish sources for repackaged analysis-api artifacts. Fixes #8979.
* Adjusts publishing so that the shadowed JAR fully replaces the normal JAR which should be transparent for all consumers. Fixes https://github.com/detekt/detekt/issues/8626.