### PR TITLE
Fixes #9322 : fix UnnecessaryFullyQualifiedName false positive with explicit import shadowing

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -220,9 +220,11 @@ class UnnecessaryFullyQualifiedName(config: Config) :
         if (resolvedSymbol !is KaCallableSymbol && isShadowedByTypeParameter(element, simpleName)) return true
 
         // Annotation references resolve to constructors, so their classifier should be checked
-        val symbol = (resolvedSymbol as? KaConstructorSymbol)?.containingClassId
-            ?.let { with(session) { findClass(it) } }
-            ?: resolvedSymbol
+        val symbol = if (resolvedSymbol is KaConstructorSymbol) {
+            resolvedSymbol.containingClassId?.let { with(session) { findClass(it) } } ?: resolvedSymbol
+        } else {
+            resolvedSymbol
+        }
         return findLocalSymbols(element, symbol, simpleName).any { it != symbol }
     }
 

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -212,19 +212,28 @@ class UnnecessaryFullyQualifiedName(config: Config) :
     private fun hasNameCollision(element: KtElement, resolvedSymbol: KaSymbol): Boolean {
         val simpleName = when (resolvedSymbol) {
             is KaClassSymbol -> resolvedSymbol.classId?.shortClassName
+            is KaConstructorSymbol -> resolvedSymbol.containingClassId?.shortClassName
             is KaCallableSymbol -> resolvedSymbol.callableId?.callableName
             else -> null
         } ?: return false
 
         if (resolvedSymbol !is KaCallableSymbol && isShadowedByTypeParameter(element, simpleName)) return true
 
-        return findLocalSymbols(element, resolvedSymbol, simpleName).any { it != resolvedSymbol }
+        // Annotation references resolve to constructors, so their classifier should be checked
+        val symbol = (resolvedSymbol as? KaConstructorSymbol)?.containingClassId
+            ?.let { with(session) { findClass(it) } }
+            ?: resolvedSymbol
+        return findLocalSymbols(element, symbol, simpleName).any { it != symbol }
     }
 
     context(session: KaSession)
     private fun findLocalSymbols(element: KtElement, resolvedSymbol: KaSymbol, name: Name): Sequence<KaSymbol> {
+        // Default imports are overridden by an added explicit import, so a default symbol with the same
+        // name is not a real collision (only explicit imports are).
         val scope = with(session) {
-            element.containingKtFile.scopeContext(element).compositeScope { it !is KaScopeKind.ImportingScope }
+            element.containingKtFile.scopeContext(element).compositeScope {
+                it !is KaScopeKind.DefaultSimpleImportingScope && it !is KaScopeKind.DefaultStarImportingScope
+            }
         }
         return if (resolvedSymbol is KaCallableSymbol) scope.callables(name) else scope.classifiers(name)
     }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1001,6 +1001,50 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
+
+        @Test
+        fun `does not report annotation call when shadowed`() {
+            val code = """
+                package foo
+
+                import foo.bar1.Foo
+
+                @foo.bar2.Foo
+                object Bar : Foo
+            """.trimIndent()
+            val annotationCode = """
+                package foo.bar1
+                interface Foo
+            """.trimIndent()
+            val interfaceCode = """
+                package foo.bar2
+                annotation class Foo
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, annotationCode, interfaceCode)).isEmpty()
+        }
+
+        @Test
+        fun `does not report annotation call when shadowed 2`() {
+            val code = """
+                package foo
+
+                import foo.bar2.Foo
+
+                @Foo
+                object Bar : foo.bar1.Foo
+            """.trimIndent()
+            val annotationCode = """
+                package foo.bar1
+                interface Foo
+            """.trimIndent()
+            val interfaceCode = """
+                package foo.bar2
+                annotation class Foo
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, annotationCode, interfaceCode)).isEmpty()
+        }
     }
 
     // https://github.com/detekt/detekt/issues/9282


### PR DESCRIPTION
While fixing #9322, I've faced 2 issues.

On one side, explicit imports were ignored. The collision check skipped all imports, so an import `foo.bar1.Foo` shadowing `@foo.bar2.Foo` was never found. Fixed by skipping only default imports.

On another side, annotations resolve to constructors, not classes. Fixed by using the constructor's containing class.

I've added the unit tests stated in the issue too.
