### PR TITLE
Stop suppressing compiler warnings in DGP

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -126,6 +126,8 @@ kotlin {
         // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
         freeCompilerArgs.addAll("-language-version", "1.8")
         freeCompilerArgs.addAll("-api-version", "1.7")
+        // Suppress warning about deprecated API version. When DGP compiles with Kotlin 2.4 change this to suppress DEPRECATED_LANGUAGE_VERSION diagnostic (see KT-83765)
+        freeCompilerArgs.add("-Xsuppress-version-warnings")
     }
 
     // Some functional tests reference internal functions in the Gradle plugin. This should become unnecessary as further

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -122,10 +122,6 @@ kotlin {
     compilerVersion = "2.1.21"
 
     compilerOptions {
-        suppressWarnings = true
-        // Note: Currently there are warnings for detekt-gradle-plugin that seemingly can't be fixed
-        //       until Gradle releases an update (https://github.com/gradle/gradle/issues/16345)
-        allWarningsAsErrors = false
         // The apiVersion Gradle property cannot be used here, so set api version using free compiler args.
         // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
         freeCompilerArgs.addAll("-language-version", "1.8")

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -6,7 +6,6 @@ import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
 import java.io.File
-import java.util.Locale
 
 private const val DEBUG_PARAMETER = "--debug"
 private const val INPUT_PARAMETER = "--input"
@@ -132,7 +131,7 @@ internal data class FailOnSeverityArgument(val ignoreFailures: Boolean, val minS
     CliArgument {
     override fun toArgument(): List<String> {
         val effectiveSeverity = if (ignoreFailures) FailOnSeverity.Never else minSeverity
-        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.toLowerCase(Locale.ROOT))
+        return listOf(FAIL_ON_SEVERITY_PARAMETER, effectiveSeverity.name.lowercase())
     }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -80,7 +80,8 @@ class DetektBasePlugin : Plugin<Project> {
             project.extensions.findByType(KotlinSourceSetContainer::class.java)
                 ?.sourceSets
                 ?.configureEach { sourceSet ->
-                    val taskName = "${DetektPlugin.DETEKT_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
+                    val taskName =
+                        "${DetektPlugin.DETEKT_TASK_NAME}${sourceSet.name.replaceFirstChar { it.uppercase() }}SourceSet"
                     tasks.register(taskName, Detekt::class.java) { detektTask ->
                         detektTask.source = sourceSet.kotlin
                         detektTask.baseline.convention(
@@ -98,7 +99,9 @@ class DetektBasePlugin : Plugin<Project> {
                         detektTask.description = "Run detekt analysis for ${sourceSet.name} source set"
                     }
 
-                    val baseLineTaskName = "${DetektPlugin.BASELINE_TASK_NAME}${sourceSet.name.capitalize()}SourceSet"
+                    val baseLineTaskName = "${DetektPlugin.BASELINE_TASK_NAME}${sourceSet.name.replaceFirstChar {
+                        it.uppercase()
+                    }}SourceSet"
                     tasks.register(baseLineTaskName, DetektCreateBaselineTask::class.java) { createBaselineTask ->
                         createBaselineTask.source = sourceSet.kotlin
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektPlugin.kt
@@ -139,7 +139,7 @@ class DetektPlugin : Plugin<Project> {
             task.detektClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT))
             task.pluginClasspath.conventionCompat(project.configurations.named(CONFIGURATION_DETEKT_PLUGINS))
             val reportName = if (task.name.startsWith(DETEKT_TASK_NAME) && task.name != DETEKT_TASK_NAME) {
-                task.name.removePrefix(DETEKT_TASK_NAME).decapitalize()
+                task.name.removePrefix(DETEKT_TASK_NAME).replaceFirstChar { it.lowercase() }
             } else {
                 task.name
             }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -80,18 +80,24 @@ internal object DetektAndroidCompilations {
         project.extensions.findByType(AndroidComponentsExtension::class.java)?.let { componentsExtension ->
             componentsExtension.onVariants { variant ->
                 if (!extension.matchesIgnoredConfiguration(variant)) {
-                    mainTaskProvider.configure {
-                        it.dependsOn(DetektPlugin.DETEKT_TASK_NAME + variant.name.capitalize())
+                    mainTaskProvider.configure { task ->
+                        task.dependsOn(DetektPlugin.DETEKT_TASK_NAME + variant.name.replaceFirstChar { it.uppercase() })
                     }
-                    mainBaselineTaskProvider.configure {
-                        it.dependsOn(DetektPlugin.BASELINE_TASK_NAME + variant.name.capitalize())
+                    mainBaselineTaskProvider.configure { task ->
+                        task.dependsOn(
+                            DetektPlugin.BASELINE_TASK_NAME + variant.name.replaceFirstChar { it.uppercase() }
+                        )
                     }
                     variant.nestedComponents.forEach { testVariant ->
-                        testTaskProvider.configure {
-                            it.dependsOn(DetektPlugin.DETEKT_TASK_NAME + testVariant.name.capitalize())
+                        testTaskProvider.configure { task ->
+                            task.dependsOn(
+                                DetektPlugin.DETEKT_TASK_NAME + testVariant.name.replaceFirstChar { it.uppercase() }
+                            )
                         }
-                        testBaselineTaskProvider.configure {
-                            it.dependsOn(DetektPlugin.BASELINE_TASK_NAME + testVariant.name.capitalize())
+                        testBaselineTaskProvider.configure { task ->
+                            task.dependsOn(
+                                DetektPlugin.BASELINE_TASK_NAME + testVariant.name.replaceFirstChar { it.uppercase() }
+                            )
                         }
                     }
                 }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -21,8 +21,12 @@ internal fun Project.registerJvmCompilationDetektTask(
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
-    val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
-    tasks.register(DetektPlugin.DETEKT_TASK_NAME + taskSuffix.capitalize(), Detekt::class.java) { detektTask ->
+    val taskSuffix =
+        if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
+    tasks.register(
+        DetektPlugin.DETEKT_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
+        Detekt::class.java
+    ) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         detektTask.source(source)
@@ -75,9 +79,10 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
-    val taskSuffix = if (target != null) compilation.name + target.name.capitalize() else compilation.name
+    val taskSuffix =
+        if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
     tasks.register(
-        DetektPlugin.BASELINE_TASK_NAME + taskSuffix.capitalize(),
+        DetektPlugin.BASELINE_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
         DetektCreateBaselineTask::class.java,
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }


### PR DESCRIPTION
Loosening compiler warnings was done years ago and isn't necessary today.