### PR TITLE
Forward languageVersionSettings to KotlinAnalysisApiEngine.compile

### DIFF
--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableMinLengthSpec.kt
@@ -4,6 +4,8 @@ import dev.detekt.api.Config
 import dev.detekt.test.TestConfig
 import dev.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -38,8 +40,12 @@ class VariableMinLengthSpec {
                     val _ = 1
                 }
             """.trimIndent()
-            // `val _ = ...` only compiles when Kotlin's experimental unused return value checker is enabled
-            assertThat(variableMinLength.lint(content = code, compile = false)).isEmpty()
+            assertThat(
+                variableMinLength.lint(
+                    content = code,
+                    languageVersionSettings = unnamedLocalVariablesEnabled,
+                )
+            ).isEmpty()
         }
 
         @Test
@@ -95,3 +101,9 @@ class VariableMinLengthSpec {
         ).isEmpty()
     }
 }
+
+private val unnamedLocalVariablesEnabled = LanguageVersionSettingsImpl(
+    languageVersion = LanguageVersionSettingsImpl.DEFAULT.languageVersion,
+    apiVersion = LanguageVersionSettingsImpl.DEFAULT.apiVersion,
+    specificFeatures = mapOf(LanguageFeature.UnnamedLocalVariables to LanguageFeature.State.ENABLED),
+)

--- a/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableNamingSpec.kt
+++ b/detekt-rules-naming/src/test/kotlin/dev/detekt/rules/naming/VariableNamingSpec.kt
@@ -5,6 +5,8 @@ import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.lint
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.jetbrains.kotlin.config.LanguageFeature
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.regex.PatternSyntaxException
@@ -124,8 +126,12 @@ class VariableNamingSpec {
                 val _ = 1
             }
         """.trimIndent()
-        // `val _ = ...` only compiles when Kotlin's experimental unused return value checker is enabled
-        assertThat(VariableNaming(Config.empty).lint(content = code, compile = false)).isEmpty()
+        assertThat(
+            VariableNaming(Config.empty).lint(
+                content = code,
+                languageVersionSettings = unnamedLocalVariablesEnabled,
+            )
+        ).isEmpty()
     }
 
     @Test
@@ -139,3 +145,9 @@ class VariableNamingSpec {
         assertThat(VariableNaming(Config.empty).lint(code)).hasSize(1)
     }
 }
