### PR TITLE
docs: fix KMP type resolution task names

### DIFF
--- a/website/docs/gettingstarted/type-resolution.md
+++ b/website/docs/gettingstarted/type-resolution.md
@@ -83,13 +83,15 @@ Gradle plugins from configuring Android-specific gradle tasks.
 
 ## Enabling on a KMP project
 
-The Detekt Gradle Plugin in a Kotlin Multiplatform project automatically generates platform-specific and common tasks for running analysis with type resolution. In general there will be a `detektMetadata<Platform>Main` task for each native platform target configured in the multiplatform plugin, specific tasks for JVM and Android modules as listed below, and a `detektMetadataCommonMain` for the `common` module.
+In a Kotlin Multiplatform project, the Detekt Gradle Plugin generates the following tasks:
 
-- `detekt` - Runs detekt WITHOUT type resolution
-- `detektMetadataCommonMain` - Runs detekt with type resolution on the `common` module in the `main` source set
-- `detektJvmMain` - Runs detekt with type resolution on the `jvm` module in the `main` source set
-- `detektMetadataIosMain` - Runs detekt with type resolution on the `ios` module in the `main` source set
-- `detektAndroid<Variant>` - Runs detekt with type resolution on the `android` module for the specific variant e.g. `detektAndroidRelease`
+- `detekt` - Runs detekt WITHOUT type resolution.
+- `detekt<SourceSet>SourceSet` - Runs detekt on a given Kotlin source set WITHOUT type resolution. A task is generated for every Kotlin source set (e.g. `detektCommonMainSourceSet`, `detektJvmMainSourceSet`, `detektIosMainSourceSet`, `detektWasmJsMainSourceSet`).
+- `detekt<Compilation><Target>` - Runs detekt with type resolution on a given compilation of a JVM or Android target (e.g. `detektMainJvm`, `detektTestJvm`, `detektMainAndroid`).
+
+Type resolution tasks are currently only generated for JVM and Android targets. Native, JS and Wasm targets are analyzed through their source-set tasks listed above, without type resolution.
+
+Corresponding `detektBaseline<SourceSet>SourceSet` and `detektBaseline<Compilation><Target>` tasks are also generated to create baselines from each of the analysis tasks.
 
 ## Enabling on Detekt CLI
 


### PR DESCRIPTION
The "Enabling on a KMP project" section listed task names that don't match what the Gradle plugin actually emits.

| Listed in docs | Actual task |
|---|---|
| `detektMetadataCommonMain` (with type resolution) | `detektCommonMainSourceSet` (without type resolution) |
| `detektJvmMain` (with type resolution) | `detektMainJvm` (with type resolution) |
| `detektMetadataIosMain` (with type resolution) | `detektIosMainSourceSet` (without type resolution) |
| `detektAndroid<Variant>` (with type resolution) | `detektMainAndroid` / `detektTestAndroid` (with type resolution) |

Update the section to reflect the actual naming scheme:

- `detekt<SourceSet>SourceSet` for every Kotlin source set (without type resolution).
- `detekt<Compilation><Target>` for every compilation of a JVM or Android target (with type resolution).

Also note that Native, JS and Wasm targets only get the source-set tasks; the plugin currently generates type-resolution tasks only for JVM and `androidJvm` platform types.

Fixes #9284