### PR TITLE
Fix `UnnecessaryFullyQualifiedName` clashes with kotlin package name

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -15,13 +15,16 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
@@ -162,6 +165,10 @@ class UnnecessaryFullyQualifiedName(config: Config) :
             val packageFqName = symbol.packageFqName() ?: return
             if (!receiverText.startsWith(packageFqName)) return
 
+            // If the leftmost part of the receiver resolves to a variable/property, this is a method call on an
+            // instance (e.g. `val kotlin = Foo(); kotlin.method()`), not a package-qualified reference
+            if (isReceiverLocalVariableOrProperty(expression.receiverExpression)) return
+
             val classId = symbol.callableId?.classId
             val symbolToCheck = classId?.let { findClass(it) } ?: symbol
             if (hasNameCollision(expression, symbolToCheck)) return
@@ -181,6 +188,18 @@ class UnnecessaryFullyQualifiedName(config: Config) :
             report(finding)
         }
     }
+
+    private fun KaSession.isReceiverLocalVariableOrProperty(receiver: KtExpression): Boolean {
+        val leftmost = leftmostReference(receiver) ?: return false
+        return leftmost.mainReference.resolveToSymbol() is KaVariableSymbol
+    }
+
+    private fun leftmostReference(expression: KtExpression): KtNameReferenceExpression? =
+        when (expression) {
+            is KtNameReferenceExpression -> expression
+            is KtDotQualifiedExpression -> leftmostReference(expression.receiverExpression)
+            else -> null
+        }
 
     private fun isInImportOrPackage(element: KtElement): Boolean =
         element.getParentOfType<KtImportDirective>(strict = false) != null ||

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1003,6 +1003,56 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
         }
     }
 
+    // https://github.com/detekt/detekt/issues/9282
+    @Nested
+    inner class `property named same as kotlin package` {
+        @Test
+        fun `does not report when class property named kotlin calls a stdlib extension`() {
+            val code = """
+                class Foo
+
+                class Test {
+                    val kotlin = Foo()
+
+                    fun method() {
+                        kotlin.run { println("hello") }
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report when local variable named kotlin calls a stdlib extension`() {
+            val code = """
+                class Foo
+
+                fun method() {
+                    val kotlin = Foo()
+                    kotlin.run { println("hello") }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report when function parameter named kotlin calls a member method`() {
+            val code = """
+                class GradleConventionsKotlin {
+                    fun configure() = Unit
+                }
+
+                fun setup(kotlin: GradleConventionsKotlin) {
+                    kotlin.configure()
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+
     @Nested
     inner class `nested type qualifiers` {
         @Test


### PR DESCRIPTION
Closes #9282

`UnnecessaryFullyQualifiedName` was incorrectly flagging code like `kotlin.configure()` when kotlin was a local property or parameter, not a package reference. The rule now checks whether the receiver resolves to a variable/property before reporting.
