### PR TITLE
Stop exposing ktlint's StandardRule to detekt-rules-ktlint-wrapper consumers

### DIFF
--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
@@ -28,7 +28,7 @@ import java.nio.file.Path
 /**
  * Rule to detect formatting violations.
  */
-abstract class KtlintRule(config: Config, description: String) : Rule(config, description) {
+internal abstract class KtlintRule(config: Config, description: String) : Rule(config, description) {
 
     abstract val wrapping: StandardRule
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationOnSeparateLine.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")
-class AnnotationOnSeparateLine(config: Config) :
+internal class AnnotationOnSeparateLine(config: Config) :
     KtlintRule(config, "Multiple annotations should be placed on separate lines.") {
 
     override val wrapping = AnnotationRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")
-class AnnotationSpacing(config: Config) :
+internal class AnnotationSpacing(config: Config) :
     KtlintRule(config, "There should not be empty lines between an annotation and the object that it's annotating") {
 
     override val wrapping = AnnotationSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ArgumentListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ArgumentListWrapping.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")
-class ArgumentListWrapping(config: Config) : KtlintRule(config, "Reports incorrect argument list wrapping") {
+internal class ArgumentListWrapping(config: Config) : KtlintRule(config, "Reports incorrect argument list wrapping") {
 
     override val wrapping = ArgumentListWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BackingPropertyNaming.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BackingPropertyNaming.kt
@@ -10,6 +10,6 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class BackingPropertyNaming(config: Config) : KtlintRule(config, "Reports incorrect property name.") {
+internal class BackingPropertyNaming(config: Config) : KtlintRule(config, "Reports incorrect property name.") {
     override val wrapping = BackingPropertyNamingRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BinaryExpressionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BinaryExpressionWrapping.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class BinaryExpressionWrapping(config: Config) :
+internal class BinaryExpressionWrapping(config: Config) :
     KtlintRule(
         config,
         "Wrap binary expression at the operator reference if the binary expression does not fit on the line"

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBeforeDeclaration.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBeforeDeclaration.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")
-class BlankLineBeforeDeclaration(config: Config) :
+internal class BlankLineBeforeDeclaration(config: Config) :
     KtlintRule(
         config,
         "A blank line is required before any class or function declaration, and before any list of top level or " +

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBetweenWhenConditions.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBetweenWhenConditions.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "2.0.0")
 @ActiveByDefault(since = "2.0.0")
-class BlankLineBetweenWhenConditions(config: Config) :
+internal class BlankLineBetweenWhenConditions(config: Config) :
     KtlintRule(config, "Consistently add or remove blank lines between when-conditions in a when-statement") {
 
     override val wrapping = BlankLineBetweenWhenConditions()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlockCommentInitialStarAlignment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlockCommentInitialStarAlignment.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class BlockCommentInitialStarAlignment(config: Config) :
+internal class BlockCommentInitialStarAlignment(config: Config) :
     KtlintRule(config, "Detect the alignment of the initial star in a block comment.") {
 
     override val wrapping = BlockCommentInitialStarAlignmentRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainMethodContinuation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainMethodContinuation.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  * for documentation.
  */
 @AutoCorrectable(since = "2.0.0")
-class ChainMethodContinuation(config: Config) :
+internal class ChainMethodContinuation(config: Config) :
     KtlintRule(config, "Checks if condition chaining is wrapped right") {
 
     override val wrapping = ChainMethodContinuationRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainWrapping.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class ChainWrapping(config: Config) : KtlintRule(config, "Checks if condition chaining is wrapped right") {
+internal class ChainWrapping(config: Config) : KtlintRule(config, "Checks if condition chaining is wrapped right") {
 
     override val wrapping = ChainWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassName.kt
@@ -8,7 +8,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#class-naming) for
  * documentation.
  */
-class ClassName(config: Config) :
+internal class ClassName(config: Config) :
     KtlintRule(config, "Class or object name should start with an uppercase letter and use camel case.") {
     override val wrapping = ClassNamingRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassSignature.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassSignature.kt
@@ -19,7 +19,8 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class ClassSignature(config: Config) : KtlintRule(config, "Ensure class signatures have a consistent format.") {
+internal class ClassSignature(config: Config) :
+    KtlintRule(config, "Ensure class signatures have a consistent format.") {
 
     override val wrapping = ClassSignatureRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class CommentSpacing(config: Config) : KtlintRule(config, "Checks if comments have the right spacing") {
+internal class CommentSpacing(config: Config) : KtlintRule(config, "Checks if comments have the right spacing") {
 
     override val wrapping = CommentSpacingRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentWrapping.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class CommentWrapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
+internal class CommentWrapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
 
     override val wrapping = CommentWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ConditionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ConditionWrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class ConditionWrapping(config: Config) :
+internal class ConditionWrapping(config: Config) :
     KtlintRule(config, "Conditions should be wrapped when expression doesn't fit on one line") {
 
     override val wrapping = ConditionWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverListWrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class ContextReceiverListWrapping(config: Config) :
+internal class ContextReceiverListWrapping(config: Config) :
     KtlintRule(config, "Wraps the context receiver list containing a context parameter") {
 
     override val wrapping = ContextReceiverListWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverMapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverMapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.23.0")
-class ContextReceiverMapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
+internal class ContextReceiverMapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
 
     override val wrapping = ContextReceiverWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumEntryNameCase.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumEntryNameCase.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 @AutoCorrectable(since = "1.4.0")
 @ActiveByDefault(since = "1.22.0")
 @Alias("EnumEntryName")
-class EnumEntryNameCase(config: Config) :
+internal class EnumEntryNameCase(config: Config) :
     KtlintRule(config, "Reports enum entries with names that don't meet standard conventions.") {
 
     override val wrapping = EnumEntryNameCaseRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumWrapping.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.23.0")
-class EnumWrapping(config: Config) :
+internal class EnumWrapping(config: Config) :
     KtlintRule(config, "An enum should be a single line, or each enum entry has to be placed on a separate line.") {
 
     override val wrapping = EnumWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ExpressionOperandWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ExpressionOperandWrapping.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")
-class ExpressionOperandWrapping(config: Config) :
+internal class ExpressionOperandWrapping(config: Config) :
     KtlintRule(config, "Wraps each operand in a multiline expression to a separate line") {
 
     override val wrapping = ExpressionOperandWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Filename.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Filename.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * from the standard rules, make sure to enable just one.
  */
 @ActiveByDefault(since = "1.0.0")
-class Filename(config: Config) : KtlintRule(config, "Checks if top level class matches the filename") {
+internal class Filename(config: Config) : KtlintRule(config, "Checks if top level class matches the filename") {
 
     override val wrapping = FilenameRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FinalNewline.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FinalNewline.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class FinalNewline(config: Config) : KtlintRule(config, "Detects missing final newlines") {
+internal class FinalNewline(config: Config) : KtlintRule(config, "Detects missing final newlines") {
 
     override val wrapping = FinalNewlineRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunKeywordSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunKeywordSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class FunKeywordSpacing(config: Config) : KtlintRule(config, "Checks the spacing after the fun keyword.") {
+internal class FunKeywordSpacing(config: Config) : KtlintRule(config, "Checks the spacing after the fun keyword.") {
 
     override val wrapping = FunKeywordSpacingRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionExpressionBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionExpressionBody.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class FunctionExpressionBody(config: Config) :
+internal class FunctionExpressionBody(config: Config) :
     KtlintRule(config, "Function body containing only a return or throw expression should be an expression body.") {
 
     override val wrapping = FunctionExpressionBodyRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionLiteral.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionLiteral.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class FunctionLiteral(config: Config) :
+internal class FunctionLiteral(config: Config) :
     KtlintRule(config, "Parameters and -> of a function literal should be on the same line as the opening brace.") {
     override val wrapping = FunctionLiteralRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionName.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-naming) for
  * documentation.
  */
-class FunctionName(config: Config) :
+internal class FunctionName(config: Config) :
     KtlintRule(
         config,
         "Function name should start with a lowercase letter (except factory methods) and use camel case."

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionReturnTypeSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionReturnTypeSpacing.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.22.0")
-class FunctionReturnTypeSpacing(config: Config) :
+internal class FunctionReturnTypeSpacing(config: Config) :
     KtlintRule(config, "Checks the spacing between colon and return type.") {
 
     override val wrapping = FunctionReturnTypeSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionSignature.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionSignature.kt
@@ -18,7 +18,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.22.0")
-class FunctionSignature(config: Config) :
+internal class FunctionSignature(config: Config) :
     KtlintRule(config, "Format signature to be single when possible, multiple lines otherwise.") {
 
     override val wrapping = FunctionSignatureRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionStartOfBodySpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionStartOfBodySpacing.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.22.0")
-class FunctionStartOfBodySpacing(config: Config) :
+internal class FunctionStartOfBodySpacing(config: Config) :
     KtlintRule(config, "Check for consistent spacing before start of function body.") {
 
     override val wrapping = FunctionStartOfBodySpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeModifierSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeModifierSpacing.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class FunctionTypeModifierSpacing(config: Config) :
+internal class FunctionTypeModifierSpacing(config: Config) :
     KtlintRule(config, "Enforce a single whitespace between the modifier list and the function type.") {
 
     override val wrapping = FunctionTypeModifierSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeReferenceSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeReferenceSpacing.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class FunctionTypeReferenceSpacing(config: Config) :
+internal class FunctionTypeReferenceSpacing(config: Config) :
     KtlintRule(config, "Checks the spacing before and after the angle brackets of a type argument list.") {
 
     override val wrapping = FunctionTypeReferenceSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseBracing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseBracing.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-bracing) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class IfElseBracing(config: Config) :
+internal class IfElseBracing(config: Config) :
     KtlintRule(config, "All branches must be wrapped in curly braces if any branches are wrapped.") {
 
     override val wrapping = IfElseBracingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class IfElseWrapping(config: Config) :
+internal class IfElseWrapping(config: Config) :
     KtlintRule(config, "A single line if-statement may contain no more than one else-branch.") {
 
     override val wrapping = IfElseWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ImportOrdering.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ImportOrdering.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "1.19.0")
 @AutoCorrectable(since = "1.0.0")
-class ImportOrdering(config: Config) : KtlintRule(config, "Detects imports in non default order") {
+internal class ImportOrdering(config: Config) : KtlintRule(config, "Detects imports in non default order") {
 
     override val wrapping = ImportOrderingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.19.0")
 @AutoCorrectable(since = "1.0.0")
-class Indentation(config: Config) : KtlintRule(config, "Reports mis-indented code") {
+internal class Indentation(config: Config) : KtlintRule(config, "Reports mis-indented code") {
 
     override val wrapping = IndentationRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Kdoc.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Kdoc.kt
@@ -9,7 +9,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#kdoc) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class Kdoc(config: Config) :
+internal class Kdoc(config: Config) :
     KtlintRule(
         config,
         "Only allow KDoc when comments are in a location that can be converted to public documentation"

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/KdocWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/KdocWrapping.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class KdocWrapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
+internal class KdocWrapping(config: Config) : KtlintRule(config, "Reports mis-indented code") {
 
     override val wrapping = KdocWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MaximumLineLength.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MaximumLineLength.kt
@@ -19,7 +19,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "1.0.0")
 @Alias("MaxLineLength")
-class MaximumLineLength(config: Config) : KtlintRule(config, "Reports lines with exceeded length") {
+internal class MaximumLineLength(config: Config) : KtlintRule(config, "Reports lines with exceeded length") {
 
     override val wrapping = MaxLineLengthRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MixedConditionOperators.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MixedConditionOperators.kt
@@ -9,7 +9,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class MixedConditionOperators(config: Config) :
+internal class MixedConditionOperators(config: Config) :
     KtlintRule(config, "Conditions should not use a both '&&' and '||' operators between operators at the same level") {
 
     override val wrapping = MixedConditionOperatorsRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierListSpacing.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class ModifierListSpacing(config: Config) :
+internal class ModifierListSpacing(config: Config) :
     KtlintRule(config, "Checks the spacing between the modifiers in and after the last modifier in a modifier list.") {
 
     override val wrapping = ModifierListSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierOrdering.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierOrdering.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class ModifierOrdering(config: Config) : KtlintRule(config, "Detects modifiers in non default order") {
+internal class ModifierOrdering(config: Config) : KtlintRule(config, "Detects modifiers in non default order") {
 
     override val wrapping = ModifierOrderRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultiLineIfElse.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultiLineIfElse.kt
@@ -15,7 +15,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")
-class MultiLineIfElse(config: Config) : KtlintRule(config, "Detects multiline if-else statements without braces") {
+internal class MultiLineIfElse(config: Config) :
+    KtlintRule(config, "Detects multiline if-else statements without braces") {
 
     override val wrapping = MultiLineIfElseRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineExpressionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineExpressionWrapping.kt
@@ -19,7 +19,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * intellij_idea by default.
  */
 @AutoCorrectable(since = "1.23.0")
-class MultilineExpressionWrapping(config: Config) :
+internal class MultilineExpressionWrapping(config: Config) :
     KtlintRule(config, "Multiline expression on the right hand side of an expression must start on a separate line.") {
 
     override val wrapping = MultilineExpressionWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineLoop.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineLoop.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class MultilineLoop(config: Config) : KtlintRule(config, "Detects multiline loop statements without braces") {
+internal class MultilineLoop(config: Config) : KtlintRule(config, "Detects multiline loop statements without braces") {
 
     override val wrapping = MultilineLoopRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineBeforeRbrace.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineBeforeRbrace.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoBlankLineBeforeRbrace(config: Config) : KtlintRule(config, "Detects blank lines before rbraces") {
+internal class NoBlankLineBeforeRbrace(config: Config) : KtlintRule(config, "Detects blank lines before rbraces") {
 
     override val wrapping = NoBlankLineBeforeRbraceRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineInList.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineInList.kt
@@ -9,7 +9,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-list) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class NoBlankLineInList(config: Config) :
+internal class NoBlankLineInList(config: Config) :
     KtlintRule(config, "Disallow blank lines in lists before, between or after any list element.") {
 
     override val wrapping = NoBlankLineInListRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLinesInChainedMethodCalls.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLinesInChainedMethodCalls.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.22.0")
 @AutoCorrectable(since = "1.22.0")
-class NoBlankLinesInChainedMethodCalls(config: Config) :
+internal class NoBlankLinesInChainedMethodCalls(config: Config) :
     KtlintRule(config, "Detects blank lines in chained method rules.") {
 
     override val wrapping = NoBlankLinesInChainedMethodCallsRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveBlankLines.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveBlankLines.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoConsecutiveBlankLines(config: Config) : KtlintRule(config, "Reports consecutive blank lines") {
+internal class NoConsecutiveBlankLines(config: Config) : KtlintRule(config, "Reports consecutive blank lines") {
 
     override val wrapping = NoConsecutiveBlankLinesRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveComments.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveComments.kt
@@ -7,7 +7,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 /**
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-comments) for documentation.
  */
-class NoConsecutiveComments(config: Config) : KtlintRule(config, "Disallow consecutive comments in most cases.") {
+internal class NoConsecutiveComments(config: Config) :
+    KtlintRule(config, "Disallow consecutive comments in most cases.") {
 
     override val wrapping = NoConsecutiveCommentsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyClassBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyClassBody.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoEmptyClassBody(config: Config) : KtlintRule(config, "Reports empty class bodies") {
+internal class NoEmptyClassBody(config: Config) : KtlintRule(config, "Reports empty class bodies") {
 
     override val wrapping = NoEmptyClassBodyRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFile.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFile.kt
@@ -9,7 +9,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-file) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class NoEmptyFile(config: Config) : KtlintRule(config, "Kotlin files must contain at least one declaration") {
+internal class NoEmptyFile(config: Config) : KtlintRule(config, "Kotlin files must contain at least one declaration") {
 
     override val wrapping = NoEmptyFileRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInClassBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInClassBody.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class NoEmptyFirstLineInClassBody(config: Config) :
+internal class NoEmptyFirstLineInClassBody(config: Config) :
     KtlintRule(config, "Disallow blank lines at start of a class body.") {
 
     override val wrapping = NoEmptyFirstLineInClassBodyRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.4.0")
 @ActiveByDefault(since = "1.22.0")
-class NoEmptyFirstLineInMethodBlock(config: Config) :
+internal class NoEmptyFirstLineInMethodBlock(config: Config) :
     KtlintRule(config, "Reports methods that have an empty first line.") {
 
     override val wrapping = NoEmptyFirstLineInMethodBlockRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakAfterElse.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakAfterElse.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoLineBreakAfterElse(config: Config) : KtlintRule(config, "Reports line breaks after else") {
+internal class NoLineBreakAfterElse(config: Config) : KtlintRule(config, "Reports line breaks after else") {
 
     override val wrapping = NoLineBreakAfterElseRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakBeforeAssignment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakBeforeAssignment.kt
@@ -12,7 +12,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoLineBreakBeforeAssignment(config: Config) : KtlintRule(config, "Reports line breaks before assignment") {
+internal class NoLineBreakBeforeAssignment(config: Config) :
+    KtlintRule(config, "Reports line breaks before assignment") {
 
     override val wrapping = NoLineBreakBeforeAssignmentRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoMultipleSpaces.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoMultipleSpaces.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoMultipleSpaces(config: Config) : KtlintRule(config, "Reports multiple space usages") {
+internal class NoMultipleSpaces(config: Config) : KtlintRule(config, "Reports multiple space usages") {
 
     override val wrapping = NoMultipleSpacesRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSemicolons.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSemicolons.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoSemicolons(config: Config) : KtlintRule(config, "Detects semicolons") {
+internal class NoSemicolons(config: Config) : KtlintRule(config, "Detects semicolons") {
 
     override val wrapping = NoSemicolonsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSingleLineBlockComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSingleLineBlockComment.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-single-line-block-comment) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class NoSingleLineBlockComment(config: Config) : KtlintRule(config, "Reports single block line comments") {
+internal class NoSingleLineBlockComment(config: Config) : KtlintRule(config, "Reports single block line comments") {
 
     override val wrapping = NoSingleLineBlockCommentRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoTrailingSpaces.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoTrailingSpaces.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoTrailingSpaces(config: Config) : KtlintRule(config, "Detects trailing spaces") {
+internal class NoTrailingSpaces(config: Config) : KtlintRule(config, "Detects trailing spaces") {
 
     override val wrapping = NoTrailingSpacesRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnitReturn.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnitReturn.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoUnitReturn(config: Config) : KtlintRule(config, "Detects optional 'Unit' return types") {
+internal class NoUnitReturn(config: Config) : KtlintRule(config, "Detects optional 'Unit' return types") {
 
     override val wrapping = NoUnitReturnRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnusedImports.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnusedImports.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class NoUnusedImports(config: Config) : KtlintRule(config, "Detects unused imports") {
+internal class NoUnusedImports(config: Config) : KtlintRule(config, "Detects unused imports") {
 
     override val wrapping = NoUnusedImportsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoWildcardImports.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoWildcardImports.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-wildcard-imports) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
-class NoWildcardImports(config: Config) : KtlintRule(config, "Detects wildcard imports") {
+internal class NoWildcardImports(config: Config) : KtlintRule(config, "Detects wildcard imports") {
 
     override val wrapping = NoWildcardImportsRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NullableTypeSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NullableTypeSpacing.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.22.0")
-class NullableTypeSpacing(config: Config) : KtlintRule(config, "Ensure no spaces in nullable type.") {
+internal class NullableTypeSpacing(config: Config) : KtlintRule(config, "Ensure no spaces in nullable type.") {
 
     override val wrapping = NullableTypeSpacingRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PackageName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PackageName.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "1.22.0")
-class PackageName(config: Config) : KtlintRule(config, "Checks package name is formatted correctly") {
+internal class PackageName(config: Config) : KtlintRule(config, "Checks package name is formatted correctly") {
 
     override val wrapping = PackageNameRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListSpacing.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.22.0")
-class ParameterListSpacing(config: Config) :
+internal class ParameterListSpacing(config: Config) :
     KtlintRule(config, "Ensure consistent spacing inside the parameter list.") {
 
     override val wrapping = ParameterListSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListWrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class ParameterListWrapping(config: Config) : KtlintRule(config, "Detects mis-aligned parameter lists") {
+internal class ParameterListWrapping(config: Config) : KtlintRule(config, "Detects mis-aligned parameter lists") {
 
     override val wrapping = ParameterListWrappingRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterWrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")
-class ParameterWrapping(config: Config) :
+internal class ParameterWrapping(config: Config) :
     KtlintRule(
         config,
         "Type or value of functions and class parameters must wrap if parameters don't fit on a single line"

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyName.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class PropertyName(config: Config) : KtlintRule(config, "Reports incorrect property name.") {
+internal class PropertyName(config: Config) : KtlintRule(config, "Reports incorrect property name.") {
     override val wrapping = PropertyNamingRule()
 
     @Configuration("The naming style ('screaming_snake_case', or 'pascal_case') to be applied on constant properties.")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyWrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")
-class PropertyWrapping(config: Config) :
+internal class PropertyWrapping(config: Config) :
     KtlintRule(config, "Type or value of properties must wrap if parameters don't fit on a single line") {
 
     override val wrapping = PropertyWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundAngleBrackets.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")
-class SpacingAroundAngleBrackets(config: Config) : KtlintRule(config, "Reports spaces around angle brackets") {
+internal class SpacingAroundAngleBrackets(config: Config) : KtlintRule(config, "Reports spaces around angle brackets") {
 
     override val wrapping = SpacingAroundAngleBracketsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundColon.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundColon.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundColon(config: Config) : KtlintRule(config, "Reports spaces around colons") {
+internal class SpacingAroundColon(config: Config) : KtlintRule(config, "Reports spaces around colons") {
 
     override val wrapping = SpacingAroundColonRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundComma.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundComma.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundComma(config: Config) : KtlintRule(config, "Reports spaces around commas") {
+internal class SpacingAroundComma(config: Config) : KtlintRule(config, "Reports spaces around commas") {
 
     override val wrapping = SpacingAroundCommaRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundCurly.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundCurly.kt
@@ -15,7 +15,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundCurly(config: Config) : KtlintRule(config, "Reports spaces around curly braces") {
+internal class SpacingAroundCurly(config: Config) : KtlintRule(config, "Reports spaces around curly braces") {
 
     override val wrapping = SpacingAroundCurlyRule()
 

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDot.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDot.kt
@@ -11,7 +11,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundDot(config: Config) : KtlintRule(config, "Reports spaces around member invocation operator (dot).") {
+internal class SpacingAroundDot(config: Config) :
+    KtlintRule(config, "Reports spaces around member invocation operator (dot).") {
 
     override val wrapping = SpacingAroundDotRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDoubleColon.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.10.0")
 @ActiveByDefault(since = "1.22.0")
-class SpacingAroundDoubleColon(config: Config) : KtlintRule(config, "Reports spaces around double colons") {
+internal class SpacingAroundDoubleColon(config: Config) : KtlintRule(config, "Reports spaces around double colons") {
 
     override val wrapping = SpacingAroundDoubleColonRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundKeyword.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundKeyword.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundKeyword(config: Config) : KtlintRule(config, "Reports spaces around keywords") {
+internal class SpacingAroundKeyword(config: Config) : KtlintRule(config, "Reports spaces around keywords") {
 
     override val wrapping = SpacingAroundKeywordRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundOperators.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundOperators.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundOperators(config: Config) : KtlintRule(config, "Reports spaces around operators") {
+internal class SpacingAroundOperators(config: Config) : KtlintRule(config, "Reports spaces around operators") {
 
     override val wrapping = SpacingAroundOperatorsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundParens.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundParens.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundParens(config: Config) : KtlintRule(config, "Reports spaces around parentheses") {
+internal class SpacingAroundParens(config: Config) : KtlintRule(config, "Reports spaces around parentheses") {
 
     override val wrapping = SpacingAroundParensRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundRangeOperator.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundRangeOperator.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class SpacingAroundRangeOperator(config: Config) : KtlintRule(config, "Reports spaces around range operator") {
+internal class SpacingAroundRangeOperator(config: Config) : KtlintRule(config, "Reports spaces around range operator") {
 
     override val wrapping = SpacingAroundRangeOperatorRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundSquareBrackets.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundSquareBrackets.kt
@@ -12,7 +12,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "2.0.0")
 @ActiveByDefault(since = "2.0.0")
-class SpacingAroundSquareBrackets(config: Config) : KtlintRule(config, "Reports spaces around square brackets") {
+internal class SpacingAroundSquareBrackets(config: Config) :
+    KtlintRule(config, "Reports spaces around square brackets") {
 
     override val wrapping = SpacingAroundSquareBracketsRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundUnaryOperator.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")
-class SpacingAroundUnaryOperator(config: Config) : KtlintRule(config, "Reports spaces around unary operator") {
+internal class SpacingAroundUnaryOperator(config: Config) : KtlintRule(config, "Reports spaces around unary operator") {
 
     override val wrapping = SpacingAroundUnaryOperatorRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.10.0")
 @ActiveByDefault(since = "1.22.0")
-class SpacingBetweenDeclarationsWithAnnotations(config: Config) :
+internal class SpacingBetweenDeclarationsWithAnnotations(config: Config) :
     KtlintRule(config, "Declarations and declarations with annotations should have an empty space between.") {
 
     override val wrapping = SpacingBetweenDeclarationsWithAnnotationsRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @AutoCorrectable(since = "1.10.0")
 @ActiveByDefault(since = "1.22.0")
-class SpacingBetweenDeclarationsWithComments(config: Config) :
+internal class SpacingBetweenDeclarationsWithComments(config: Config) :
     KtlintRule(config, "Declarations and declarations with comments should have an empty space between.") {
 
     override val wrapping = SpacingBetweenDeclarationsWithCommentsRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.22.0")
-class SpacingBetweenFunctionNameAndOpeningParenthesis(config: Config) :
+internal class SpacingBetweenFunctionNameAndOpeningParenthesis(config: Config) :
     KtlintRule(config, "Ensure consistent spacing between function name and opening parenthesis.") {
 
     override val wrapping = SpacingBetweenFunctionNameAndOpeningParenthesisRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StatementWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StatementWrapping.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class StatementWrapping(config: Config) :
+internal class StatementWrapping(config: Config) :
     KtlintRule(config, "Block body statements must be placed on a different line than the braces of the body block.") {
 
     override val wrapping = StatementWrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplate.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplate.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")
-class StringTemplate(config: Config) : KtlintRule(config, "Detects simplifications in template strings") {
+internal class StringTemplate(config: Config) : KtlintRule(config, "Detects simplifications in template strings") {
 
     override val wrapping = StringTemplateRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplateIndent.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplateIndent.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template-indent) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class StringTemplateIndent(config: Config) :
+internal class StringTemplateIndent(config: Config) :
     KtlintRule(
         config,
         "Enforce consistent multiline string template indentation which are post-fixed with .trimIndent()"

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ThenSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ThenSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")
-class ThenSpacing(config: Config) :
+internal class ThenSpacing(config: Config) :
     KtlintRule(config, "Enforces consistent spacing around the `then` block in an `if`-statement") {
 
     override val wrapping = ThenSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnCallSite.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnCallSite.kt
@@ -21,7 +21,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.22.0")
-class TrailingCommaOnCallSite(config: Config) :
+internal class TrailingCommaOnCallSite(config: Config) :
     KtlintRule(config, "Rule to mandate/forbid trailing commas at call sites") {
 
     override val wrapping = TrailingCommaOnCallSiteRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnDeclarationSite.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnDeclarationSite.kt
@@ -21,7 +21,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.22.0")
-class TrailingCommaOnDeclarationSite(config: Config) :
+internal class TrailingCommaOnDeclarationSite(config: Config) :
     KtlintRule(config, "Rule to mandate/forbid trailing commas at declaration sites") {
 
     override val wrapping = TrailingCommaOnDeclarationSiteRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TryCatchFinallySpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TryCatchFinallySpacing.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @AutoCorrectable(since = "1.23.0")
-class TryCatchFinallySpacing(config: Config) :
+internal class TryCatchFinallySpacing(config: Config) :
     KtlintRule(config, "Enforce consistent spacing in try-catch-finally blocks.") {
 
     override val wrapping = TryCatchFinallySpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentComment.kt
@@ -10,7 +10,8 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class TypeArgumentComment(config: Config) : KtlintRule(config, "Detect discouraged type argument comment locations.") {
+internal class TypeArgumentComment(config: Config) :
+    KtlintRule(config, "Detect discouraged type argument comment locations.") {
 
     override val wrapping = TypeArgumentCommentRule()
 }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentListSpacing.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.20.0")
-class TypeArgumentListSpacing(config: Config) :
+internal class TypeArgumentListSpacing(config: Config) :
     KtlintRule(config, "Reports spaces in the type reference before a function.") {
 
     override val wrapping = TypeArgumentListSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterComment.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class TypeParameterComment(config: Config) :
+internal class TypeParameterComment(config: Config) :
     KtlintRule(config, "Detect discouraged type parameter comment locations.") {
 
     override val wrapping = TypeParameterCommentRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterListSpacing.kt
@@ -16,7 +16,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.22.0")
-class TypeParameterListSpacing(config: Config) :
+internal class TypeParameterListSpacing(config: Config) :
     KtlintRule(config, "Check spacing after a type parameter list in function and class declarations.") {
 
     override val wrapping = TypeParameterListSpacingRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")
-class UnnecessaryParenthesesBeforeTrailingLambda(config: Config) :
+internal class UnnecessaryParenthesesBeforeTrailingLambda(config: Config) :
     KtlintRule(config, "Ensures there are no unnecessary parentheses before a trailing lambda") {
 
     override val wrapping = UnnecessaryParenthesesBeforeTrailingLambdaRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueArgumentComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueArgumentComment.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class ValueArgumentComment(config: Config) :
+internal class ValueArgumentComment(config: Config) :
     KtlintRule(config, "Detect discouraged value argument comment locations.") {
 
     override val wrapping = ValueArgumentCommentRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueParameterComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueParameterComment.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")
-class ValueParameterComment(config: Config) :
+internal class ValueParameterComment(config: Config) :
     KtlintRule(config, "Detect discouraged value parameter comment locations.") {
 
     override val wrapping = ValueParameterCommentRule()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/WhenEntryBracing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/WhenEntryBracing.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")
-class WhenEntryBracing(config: Config) :
+internal class WhenEntryBracing(config: Config) :
     KtlintRule(config, "Enforce consistent usages of braces inside the when-statement.") {
 
     override val wrapping = WhenEntryBracing()

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Wrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Wrapping.kt
@@ -17,7 +17,7 @@ import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
  */
 @ActiveByDefault(since = "1.20.0")
 @AutoCorrectable(since = "1.20.0")
-class Wrapping(config: Config) :
+internal class Wrapping(config: Config) :
     KtlintRule(config, "Reports missing newlines (e.g. between parentheses of a multi-line function call") {
 
     override val wrapping = WrappingRule()

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/TestFiles.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/TestFiles.kt
@@ -10,7 +10,7 @@ import org.intellij.lang.annotations.Language
 import java.io.File
 import kotlin.io.path.toPath
 
-fun KtlintRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
+internal fun KtlintRule.lint(@Language("kotlin") content: String, fileName: String = "Test.kt"): List<Finding> {
     require('/' !in fileName && '\\' !in fileName) {
         "filename must be a file name only and not contain any path elements"
     }

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/WrapperSmokeTestSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/WrapperSmokeTestSpec.kt
@@ -7,7 +7,7 @@ import io.github.classgraph.ClassGraph
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 
-class WrapperSmokeTestSpec {
+internal class WrapperSmokeTestSpec {
     @ParameterizedTest(name = "for rule: {0}")
     @MethodSource("ktlintRules")
     fun `smoke test`(subject: KtlintRule) {


### PR DESCRIPTION
This is unnecessary and results in DAGP saying ktlint-repackage should be an api dependency:

```
> Task :detekt-rules-ktlint-wrapper:projectHealth
C:\Users\.\IdeaProjects\detekt\detekt-rules-ktlint-wrapper\build.gradle.kts
Existing dependencies which should be modified to be as indicated:
  api(project(":detekt-rules-ktlint-wrapper:ktlint-repackage")) (was implementation)
```

Helps with #8349 