### PR TITLE
Stop using out-of-process compilation mode for build-logic

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,10 +19,3 @@ kotlin {
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
 }
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    val isCiBuild = providers.environmentVariable("CI").isPresent
-    if (isCiBuild) {
-        compilerExecutionStrategy = org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.OUT_OF_PROCESS
-    }
-}


### PR DESCRIPTION
This is deprecated and will start failing when Gradle updates embedded Kotlin to 2.4 or higher.

https://youtrack.jetbrains.com/issue/KT-83125/Deprecate-out-of-process-compilation-mode https://youtrack.jetbrains.com/issue/KT-83126/Remove-out-of-process-compilation-mode

Effectively reverts #5162 