### PR TITLE
Apply indent_style to all ktlint wrapper rules

### DIFF
--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
@@ -38,9 +38,9 @@ internal abstract class KtlintRule(config: Config, description: String) : Rule(c
             ?: KtlintWrapperProvider.code_style.defaultValue
 
     protected val indentStyle: String
-        get() = config.valueOrNull("indent_style")
-            ?: config.parent?.let { KtlintWrapperProvider.indent_style.value(it) }
-            ?: KtlintWrapperProvider.indent_style.defaultValue
+        get() = config.valueOrNull("indentStyle")
+            ?: config.parent?.let { KtlintWrapperProvider.indentStyle.value(it) }
+            ?: KtlintWrapperProvider.indentStyle.defaultValue
 
     private lateinit var positionByOffset: (offset: Int) -> Pair<Int, Int>
     private lateinit var root: KtFile

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintRule.kt
@@ -37,6 +37,11 @@ internal abstract class KtlintRule(config: Config, description: String) : Rule(c
             ?: config.parent?.let { KtlintWrapperProvider.code_style.value(it) }
             ?: KtlintWrapperProvider.code_style.defaultValue
 
+    protected val indentStyle: String
+        get() = config.valueOrNull("indent_style")
+            ?: config.parent?.let { KtlintWrapperProvider.indent_style.value(it) }
+            ?: KtlintWrapperProvider.indent_style.defaultValue
+
     private lateinit var positionByOffset: (offset: Int) -> Pair<Int, Int>
     private lateinit var root: KtFile
     private lateinit var originalFilePath: Path
@@ -71,7 +76,7 @@ internal abstract class KtlintRule(config: Config, description: String) : Rule(c
 
         usesEditorConfigProperties[INDENT_STYLE_PROPERTY] = usesEditorConfigProperties.getOrDefault(
             INDENT_STYLE_PROPERTY,
-            "space",
+            indentStyle,
         )
 
         val properties = buildMap {

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
@@ -244,7 +244,7 @@ class KtlintWrapperProvider : RuleSetProvider {
         val code_style by ruleSetConfig("intellij_idea")
 
         @Configuration("indentation style applied across all ktlint rules (space or tab)")
-        val indent_style by ruleSetConfig("space")
+        val indentStyle by ruleSetConfig("space")
 
         @Configuration("if rules should auto correct style violation")
         val autoCorrect by ruleSetConfig(true)

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
@@ -243,6 +243,9 @@ class KtlintWrapperProvider : RuleSetProvider {
         @Configuration("ktlint code style for formatting rules (ktlint_official, intellij_idea or android_studio)")
         val code_style by ruleSetConfig("intellij_idea")
 
+        @Configuration("indentation style applied across all ktlint rules (space or tab)")
+        val indent_style by ruleSetConfig("space")
+
         @Configuration("if rules should auto correct style violation")
         val autoCorrect by ruleSetConfig(true)
     }

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
@@ -2,7 +2,6 @@ package dev.detekt.rules.ktlintwrapper.wrappers
 
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.EditorConfigProperty
 import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_SIZE_PROPERTY
-import com.pinterest.ktlint.rule.engine.core.api.editorconfig.INDENT_STYLE_PROPERTY
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule
 import com.pinterest.ktlint.ruleset.standard.rules.IndentationRule.Companion.INDENT_WHEN_ARROW_ON_NEW_LINE
 import dev.detekt.api.ActiveByDefault
@@ -24,16 +23,12 @@ internal class Indentation(config: Config) : KtlintRule(config, "Reports mis-ind
     @Configuration("indentation size")
     private val indentSize by config(4)
 
-    @Configuration("indentation style (space or tab)")
-    private val indentStyle by config("space")
-
     @Configuration("indent when arrow on new line")
     private val indentWhenArrowOnNewLine by config(false)
 
     override fun overrideEditorConfigProperties(): Map<EditorConfigProperty<*>, String> =
         mapOf(
             INDENT_SIZE_PROPERTY to indentSize.toString(),
-            INDENT_STYLE_PROPERTY to indentStyle,
             INDENT_WHEN_ARROW_ON_NEW_LINE to indentWhenArrowOnNewLine.toString(),
         )
 }

--- a/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
+++ b/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
@@ -1,6 +1,7 @@
 ktlint:
   active: true
   code_style: 'intellij_idea'
+  indent_style: 'space'
   autoCorrect: true
   AnnotationOnSeparateLine:
     active: true
@@ -140,7 +141,6 @@ ktlint:
     active: true
     autoCorrect: true
     indentSize: 4
-    indentStyle: 'space'
     indentWhenArrowOnNewLine: false
   Kdoc:
     active: true

--- a/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
+++ b/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
@@ -1,7 +1,7 @@
 ktlint:
   active: true
   code_style: 'intellij_idea'
-  indent_style: 'space'
+  indentStyle: 'space'
   autoCorrect: true
   AnnotationOnSeparateLine:
     active: true

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationFunctionSignatureSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationFunctionSignatureSpec.kt
@@ -1,0 +1,55 @@
+package dev.detekt.rules.ktlintwrapper
+
+import dev.detekt.api.modifiedText
+import dev.detekt.rules.ktlintwrapper.wrappers.FunctionSignature
+import dev.detekt.rules.ktlintwrapper.wrappers.Indentation
+import dev.detekt.test.TestConfig
+import dev.detekt.test.assertj.assertThat
+import dev.detekt.test.lint
+import dev.detekt.test.utils.compileContentForTest
+import org.junit.jupiter.api.Test
+import org.assertj.core.api.Assertions.assertThat as assertThatJ
+
+/**
+ * Regression test for https://github.com/detekt/detekt/issues/9295.
+ *
+ * `indent_style` used to only reach the `Indentation` rule, so setting it to `tab` made `Indentation`
+ * and `FunctionSignature` disagree on how to indent the parameters of a multi-line signature; with
+ * autocorrect on, they'd undo each other's changes. The config below mirrors how detekt resolves it:
+ * the value sits on the `ktlint` rule set, with the rules nested under it.
+ */
+class IndentationFunctionSignatureSpec {
+
+    @Test
+    fun `Indentation and FunctionSignature agree on tab-indented multiline signature`() {
+        val ktlintConfig = TestConfig(
+            "ktlint" to mapOf(
+                "indent_style" to "tab",
+                "autoCorrect" to true,
+                "Indentation" to mapOf("active" to true),
+                "FunctionSignature" to mapOf("active" to true),
+            ),
+        ).subConfig("ktlint")
+        val file = compileContentForTest(TAB_INDENTED_SNIPPET)
+
+        val findings = Indentation(ktlintConfig.subConfig("Indentation")).lint(file) +
+            FunctionSignature(ktlintConfig.subConfig("FunctionSignature")).lint(file)
+
+        assertThat(findings).isEmpty()
+        assertThatJ(file.modifiedText).isNull()
+    }
+
+    companion object {
+        private val TAB_INDENTED_SNIPPET = listOf(
+            "class A {",
+            "\tfun func(",
+            "\t\targ1: SomeLongType,",
+            "\t\targ2: SomeOtherLongType,",
+            "\t\targ3: AnotherLongTypeNameBecauseWeLoveJavaNamingSchemeFactory,",
+            "\t\targ4: RunningOutOfTypeNameIdeas,",
+            "\t) {",
+            "\t}",
+            "}",
+        ).joinToString(separator = "\n", postfix = "\n")
+    }
+}

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationFunctionSignatureSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationFunctionSignatureSpec.kt
@@ -13,10 +13,10 @@ import org.assertj.core.api.Assertions.assertThat as assertThatJ
 /**
  * Regression test for https://github.com/detekt/detekt/issues/9295.
  *
- * `indent_style` used to only reach the `Indentation` rule, so setting it to `tab` made `Indentation`
- * and `FunctionSignature` disagree on how to indent the parameters of a multi-line signature; with
- * autocorrect on, they'd undo each other's changes. The config below mirrors how detekt resolves it:
- * the value sits on the `ktlint` rule set, with the rules nested under it.
+ * Before the fix, indent style was a per-rule setting on `Indentation` only, so configuring `tab`
+ * left `Indentation` and `FunctionSignature` disagreeing on how to indent the parameters of a
+ * multi-line signature; with autocorrect on, they'd undo each other's changes. The config below sets
+ * it at the `ktlint` rule set level (the way detekt resolves it now), with the rules nested under it.
  */
 class IndentationFunctionSignatureSpec {
 
@@ -24,7 +24,7 @@ class IndentationFunctionSignatureSpec {
     fun `Indentation and FunctionSignature agree on tab-indented multiline signature`() {
         val ktlintConfig = TestConfig(
             "ktlint" to mapOf(
-                "indent_style" to "tab",
+                "indentStyle" to "tab",
                 "autoCorrect" to true,
                 "Indentation" to mapOf("active" to true),
                 "FunctionSignature" to mapOf("active" to true),

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
@@ -81,6 +81,12 @@ class IndentationSpec {
         assertThat(subject.lint(code)).isEmpty()
     }
 
+    @Test
+    fun `falls back to the default space indent style when the config has no parent`() {
+        val code = "fun main() {\n    println()\n}"
+        assertThat(Indentation(TestConfig(parent = null)).lint(code)).isEmpty()
+    }
+
     @Nested
     inner class `parameter list indent size equals 1` {
 

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
@@ -48,7 +48,7 @@ class IndentationSpec {
 
         @Test
         fun `does not report when using an indentation level config of 1 and style of tab`() {
-            val config = TestConfig("indentSize" to 1, "indent_style" to "tab")
+            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
             val code = """
                 fun main() {
                 ${TAB}println()
@@ -59,7 +59,7 @@ class IndentationSpec {
 
         @Test
         fun `reports usage of space when using an indentation level config of 1 and style of tab`() {
-            val config = TestConfig("indentSize" to 1, "indent_style" to "tab")
+            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
             val code = """
                 fun main() {
                   println()

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/IndentationSpec.kt
@@ -48,7 +48,7 @@ class IndentationSpec {
 
         @Test
         fun `does not report when using an indentation level config of 1 and style of tab`() {
-            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
+            val config = TestConfig("indentSize" to 1, "indent_style" to "tab")
             val code = """
                 fun main() {
                 ${TAB}println()
@@ -59,7 +59,7 @@ class IndentationSpec {
 
         @Test
         fun `reports usage of space when using an indentation level config of 1 and style of tab`() {
-            val config = TestConfig("indentSize" to 1, "indentStyle" to "tab")
+            val config = TestConfig("indentSize" to 1, "indent_style" to "tab")
             val code = """
                 fun main() {
                   println()


### PR DESCRIPTION
Fixes #9295.

The indent_style option added in #9180 applied only to the Indentation rule. None of the other indentation-aware ktlint wrappers (FunctionSignature, ParameterListWrapping,  on, the two rules just kept rewriting each other's output.

So indent_style now lives on the ktlint rule set itself, the same way code_style does, and a shared getter on KtlintRule makes every wrapped rule resolve the same value. The old per-rule Indentation.indentStyle property is gone.

Breaking change (since indent_style only came in 2.0.0-alpha.3 via #9180): configure tab indentation at the rule set level instead of on the Indentation rule:
```
ktlint:
   indent_style: tab
```

detekt doesn't validate plugin rule set configs, so an existing ktlint.Indentation.indentStyle setting won't cause an error on upgrade; it just gets ignored, so you'll want to switch it to ktlint.indent_style.

The regression test in IndentationFunctionSignatureSpec runs both Indentation and FunctionSignature over the snippet from the issue with ktlint.indent_style: tab set up the way detekt resolves config in practice (rule set value, rules as children), and checks that there are no findings and nothing gets rewritten.