### PR TITLE
Add configuration ignoredFullyQualifiedNames to UnnecessaryFullyQualifiedName rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -780,6 +780,7 @@ style:
     active: true
   UnnecessaryFullyQualifiedName:
     active: false
+    ignoredFullyQualifiedNames: []
   UnnecessaryInheritance:
     active: true
   UnnecessaryInnerClass:

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -1,10 +1,15 @@
+@file:Suppress("TooManyFunctions")
+
 package dev.detekt.rules.style
 
 import dev.detekt.api.Config
+import dev.detekt.api.Configuration
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
+import dev.detekt.api.config
+import dev.detekt.psi.fullyQualifiedNameGlobToRegex
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KaScopeKind
@@ -12,6 +17,7 @@ import org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall
 import org.jetbrains.kotlin.analysis.api.resolution.successfulCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassLikeSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaConstructorSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
@@ -42,6 +48,7 @@ import org.jetbrains.kotlin.psi.psiUtil.parents
  * - Package declarations
  * - String literals
  * - Nested class references without packages (e.g., Outer.Inner)
+ * - Fully qualified names that were ignored by configuration
  *
  * See [PMD UnnecessaryFullyQualifiedName](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#unnecessaryfullyqualifiedname)
  * for a similar rule in the Java ecosystem.
@@ -78,6 +85,16 @@ class UnnecessaryFullyQualifiedName(config: Config) :
     Rule(config, "Unnecessary fully qualified names make code harder to read. Use imports instead."),
     RequiresAnalysisApi {
 
+    @Configuration(
+        "fully qualified names that are ignored, for example `['java.lang.String', 'kotlin.**.*', " +
+            "'java.util.*List', 'java.net.UR?']`",
+    )
+    private val ignoredFullyQualifiedNames: List<Regex> by config(emptyList<String>()) {
+        it.distinct().map { fqn ->
+            fqn.fullyQualifiedNameGlobToRegex()
+        }
+    }
+
     @Suppress("ReturnCount")
     override fun visitUserType(type: KtUserType) {
         super.visitUserType(type)
@@ -100,6 +117,8 @@ class UnnecessaryFullyQualifiedName(config: Config) :
 
         analyze(type) {
             val resolvedSymbol = type.referenceExpression?.mainReference?.resolveToSymbol() ?: return
+            val candidate = resolvedSymbol.ignoredFqNameCandidate()
+            if (candidate != null && ignoredFullyQualifiedNames.any { it.matches(candidate) }) return
             val packageFqName = resolvedSymbol.packageFqName() ?: return
             if (!typeText.startsWith(packageFqName)) return
             if (hasNameCollision(type, resolvedSymbol)) return
@@ -127,6 +146,8 @@ class UnnecessaryFullyQualifiedName(config: Config) :
 
         analyze(receiverExpression) {
             val resolvedSymbol = receiverExpression.expressionType?.symbol ?: return
+            val candidate = resolvedSymbol.ignoredFqNameCandidate()
+            if (candidate != null && ignoredFullyQualifiedNames.any { it.matches(candidate) }) return
             val packageFqName = resolvedSymbol.packageFqName() ?: return
             if (!receiverText.startsWith("$packageFqName.")) return
             if (hasNameCollision(expression, resolvedSymbol)) return
@@ -162,6 +183,8 @@ class UnnecessaryFullyQualifiedName(config: Config) :
         analyze(expression) {
             val resolvedCall = expression.resolveToCall()?.successfulCallOrNull<KaCallableMemberCall<*, *>>()
             val symbol = resolvedCall?.partiallyAppliedSymbol?.symbol ?: return
+            val candidate = symbol.ignoredFqNameCandidate()
+            if (candidate != null && ignoredFullyQualifiedNames.any { it.matches(candidate) }) return
             val packageFqName = symbol.packageFqName() ?: return
             if (!receiverText.startsWith(packageFqName)) return
 
@@ -253,4 +276,13 @@ class UnnecessaryFullyQualifiedName(config: Config) :
             is KaCallableSymbol -> callableId?.packageName
             else -> null
         }?.asString()?.takeIf { it.isNotBlank() }
+
+    private fun KaSymbol.ignoredFqNameCandidate(): String? =
+        when (this) {
+            is KaClassSymbol -> classId?.asFqNameString()
+            is KaClassLikeSymbol -> classId?.asFqNameString()
+            is KaConstructorSymbol -> containingClassId?.asFqNameString()
+            is KaCallableSymbol -> callableId?.classId?.asFqNameString() ?: callableId?.asSingleFqName()?.asString()
+            else -> null
+        }?.takeIf { it.isNotBlank() }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -3,12 +3,15 @@
 package dev.detekt.rules.style
 
 import dev.detekt.api.Config
+import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 
 @KotlinCoreEnvironmentTest
 class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
@@ -55,22 +58,56 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
+
+        @ParameterizedTest(name = "{0}")
+        @CsvSource(
+            value = [
+                "java.util.ArrayList",
+                "java.util.*List",
+                "java.util.*",
+                "java.**.*",
+            ],
+        )
+        fun `does not report fully qualified class names in type annotations when ignored`(fqnToIgnore: String) {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf(fqnToIgnore))
+            val code = """
+                class Test {
+                    fun method(): java.util.ArrayList<String> {
+                        val list: java.util.ArrayList<String> = java.util.ArrayList()
+                        return java.util.ArrayList()
+                    }
+                }
+            """.trimIndent()
+            assertThat(ignored.lintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Nested
     inner class `fully qualified static method calls` {
+        val code = """
+            class Test {
+                fun method() {
+                    val date = java.time.LocalDate.now()
+                    val list = java.util.Collections.emptyList<String>()
+                }
+            }
+        """.trimIndent()
+
         @Test
         fun `reports fully qualified class names in static method calls`() {
-            val code = """
-                class Test {
-                    fun method() {
-                        val date = java.time.LocalDate.now()
-                        val list = java.util.Collections.emptyList<String>()
-                    }
-                }
-            """.trimIndent()
-
             assertThat(subject.lintWithContext(env, code)).hasSize(2)
+        }
+
+        @ParameterizedTest(name = "{0}, {1}")
+        @CsvSource(
+            value = [
+                "java.time.LocalDate, java.util.Collections",
+                "java.time.*, java.util.*",
+            ],
+        )
+        fun `does not report fully qualified class names in static method calls when ignored`(n1: String, n2: String) {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf(n1, n2))
+            assertThat(ignored.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -206,18 +243,30 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `constructor calls` {
+        val code = """
+            class Test {
+                fun method() {
+                    val list = java.util.ArrayList<String>()
+                    val date = java.time.LocalDate.of(2024, 1, 1)
+                }
+            }
+        """.trimIndent()
+
         @Test
         fun `reports constructor calls with fully qualified names`() {
-            val code = """
-                class Test {
-                    fun method() {
-                        val list = java.util.ArrayList<String>()
-                        val date = java.time.LocalDate.of(2024, 1, 1)
-                    }
-                }
-            """.trimIndent()
-
             assertThat(subject.lintWithContext(env, code)).hasSize(2)
+        }
+
+        @ParameterizedTest(name = "{0}, {1}")
+        @CsvSource(
+            value = [
+                "java.time.LocalDate, java.util.ArrayList",
+                "java.time.*, java.util.*",
+            ],
+        )
+        fun `does not report constructor calls with fully qualified names when ignored`(n1: String, n2: String) {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf(n1, n2))
+            assertThat(ignored.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -290,20 +339,68 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Nested
+    inner class `ignore nested classes` {
+        val code = """
+            import java.util.concurrent.ConcurrentHashMap
+
+            class Test {
+                fun method() {
+                    val entry: java.util.AbstractMap.SimpleEntry<String, Int> = java.util.AbstractMap.SimpleEntry("key1", 1)
+                    val key = java.util.AbstractMap.SimpleEntry("key2", 2).key
+                    val immutableEntry: java.util.AbstractMap.SimpleImmutableEntry<String, Int> = java.util.AbstractMap.SimpleImmutableEntry("key3", 3)
+                    val map: java.util.AbstractMap<String, Int> = ConcurrentHashMap()
+                }
+            }
+        """.trimIndent()
+
+        @Test
+        fun `does not report nested classes, if ignored`() {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.AbstractMap.*"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(
+                findings.first(),
+            ).hasMessage("Fully qualified class name 'java.util.AbstractMap' can be replaced with an import.")
+            assertThat(findings.first()).hasStartSourceLocation(8, 18)
+        }
+
+        @Test
+        fun `reports nested classes, if only enclosing class is ignored`() {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.AbstractMap"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).hasSize(5)
+            assertThat(findings).allMatch { it.entity.location.source.line != 8 }
+        }
+
+        @Test
+        fun `does not report classes and nested classes, if all ignored`() {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.**.*", "java.util.*"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).isEmpty()
+        }
+    }
+
+    @Nested
     inner class `class literals` {
+        val classNamesCode = """
+            class Test {
+                fun method() {
+                    val clazz = java.lang.String::class
+                    val javaClass = java.util.ArrayList::class.java
+                    val kClass = kotlin.collections.List::class
+                }
+            }
+        """.trimIndent()
+
         @Test
         fun `reports fully qualified names in class literals`() {
-            val code = """
-                class Test {
-                    fun method() {
-                        val clazz = java.lang.String::class
-                        val javaClass = java.util.ArrayList::class.java
-                        val kClass = kotlin.collections.List::class
-                    }
-                }
-            """.trimIndent()
+            assertThat(subject.lintWithContext(env, classNamesCode)).hasSize(3)
+        }
 
-            assertThat(subject.lintWithContext(env, code)).hasSize(3)
+        @Test
+        fun `does not report fully qualified names in class literals when ignored`() {
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.**.*", "kotlin.collections.List"))
+            assertThat(ignored.lintWithContext(env, classNamesCode)).isEmpty()
         }
 
         @Test
@@ -626,6 +723,40 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code)).hasSize(3)
         }
+
+        @ParameterizedTest(name = "{0}")
+        @CsvSource(
+            value = [
+                "kotlin.io.println",
+                "kotlin.io.print??",
+                "kotlin.io.*,",
+                "kotlin.**.*",
+            ],
+        )
+        fun `does not report fully qualified top-level function when ignored`(fqnToIgnore: String) {
+            val code = """
+                class Test {
+                    fun method() {
+                        kotlin.io.println("MyString")
+                    }
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf(fqnToIgnore))
+            assertThat(ignored.lintWithContext(env, code)).hasSize(0)
+        }
+
+        @Test
+        fun `does not report fully qualified top-level property when ignored`() {
+            val code = """
+                class Test {
+                    fun method() {
+                        val size = kotlin.io.DEFAULT_BUFFER_SIZE
+                    }
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("kotlin.io.*"))
+            assertThat(ignored.lintWithContext(env, code)).hasSize(0)
+        }
     }
 
     @Nested
@@ -711,6 +842,25 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
 
             assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @CsvSource(
+            value = [
+                "java.util.Calendar",
+                "java.util.*",
+                "java.**.?alendar",
+                "java.**.*",
+            ],
+        )
+        fun `does not report static property access when ignored`(fqnToIgnore: String) {
+            val code = """
+                class Test {
+                    val month = java.util.Calendar.JANUARY
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf(fqnToIgnore))
+            assertThat(ignored.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -1125,4 +1275,78 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             )
         }
     }
+
+    @Nested
+    inner class `ignoredFullyQualifiedNames validations` {
+        @Test
+        fun `ignores only configured fully qualified names`() {
+            val code = """
+                class Test {
+                    fun method(obj: Any) {
+                        val list = obj as java.util.List<String>
+                        val date = java.lang.Integer.MAX_VALUE
+                        val str = java.lang.String::class
+                    }
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.lang.*"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(
+                findings.first(),
+            ).hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
+        }
+
+        @Test
+        fun `does not ignore parent packages when only a subpackage is ignored`() {
+            val code = """
+                class Test {
+                    fun method(obj: Any) {
+                        val list = obj as java.util.List<String>
+                        val second = java.util.concurrent.TimeUnit.SECONDS
+                    }
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.concurrent.*"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(
+                findings.first(),
+            ).hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
+        }
+
+        @Test
+        fun `does not ignore subpackages when only a parent package is ignored`() {
+            val code = """
+                class Test {
+                    val charset = java.nio.charset.StandardCharsets.UTF_8
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.nio.*"))
+            assertThat(ignored.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not ignore other classes in a package when a single class is ignored`() {
+            val code = """
+                class Test {
+                    fun method() {
+                        val date = java.lang.Integer.MAX_VALUE
+                        val str = java.lang.String::class
+                    }
+                }
+            """.trimIndent()
+            val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.lang.Integer"))
+            val findings = ignored.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+            assertThat(
+                findings.first(),
+            ).hasMessage("Fully qualified class reference 'java.lang.String' can be replaced with an import.")
+        }
+    }
+
+    private fun createRule(ignoredFullyQualifiedNames: List<String>) =
+        UnnecessaryFullyQualifiedName(
+            TestConfig("ignoredFullyQualifiedNames" to ignoredFullyQualifiedNames),
+        )
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -357,11 +357,10 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
         fun `does not report nested classes, if ignored`() {
             val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.AbstractMap.*"))
             val findings = ignored.lintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(
-                findings.first(),
-            ).hasMessage("Fully qualified class name 'java.util.AbstractMap' can be replaced with an import.")
-            assertThat(findings.first()).hasStartSourceLocation(8, 18)
+            assertThat(findings)
+                .singleElement()
+                .hasMessage("Fully qualified class name 'java.util.AbstractMap' can be replaced with an import.")
+                .hasStartSourceLocation(8, 18)
         }
 
         @Test
@@ -1269,10 +1268,10 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
 
             val findings = subject.lintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(findings.first()).hasMessage(
-                "Fully qualified class name 'java.util.AbstractMap.SimpleEntry' can be replaced with an import."
-            )
+            assertThat(findings).singleElement()
+                .hasMessage(
+                    "Fully qualified class name 'java.util.AbstractMap.SimpleEntry' can be replaced with an import."
+                )
         }
     }
 
@@ -1291,10 +1290,8 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.lang.*"))
             val findings = ignored.lintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(
-                findings.first(),
-            ).hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
+            assertThat(findings).singleElement()
+                .hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
         }
 
         @Test
@@ -1309,10 +1306,8 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.util.concurrent.*"))
             val findings = ignored.lintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(
-                findings.first(),
-            ).hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
+            assertThat(findings).singleElement()
+                .hasMessage("Fully qualified class name 'java.util.List' can be replaced with an import.")
         }
 
         @Test
@@ -1338,10 +1333,8 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             val ignored = createRule(ignoredFullyQualifiedNames = listOf("java.lang.Integer"))
             val findings = ignored.lintWithContext(env, code)
-            assertThat(findings).hasSize(1)
-            assertThat(
-                findings.first(),
-            ).hasMessage("Fully qualified class reference 'java.lang.String' can be replaced with an import.")
+            assertThat(findings).singleElement()
+                .hasMessage("Fully qualified class reference 'java.lang.String' can be replaced with an import.")
         }
     }
 


### PR DESCRIPTION
Implementation of #9279

Introduce configuration option to ignore certain fully qualified names for the rule `UnnecessaryFullyQualifiedName`. 