### PR TITLE
Stop publishing ktlint-repackage

### DIFF
--- a/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("packaging")
+    id("java")
     id("com.gradleup.shadow") version "9.4.1"
 }
 


### PR DESCRIPTION
This package is not intended to be used directly. Its only purpose it to be included in detekt-rules-ktlint-wrapper.