### PR TITLE
Gradle 9.4 improvements

### DIFF
--- a/build-logic/src/main/kotlin/ConsumeGeneratedConfig.kt
+++ b/build-logic/src/main/kotlin/ConsumeGeneratedConfig.kt
@@ -12,7 +12,7 @@ fun Project.consumeGeneratedConfig(
     val configurationName = "generatedConfigFor${forTask.name.replaceFirstChar { it.titlecase() }}"
     val generatedConfig = configurations.dependencyScope(configurationName)
     val generatedConfigFiles = configurations.resolvable("${configurationName}Files") {
-        extendsFrom(generatedConfig.get())
+        extendsFrom(generatedConfig)
     }
 
     dependencies {

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -18,7 +18,7 @@ nexusPublishing {
 
 val releaseArtifacts = configurations.dependencyScope("releaseArtifacts")
 val releaseAssetFiles = configurations.resolvable("releaseAssetFiles") {
-    extendsFrom(releaseArtifacts.get())
+    extendsFrom(releaseArtifacts)
 }
 
 val version = Versions.currentOrSnapshot()

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -13,7 +13,7 @@ val pluginsJar = configurations.dependencyScope("pluginsJar") {
 }
 
 val pluginsJarFiles = configurations.resolvable("pluginsJarFiles") {
-    extendsFrom(pluginsJar.get())
+    extendsFrom(pluginsJar)
 }
 
 dependencies {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -12,7 +12,7 @@ application {
 
 val detektCli = configurations.dependencyScope("detektCli")
 val detektCliClasspath = configurations.resolvable("detektCliClasspath") {
-    extendsFrom(detektCli.get())
+    extendsFrom(detektCli)
 }
 
 dependencies {

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -173,17 +173,17 @@ gradlePlugin {
     website = "https://detekt.dev"
     vcsUrl = "https://github.com/detekt/detekt"
     plugins {
-        create("dev.detekt.gradle.base") {
+        register("dev.detekt.gradle.base") {
             displayName = "Static code analysis for Kotlin - Base Plugin"
             description = "Static code analysis for Kotlin - Base Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
         }
-        create("dev.detekt") {
+        register("dev.detekt") {
             displayName = "Static code analysis for Kotlin"
             description = "Static code analysis for Kotlin"
             implementationClass = "dev.detekt.gradle.plugin.DetektPlugin"
         }
-        create("dev.detekt.gradle.compiler-plugin") {
+        register("dev.detekt.gradle.compiler-plugin") {
             displayName = "Static code analysis for Kotlin - Compiler Plugin"
             description = "Static code analysis for Kotlin - Compiler Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektKotlinCompilerPlugin"

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -173,20 +173,17 @@ gradlePlugin {
     website = "https://detekt.dev"
     vcsUrl = "https://github.com/detekt/detekt"
     plugins {
-        create("detektBasePlugin") {
-            id = "dev.detekt.gradle.base"
+        create("dev.detekt.gradle.base") {
             displayName = "Static code analysis for Kotlin - Base Plugin"
             description = "Static code analysis for Kotlin - Base Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektBasePlugin"
         }
-        create("detektPlugin") {
-            id = "dev.detekt"
+        create("dev.detekt") {
             displayName = "Static code analysis for Kotlin"
             description = "Static code analysis for Kotlin"
             implementationClass = "dev.detekt.gradle.plugin.DetektPlugin"
         }
-        create("detektCompilerPlugin") {
-            id = "dev.detekt.gradle.compiler-plugin"
+        create("dev.detekt.gradle.compiler-plugin") {
             displayName = "Static code analysis for Kotlin - Compiler Plugin"
             description = "Static code analysis for Kotlin - Compiler Plugin"
             implementationClass = "dev.detekt.gradle.plugin.DetektKotlinCompilerPlugin"

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 val aaDependency = configurations.dependencyScope("aaDependency")
 val aaDependencies = configurations.resolvable("aaDependencies") {
-    extendsFrom(aaDependency.get())
+    extendsFrom(aaDependency)
 }
 
 dependencies {

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 val aaDependency = configurations.dependencyScope("aaDependency")
 val aaDependencies = configurations.resolvable("aaDependencies") {
-    extendsFrom(aaDependency.get())
+    extendsFrom(aaDependency)
 }
 
 dependencies {


### PR DESCRIPTION
Makes a couple of minor improvements to the build configuration that were enabled by Gradle 9.4 upgrade.

Changing `create` to `register` wasn't enabled by the upgrade but something that should have been done a while ago.