### PR TITLE
docs: add ForbiddenImport configuration example

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
@@ -15,6 +15,19 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *
  * This rule allows to set a list of forbidden [forbiddenImports].
  * This can be used to discourage the use of unstable, experimental or deprecated APIs.
+ * Imports are configured as glob patterns and may include a reason that is shown in the finding:
+ *
+ * ```yaml
+ * ForbiddenImport:
+ *   active: true
+ *   forbiddenImports:
+ *     - value: 'kotlin.jvm.JvmField'
+ *       reason: 'Use explicit backing properties instead.'
+ *     - value: 'java.util.*'
+ *       reason: 'Use Kotlin standard library APIs instead.'
+ *   allowedImports:
+ *     - 'java.util.UUID'
+ * ```
  *
  * <noncompliant>
  * import kotlin.jvm.JvmField


### PR DESCRIPTION
## What

Adds a concrete `ForbiddenImport` configuration example to the rule KDoc so the generated docs show how to configure forbidden imports with reasons, wildcard imports, and allowed exceptions.

Refs #6088.

## Why

The issue asks for a practical example of the rule configuration, including the `value`/`reason` form and wildcard usage. The new example is added to the rule source documentation, which is the source used by Detekt's documentation generator.

## Verification

- `./gradlew generateDocumentation`
- `./gradlew :detekt-rules-style:test --tests "dev.detekt.rules.style.ForbiddenImportSpec"`
- `git diff --check`
