### PR TITLE
Replace `isSingleUnderscore` with detekt-psi-utils equivalent

### DIFF
--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -71,6 +71,10 @@ public final class dev/detekt/psi/KtModifierListKt {
 	public static final fun isPublicNotOverridden (Lorg/jetbrains/kotlin/psi/KtModifierListOwner;Z)Z
 }
 
+public final class dev/detekt/psi/KtNamedDeclarationKt {
+	public static final fun isSingleUnderscore (Lorg/jetbrains/kotlin/psi/KtNamedDeclaration;)Z
+}
+
 public final class dev/detekt/psi/KtValueArgumentKt {
 	public static final fun isEmptyOrSingleStringArgument (Ljava/util/List;)Z
 	public static final fun isString (Lorg/jetbrains/kotlin/psi/KtValueArgument;)Z

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/KtNamedDeclaration.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/KtNamedDeclaration.kt
@@ -1,0 +1,5 @@
+package dev.detekt.psi
+
+import org.jetbrains.kotlin.psi.KtNamedDeclaration
+
+fun KtNamedDeclaration.isSingleUnderscore(): Boolean = nameIdentifier?.text == "_"

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/VariableMinLength.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/VariableMinLength.kt
@@ -7,8 +7,8 @@ import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.isOverride
+import dev.detekt.psi.isSingleUnderscore
 import org.jetbrains.kotlin.psi.KtProperty
-import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
 /**
  * Reports when very short variable names are used.
@@ -24,7 +24,7 @@ class VariableMinLength(config: Config) :
             return
         }
 
-        if (property.isSingleUnderscore) {
+        if (property.isSingleUnderscore()) {
             return
         }
 

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/VariableNaming.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/VariableNaming.kt
@@ -9,12 +9,12 @@ import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.isOverride
+import dev.detekt.psi.isSingleUnderscore
 import dev.detekt.rules.naming.util.isContainingExcludedClassOrObject
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.psiUtil.getNonStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
-import org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore
 
 /**
  * Reports variable names that do not follow the specified naming convention.
@@ -37,7 +37,7 @@ class VariableNaming(config: Config) :
         if (property.isPropertyTopLevelOrInCompanion()) {
             return
         }
-        if (property.isSingleUnderscore || property.isContainingExcludedClassOrObject(excludeClassPattern)) {
+        if (property.isSingleUnderscore() || property.isContainingExcludedClassOrObject(excludeClassPattern)) {
             return
         }
 

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -30,6 +30,28 @@ class VariableMinLengthSpec {
             """.trimIndent()
             assertThat(variableMinLength.lint(code)).isEmpty()
         }
+
+        @Test
+        fun `does not report a local property named with a single underscore`() {
+            val code = """
+                fun foo() {
+                    val _ = 1
+                }
+            """.trimIndent()
+            // `val _ = ...` only compiles when Kotlin's experimental unused return value checker is enabled
+            assertThat(variableMinLength.lint(content = code, compile = false)).isEmpty()
+        }
+
+        @Test
+        fun `does report a backtick-escaped underscore local property`() {
+            val code = """
+                fun foo() {
+                    val `_` = 1
+                }
+            """.trimIndent()
+
+            assertThat(variableMinLength.lint(code)).hasSize(1)
+        }
     }
 
     @Test

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableNamingSpec.kt
@@ -116,4 +116,26 @@ class VariableNamingSpec {
         """.trimIndent()
         assertThat(VariableNaming(Config.empty).lint(code)).isEmpty()
     }
+
+    @Test
+    fun `should not flag a local property named with a single underscore`() {
+        val code = """
+            fun foo() {
+                val _ = 1
+            }
+        """.trimIndent()
+        // `val _ = ...` only compiles when Kotlin's experimental unused return value checker is enabled
+        assertThat(VariableNaming(Config.empty).lint(content = code, compile = false)).isEmpty()
+    }
+
+    @Test
+    fun `should flag a backtick-escaped underscore local property`() {
+        val code = """
+            fun foo() {
+                val `_` = 1
+            }
+        """.trimIndent()
+
+        assertThat(VariableNaming(Config.empty).lint(code)).hasSize(1)
+    }
 }


### PR DESCRIPTION
This is my very first contribution to detekt. I'd appreciate it if you could share any feedback or comments.

## Summary
- Adds a PSI-only `KtNamedDeclaration.isSingleUnderscore()` extension to `detekt-psi-utils`.
- Migrates `VariableMinLength` and `VariableNaming` (the only two call sites) off the compiler-internals import `org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore`.
- Adds regression tests covering single-underscore local properties and backtick-escaped underscore names.
- Progresses #8091.

## Why
This helper is purely PSI logic but lives under a compiler-internals package that detekt is moving away from. The Analysis API does not expose a public equivalent — as of Kotlin 2.3, the Analysis API still imports this helper from the internal package — so a small in-repo helper is the simplest path forward.

## Design notes
- Implemented as `fun KtNamedDeclaration.isSingleUnderscore()` rather than as a `val` extension property. The upstream helper is a property and the body would fit either form, but neighbouring extensions in `detekt-psi-utils` (e.g. `KtModifierList.kt`'s `isOverride()`, `isLateinit()`) are consistently functions, so we match that convention here.
- The upstream implementation guards against `nameIdentifier` materialisation on stub-backed declarations. That guard is omitted here because detekt analyses source files where stub-backed PSI does not occur in practice, and dropping it keeps the implementation a one-liner aligned with the no-comment style of neighbouring extensions.
- Backtick-escaped `` `_` `` is correctly excluded because `nameIdentifier?.text` returns the raw source text including the backticks.
- The naming-rule regression tests exercise `val _ = ...` via PSI-backed `lint(KtFile)` because those snippets depend on compiler support that is not enabled in the default test harness configuration.

## Test plan
- [x] No remaining `org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore` references in the codebase
- [x] `VariableMinLengthSpec` and `VariableNamingSpec` pass with the final `detekt-psi-utils` implementation
- [x] The same changed tests also pass when `VariableMinLength` and `VariableNaming` are temporarily switched back to `org.jetbrains.kotlin.resolve.calls.util.isSingleUnderscore`

## Review
- [x] I (the human PR author) have read through every change, verified the implementation, tests, and rationale, and the description reflects my own understanding and intent
- [x] Implemented with Claude Opus 4.7
- [x] Additionally cross-reviewed with GPT-5.4 (different model from the author, per the project's AI review policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)