### PR TITLE
Remove excludeImportStatements from Deprecation rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -430,7 +430,6 @@ potential-bugs:
   Deprecation:
     active: false
     aliases: ['DEPRECATION']
-    excludeImportStatements: false
   DontDowncastCollectionTypes:
     active: false
   DoubleMutabilityForCollection:

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/Deprecation.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/Deprecation.kt
@@ -2,18 +2,15 @@ package dev.detekt.rules.potentialbugs
 
 import dev.detekt.api.Alias
 import dev.detekt.api.Config
-import dev.detekt.api.Configuration
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
-import dev.detekt.api.config
 import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaDiagnosticCheckerFilter
 import org.jetbrains.kotlin.analysis.api.fir.diagnostics.KaFirDiagnostic
 import org.jetbrains.kotlin.psi.KtElement
-import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtNamedDeclaration
 
 /**
@@ -28,11 +25,7 @@ class Deprecation(config: Config) :
     ),
     RequiresAnalysisApi {
 
-    @Configuration("Ignore deprecation in import statements")
-    private val excludeImportStatements: Boolean by config(false)
-
     override fun visitKtElement(element: KtElement) {
-        if (excludeImportStatements && element is KtImportDirective) return
         val diagnostic = deprecationDiagnostic(element)
         if (diagnostic != null) {
             report(

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/DeprecationSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/DeprecationSpec.kt
@@ -1,12 +1,10 @@
 package dev.detekt.rules.potentialbugs
 
 import dev.detekt.api.Config
-import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
@@ -74,99 +72,5 @@ class DeprecationSpec(private val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code, stateFile)).singleElement()
             .hasMessage("""state is deprecated with message "Some reason"""")
-    }
-
-    @Test
-    fun `does report import location when excludeImportStatements has default value`() {
-        val deprecatedFile = """
-            package com.example.detekt.featureflag
-
-            @Deprecated("Moved to other service")
-            enum class LegacyFeatureFlags {
-                FEATURE_A, FEATURE_B,
-            }
-        """.trimIndent()
-        val code = """
-            import com.example.detekt.featureflag.LegacyFeatureFlags
-            class FeatureFlagManager {
-                @Suppress("DEPRECATION")
-                fun getFeatureFlagValue(featureFlag: LegacyFeatureFlags): Boolean {
-                    return true
-                }
-            }
-
-            class Manager(private val featureFlagManager: FeatureFlagManager) {
-                fun doSomething() {
-                    @Suppress("DEPRECATION")
-                    val isFeatureAEnabled =
-                        featureFlagManager.getFeatureFlagValue(LegacyFeatureFlags.FEATURE_A)
-                }
-            }
-        """.trimIndent()
-        assertThat(subject.lintWithContext(env, code, deprecatedFile)).singleElement()
-            .hasStartSourceLocation(1, 1)
-    }
-
-    @Nested
-    inner class `With ignore import true` {
-        private val ignoredImportSubject =
-            Deprecation(TestConfig(IGNORED_IMPORT to true))
-
-        @Test
-        fun `does not report import location - #7402`() {
-            val deprecatedFile = """
-                package com.example.detekt.featureflag
-
-                @Deprecated("Moved to other service")
-                enum class LegacyFeatureFlags {
-                    FEATURE_A, FEATURE_B,
-                }
-            """.trimIndent()
-            val code = """
-                import com.example.detekt.featureflag.LegacyFeatureFlags
-                class FeatureFlagManager {
-                    @Suppress("DEPRECATION")
-                    fun getFeatureFlagValue(featureFlag: LegacyFeatureFlags): Boolean {
-                        return true
-                    }
-                }
-
-                class Manager(private val featureFlagManager: FeatureFlagManager) {
-                    fun doSomething() {
-                        @Suppress("DEPRECATION")
-                        val isFeatureAEnabled =
-                            featureFlagManager.getFeatureFlagValue(LegacyFeatureFlags.FEATURE_A)
-                    }
-                }
-            """.trimIndent()
-            assertThat(ignoredImportSubject.lintWithContext(env, code, deprecatedFile))
-                .isEmpty()
-        }
-
-        @Test
-        fun `report when property delegate is deprecated`() {
-            val stateFile = """
-                package state
-                import kotlin.reflect.KProperty
-                interface State {
-                    val value: Double
-                }
-                @Deprecated("Some reason")
-                operator fun State.getValue(thisObj: Any?, property: KProperty<*>): Double = value
-            """.trimIndent()
-            val code = """
-                import state.State
-                import state.getValue
-                fun foo(state: State) {
-                    val d by state
-                }
-            """.trimIndent()
-            assertThat(ignoredImportSubject.lintWithContext(env, code, stateFile)).singleElement()
-                .hasMessage("""state is deprecated with message "Some reason"""")
-        }
-    }
-
-    companion object {
-        private const val IGNORED_IMPORT = "excludeImportStatements"
     }
 }


### PR DESCRIPTION
The Kotlin compiler stopped reporting deprecation warnings on import statements as of Kotlin 2.4.0-Beta2. Since the Deprecation rule relies on compiler diagnostics, the excludeImportStatements option is no longer meaningful. When a deprecated symbol is replaced, its import is flagged as unused anyway, so the option is also redundant.

Closes #9280

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