+
+private val unnamedLocalVariablesEnabled = LanguageVersionSettingsImpl(
+    languageVersion = LanguageVersionSettingsImpl.DEFAULT.languageVersion,
+    apiVersion = LanguageVersionSettingsImpl.DEFAULT.apiVersion,
+    specificFeatures = mapOf(LanguageFeature.UnnamedLocalVariables to LanguageFeature.State.ENABLED),
+)

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/RedundantVisibilityModifierSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/RedundantVisibilityModifierSpec.kt
@@ -164,27 +164,27 @@ class RedundantVisibilityModifierSpec {
     @Nested
     inner class `Explicit API mode` {
         val code = """
-            public class A() {
-                fun f() {}
+            public class A {
+                public fun f() {}
             }
         """.trimIndent()
 
         @Test
-        fun `does not report public function in class if explicit API mode is set to strict`() {
+        fun `does not report public modifiers in strict mode`() {
             val findings = subject.lint(code, FakeLanguageVersionSettings(ExplicitApiMode.STRICT))
             assertThat(findings).isEmpty()
         }
 
         @Test
-        fun `does not report public function in class if explicit API mode is set to warning`() {
+        fun `does not report public modifiers in warning mode`() {
             val findings = subject.lint(code, FakeLanguageVersionSettings(ExplicitApiMode.WARNING))
             assertThat(findings).isEmpty()
         }
 
         @Test
-        fun `reports public function in class if explicit API mode is disabled`() {
+        fun `reports public modifiers in disabled mode`() {
             val findings = subject.lint(code, FakeLanguageVersionSettings(ExplicitApiMode.DISABLED))
-            assertThat(findings).hasSize(1)
+            assertThat(findings).hasSize(2)
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/optional/OptionalUnitSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/optional/OptionalUnitSpec.kt
@@ -405,7 +405,7 @@ class OptionalUnitSpec(val env: KotlinEnvironmentContainer) {
         @Test
         fun `should report when a function has an explicit Unit return type when config is strict`() {
             val code = """
-                fun foo(): Unit { }
+                public fun foo(): Unit { }
             """.trimIndent()
             val findings = subject.lintWithContext(
                 env,
@@ -444,7 +444,7 @@ class OptionalUnitSpec(val env: KotlinEnvironmentContainer) {
         @Test
         fun `should not report when a function has expression with Unit return type when config is strict`() {
             val code = """
-                fun foo(): Unit = println("")
+                public fun foo(): Unit = println("")
             """.trimIndent()
             val findings = subject.lintWithContext(
                 env,

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -10,8 +10,8 @@ public final class dev/detekt/test/utils/CompileExtensionsKt {
 public final class dev/detekt/test/utils/KotlinAnalysisApiEngine : java/lang/AutoCloseable {
 	public fun <init> ()V
 	public fun close ()V
-	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Z)Lorg/jetbrains/kotlin/psi/KtFile;
-	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLorg/jetbrains/kotlin/config/LanguageVersionSettings;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLorg/jetbrains/kotlin/config/LanguageVersionSettings;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
 public final class dev/detekt/test/utils/KotlinEnvironmentContainer {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
@@ -7,6 +7,8 @@ import org.jetbrains.kotlin.analysis.api.standalone.buildStandaloneAnalysisAPISe
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtLibraryModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSdkModule
 import org.jetbrains.kotlin.analysis.project.structure.builder.buildKtSourceModule
+import org.jetbrains.kotlin.config.LanguageVersionSettings
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.File
@@ -30,6 +32,7 @@ class KotlinAnalysisApiEngine : AutoCloseable {
      *
      * @throws IllegalStateException if the given code snippet does not compile
      */
+    @Suppress("LongParameterList")
     fun compile(
         @Language("kotlin") code: String,
         dependencyCodes: List<String> = emptyList(),
@@ -37,6 +40,7 @@ class KotlinAnalysisApiEngine : AutoCloseable {
         jvmClasspathRoots: List<Path> =
             listOf(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath()),
         allowCompilationErrors: Boolean = shouldCompileTestSnippets,
+        languageVersionSettings: LanguageVersionSettings = LanguageVersionSettingsImpl.DEFAULT,
     ): KtFile {
         val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
@@ -69,6 +73,7 @@ class KotlinAnalysisApiEngine : AutoCloseable {
                         addSourceRoots(javaSourceRoots)
                         platform = targetPlatform
                         moduleName = "source"
+                        this.languageVersionSettings = languageVersionSettings
                     }
                 )
             }

--- a/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
+++ b/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
@@ -2,6 +2,9 @@ package dev.detekt.test.utils
 
 import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.jetbrains.kotlin.config.AnalysisFlags
+import org.jetbrains.kotlin.config.ExplicitApiMode
+import org.jetbrains.kotlin.config.LanguageVersionSettingsImpl
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -73,6 +76,35 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
         assertThatThrownBy { analysisApiEngine.compile(invalidCode, allowCompilationErrors = false) }
             .isInstanceOf(IllegalStateException::class.java)
     }
+
+    @Test
+    fun `respects custom language version settings`() {
+        val code = """
+            fun foo() = Unit
+        """.trimIndent()
+
+        assertThatThrownBy {
+            analysisApiEngine.compile(
+                code = code,
+                allowCompilationErrors = false,
+                languageVersionSettings = explicitApi(ExplicitApiMode.STRICT),
+            )
+        }.isInstanceOf(IllegalStateException::class.java)
+
+        analysisApiEngine.compile(
+            code = code,
+            allowCompilationErrors = false,
+            languageVersionSettings = explicitApi(ExplicitApiMode.DISABLED),
+        )
+    }
+
+    private fun explicitApi(mode: ExplicitApiMode) =
+        LanguageVersionSettingsImpl(
+            languageVersion = LanguageVersionSettingsImpl.DEFAULT.languageVersion,
+            apiVersion = LanguageVersionSettingsImpl.DEFAULT.apiVersion,
+            analysisFlags = mapOf(AnalysisFlags.explicitApiMode to mode),
+            specificFeatures = emptyMap(),
+        )
 
     @Test
     fun `can compile with an external JAR dependency`() {

--- a/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
@@ -32,8 +32,9 @@ fun Rule.lint(
         try {
             KotlinAnalysisApiEngine().use {
                 it.compile(
-                    content,
+                    code = content,
                     jvmClasspathRoots = createEnvironment().jvmClasspathRoots,
+                    languageVersionSettings = languageVersionSettings,
                     allowCompilationErrors = false,
                 )
             }
@@ -58,6 +59,7 @@ fun <T> T.lintWithContext(
             dependencyCodes = dependencyContents.toList(),
             javaSourceRoots = environment.javaSourceRoots,
             jvmClasspathRoots = environment.jvmClasspathRoots,
+            languageVersionSettings = languageVersionSettings,
             allowCompilationErrors = allowCompilationErrors || !shouldCompileTestSnippets
         )
         visitFile(ktFile, languageVersionSettings).filterSuppressed(this)


### PR DESCRIPTION
Follow-up to https://github.com/detekt/detekt/pull/9300#discussion_r3176765976

## What
Forward `languageVersionSettings` from `Rule.lint` / `Rule.lintWithContext` into `KotlinAnalysisApiEngine.compile`, so the compile step matches the language settings the rule visit phase already uses.

- New `languageVersionSettings` parameter on `compile` (default: `LanguageVersionSettingsImpl.DEFAULT`), applied to the source module of the `StandaloneAnalysisAPISession`.
- `VariableMinLength` / `VariableNaming` unnamed-local-variable tests now enable `UnnamedLocalVariables` instead of using `compile = false`.
- `RedundantVisibilityModifier` / `OptionalUnit` explicit-API-mode specs updated so snippets remain valid Kotlin under strict mode (now enforced on the compile side too).

## Why
Previously `languageVersionSettings` was honoured during rule visitation but the preceding compile step silently fell back to defaults. This caused:

- `ExplicitApiMode` was effectively ignored on compile.
- Snippets requiring experimental features (e.g. `val _ = 1`) had to opt out of compilation entirely with `compile = false`.

## Review
- [x] I have read through every change and the description reflects my own intent
- [x] Implemented with Claude Opus 4.7
- [x] Cross-reviewed with GPT-5.4 (different model, per AI review policy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)