### PR TITLE
Register compiler plugin services in Analysis API session

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -10,7 +10,9 @@ import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArguments
 import org.jetbrains.kotlin.cli.common.checkPluginsArguments
+import org.jetbrains.kotlin.cli.common.computeKotlinPaths
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
+import org.jetbrains.kotlin.cli.common.kotlinPaths
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.LOGGING
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
@@ -51,6 +53,7 @@ fun createCompilerConfiguration(
     jdkHome: Path?,
     freeCompilerArgs: List<String>,
     printStream: PrintStream,
+    disposable: Disposable,
 ): CompilerConfiguration {
     val javaFiles = pathsToAnalyze.flatMap { path ->
         path.toFile().walk()
@@ -95,6 +98,13 @@ fun createCompilerConfiguration(
             CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY,
             PrintingMessageCollector(printStream, MessageRenderer.PLAIN_FULL_PATHS, false)
         )
+
+        val paths = computeKotlinPaths(this, jvmCompilerArguments)?.also {
+            kotlinPaths = it
+        }
+
+        loadPlugins(paths, jvmCompilerArguments, this, disposable)
+
         setupLanguageVersionSettings(jvmCompilerArguments)
         setupJvmSpecificArguments(jvmCompilerArguments)
         configureAdvancedJvmOptions(jvmCompilerArguments)

--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -91,3 +91,113 @@ fun createCompilerConfiguration(
         configureJdkClasspathRoots()
     }
 }
+
+// https://github.com/JetBrains/kotlin/blob/v2.4.0/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt#L207-L300
+protected fun loadPlugins(
+    paths: KotlinPaths?,
+    arguments: A,
+    configuration: CompilerConfiguration,
+    parentDisposable: Disposable,
+): ExitCode {
+    val pluginClasspaths = arguments.pluginClasspaths.orEmpty().toMutableList()
+    val pluginOptions = arguments.pluginOptions.orEmpty().toMutableList()
+    val pluginConfigurations = arguments.pluginConfigurations?.asList().orEmpty()
+    val pluginOrderConstraints = arguments.pluginOrderConstraints?.asList().orEmpty()
+
+    val useK2 = configuration.get(CommonConfigurationKeys.USE_FIR) == true
+
+    if (!checkPluginsArguments(configuration, useK2, pluginClasspaths, pluginOptions, pluginConfigurations)) {
+        return INTERNAL_ERROR
+    }
+
+    val scriptingPluginClasspath = mutableListOf<String>()
+    val scriptingPluginOptions = mutableListOf<String>()
+
+    if (!arguments.disableDefaultScriptingPlugin) {
+        scriptingPluginOptions.addPlatformOptions(arguments)
+        val explicitScriptingPlugin =
+            extractPluginClasspathAndOptions(pluginConfigurations).any { (_, classpath, _) ->
+                classpath.any { File(it).name.startsWith(PathUtil.KOTLIN_SCRIPTING_COMPILER_PLUGIN_NAME) }
+            } || pluginClasspaths.any { File(it).name.startsWith(PathUtil.KOTLIN_SCRIPTING_COMPILER_PLUGIN_NAME) }
+        val explicitOrLoadedScriptingPlugin = explicitScriptingPlugin ||
+            tryLoadScriptingPluginFromCurrentClassLoader(configuration, pluginOptions, useK2)
+        if (!explicitOrLoadedScriptingPlugin) {
+            val kotlinPaths = paths ?: PathUtil.kotlinPathsForCompiler
+            val libPath = kotlinPaths.libPath.takeIf { it.exists() && it.isDirectory } ?: File(".")
+            val (jars, missingJars) =
+                PathUtil.KOTLIN_SCRIPTING_PLUGIN_CLASSPATH_JARS.map { File(libPath, it) }.partition { it.exists() }
+            if (missingJars.isEmpty()) {
+                scriptingPluginClasspath.addAll(0, jars.map { it.canonicalPath })
+            } else {
+                configuration.messageCollector.report(
+                    LOGGING,
+                    "Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: $missingJars)"
+                )
+            }
+        }
+    } else {
+        scriptingPluginOptions.add("plugin:kotlin.scripting:disable=true")
+    }
+
+    pluginClasspaths.addAll(scriptingPluginClasspath)
+    pluginOptions.addAll(scriptingPluginOptions)
+
+    return PluginCliParser.loadPluginsSafe(
+        pluginClasspaths,
+        pluginOptions,
+        pluginConfigurations,
+        pluginOrderConstraints,
+        configuration,
+        parentDisposable
+    )
+}
+
+private fun tryLoadScriptingPluginFromCurrentClassLoader(
+    configuration: CompilerConfiguration,
+    pluginOptions: List<String>,
+    useK2: Boolean
+): Boolean =
+    try {
+        val pluginRegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_REGISTRAR_NAME)
+        val pluginRegistrar = (pluginRegistrarClass.getDeclaredConstructor().newInstance() as? ComponentRegistrar)?.also {
+            configuration.add(ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, it)
+        }
+        val pluginK2Registrar = if (useK2) {
+            val pluginK2RegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_K2_REGISTRAR_NAME)
+            (pluginK2RegistrarClass.getDeclaredConstructor().newInstance() as? CompilerPluginRegistrar)?.also {
+                configuration.add(CompilerPluginRegistrar.COMPILER_PLUGIN_REGISTRARS, it)
+            }
+        } else null
+        if (pluginRegistrar != null || pluginK2Registrar != null) {
+            processScriptPluginCliOptions(pluginOptions, configuration)
+            true
+        } else false
+    } catch (e: Throwable) {
+        val messageCollector = configuration.getNotNull(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
+        messageCollector.report(LOGGING, "Exception on loading scripting plugin: $e")
+        false
+    }
+
+private fun processScriptPluginCliOptions(pluginOptions: List<String>, configuration: CompilerConfiguration) {
+    val cmdlineProcessorClass =
+        if (pluginOptions.isEmpty()) null
+        else PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_COMMANDLINE_PROCESSOR_NAME)!!
+    val cmdlineProcessor = cmdlineProcessorClass?.getDeclaredConstructor()?.newInstance() as? CommandLineProcessor
+    if (cmdlineProcessor != null) {
+        processCompilerPluginsOptions(configuration, pluginOptions, listOf(cmdlineProcessor))
+    }
+}
+
+// https://github.com/JetBrains/kotlin/blob/v2.4.0/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt#L182-L193
+override fun MutableList<String>.addPlatformOptions(arguments: K2JVMCompilerArguments) {
+    if (arguments.scriptTemplates?.isNotEmpty() == true) {
+        add("plugin:kotlin.scripting:script-templates=${arguments.scriptTemplates!!.joinToString(",")}")
+    }
+    if (arguments.scriptResolverEnvironment?.isNotEmpty() == true) {
+        add(
+            "plugin:kotlin.scripting:script-resolver-environment=${arguments.scriptResolverEnvironment!!.joinToString(
+                ","
+            )}"
+        )
+    }
+}

--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -1,9 +1,17 @@
 package dev.detekt.core.parser
 
+import com.intellij.openapi.Disposable
+import org.jetbrains.kotlin.cli.common.CLICompiler.Companion.SCRIPT_PLUGIN_COMMANDLINE_PROCESSOR_NAME
+import org.jetbrains.kotlin.cli.common.CLICompiler.Companion.SCRIPT_PLUGIN_K2_REGISTRAR_NAME
+import org.jetbrains.kotlin.cli.common.CLICompiler.Companion.SCRIPT_PLUGIN_REGISTRAR_NAME
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.common.ExitCode.INTERNAL_ERROR
 import org.jetbrains.kotlin.cli.common.arguments.K2JVMCompilerArguments
 import org.jetbrains.kotlin.cli.common.arguments.parseCommandLineArguments
 import org.jetbrains.kotlin.cli.common.arguments.validateArguments
+import org.jetbrains.kotlin.cli.common.checkPluginsArguments
 import org.jetbrains.kotlin.cli.common.config.addKotlinSourceRoots
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.LOGGING
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.common.setupLanguageVersionSettings
@@ -12,10 +20,19 @@ import org.jetbrains.kotlin.cli.jvm.config.addJavaSourceRoots
 import org.jetbrains.kotlin.cli.jvm.config.addJvmClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.config.configureJdkClasspathRoots
 import org.jetbrains.kotlin.cli.jvm.configureAdvancedJvmOptions
+import org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser
 import org.jetbrains.kotlin.cli.jvm.setupJvmSpecificArguments
+import org.jetbrains.kotlin.cli.plugins.extractPluginClasspathAndOptions
+import org.jetbrains.kotlin.cli.plugins.processCompilerPluginsOptions
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.CompilerPluginRegistrar
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.jetbrains.kotlin.config.CommonConfigurationKeys
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.config.messageCollector
+import org.jetbrains.kotlin.utils.KotlinPaths
+import org.jetbrains.kotlin.utils.PathUtil
 import java.io.File
 import java.io.PrintStream
 import java.nio.file.Path
@@ -93,9 +110,9 @@ fun createCompilerConfiguration(
 }
 
 // https://github.com/JetBrains/kotlin/blob/v2.4.0/compiler/cli/src/org/jetbrains/kotlin/cli/common/CLICompiler.kt#L207-L300
-protected fun loadPlugins(
+private fun loadPlugins(
     paths: KotlinPaths?,
-    arguments: A,
+    arguments: K2JVMCompilerArguments,
     configuration: CompilerConfiguration,
     parentDisposable: Disposable,
 ): ExitCode {
@@ -152,6 +169,7 @@ protected fun loadPlugins(
     )
 }
 
+@OptIn(ExperimentalCompilerApi::class)
 private fun tryLoadScriptingPluginFromCurrentClassLoader(
     configuration: CompilerConfiguration,
     pluginOptions: List<String>,
@@ -159,8 +177,9 @@ private fun tryLoadScriptingPluginFromCurrentClassLoader(
 ): Boolean =
     try {
         val pluginRegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_REGISTRAR_NAME)
-        val pluginRegistrar = (pluginRegistrarClass.getDeclaredConstructor().newInstance() as? ComponentRegistrar)?.also {
-            configuration.add(ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, it)
+        @Suppress("DEPRECATION_ERROR")
+        val pluginRegistrar = (pluginRegistrarClass.getDeclaredConstructor().newInstance() as? org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar)?.also {
+            configuration.add(org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, it)
         }
         val pluginK2Registrar = if (useK2) {
             val pluginK2RegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_K2_REGISTRAR_NAME)
@@ -178,6 +197,7 @@ private fun tryLoadScriptingPluginFromCurrentClassLoader(
         false
     }
 
+@OptIn(ExperimentalCompilerApi::class)
 private fun processScriptPluginCliOptions(pluginOptions: List<String>, configuration: CompilerConfiguration) {
     val cmdlineProcessorClass =
         if (pluginOptions.isEmpty()) null
@@ -189,7 +209,7 @@ private fun processScriptPluginCliOptions(pluginOptions: List<String>, configura
 }
 
 // https://github.com/JetBrains/kotlin/blob/v2.4.0/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt#L182-L193
-override fun MutableList<String>.addPlatformOptions(arguments: K2JVMCompilerArguments) {
+private fun MutableList<String>.addPlatformOptions(arguments: K2JVMCompilerArguments) {
     if (arguments.scriptTemplates?.isNotEmpty() == true) {
         add("plugin:kotlin.scripting:script-templates=${arguments.scriptTemplates!!.joinToString(",")}")
     }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/parser/KotlinEnvironmentUtils.kt
@@ -116,12 +116,12 @@ private fun loadPlugins(
     configuration: CompilerConfiguration,
     parentDisposable: Disposable,
 ): ExitCode {
-    val pluginClasspaths = arguments.pluginClasspaths.orEmpty().toMutableList()
-    val pluginOptions = arguments.pluginOptions.orEmpty().toMutableList()
-    val pluginConfigurations = arguments.pluginConfigurations?.asList().orEmpty()
-    val pluginOrderConstraints = arguments.pluginOrderConstraints?.asList().orEmpty()
+    val pluginClasspaths = arguments.pluginClasspaths.toMutableList()
+    val pluginOptions = arguments.pluginOptions.toMutableList()
+    val pluginConfigurations = arguments.pluginConfigurations.asList()
+    val pluginOrderConstraints = arguments.pluginOrderConstraints.asList()
 
-    val useK2 = configuration.get(CommonConfigurationKeys.USE_FIR) == true
+    val useK2 = configuration[CommonConfigurationKeys.USE_FIR] == true
 
     if (!checkPluginsArguments(configuration, useK2, pluginClasspaths, pluginOptions, pluginConfigurations)) {
         return INTERNAL_ERROR
@@ -148,7 +148,8 @@ private fun loadPlugins(
             } else {
                 configuration.messageCollector.report(
                     LOGGING,
-                    "Scripting plugin will not be loaded: not all required jars are present in the classpath (missing files: $missingJars)"
+                    "Scripting plugin will not be loaded: not all required jars are present in the classpath (missing" +
+                        " files: $missingJars)"
                 )
             }
         }
@@ -173,25 +174,38 @@ private fun loadPlugins(
 private fun tryLoadScriptingPluginFromCurrentClassLoader(
     configuration: CompilerConfiguration,
     pluginOptions: List<String>,
-    useK2: Boolean
+    useK2: Boolean,
 ): Boolean =
     try {
         val pluginRegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_REGISTRAR_NAME)
+
         @Suppress("DEPRECATION_ERROR")
-        val pluginRegistrar = (pluginRegistrarClass.getDeclaredConstructor().newInstance() as? org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar)?.also {
-            configuration.add(org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS, it)
+        val pluginRegistrar = (
+            pluginRegistrarClass.getDeclaredConstructor().newInstance()
+                as? org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+            )?.also {
+            configuration.add(
+                org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar.PLUGIN_COMPONENT_REGISTRARS,
+                it
+            )
         }
         val pluginK2Registrar = if (useK2) {
-            val pluginK2RegistrarClass = PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_K2_REGISTRAR_NAME)
+            val pluginK2RegistrarClass = PluginCliParser::class.java.classLoader.loadClass(
+                SCRIPT_PLUGIN_K2_REGISTRAR_NAME
+            )
             (pluginK2RegistrarClass.getDeclaredConstructor().newInstance() as? CompilerPluginRegistrar)?.also {
                 configuration.add(CompilerPluginRegistrar.COMPILER_PLUGIN_REGISTRARS, it)
             }
-        } else null
+        } else {
+            null
+        }
         if (pluginRegistrar != null || pluginK2Registrar != null) {
             processScriptPluginCliOptions(pluginOptions, configuration)
             true
-        } else false
-    } catch (e: Throwable) {
+        } else {
+            false
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
         val messageCollector = configuration.getNotNull(CommonConfigurationKeys.MESSAGE_COLLECTOR_KEY)
         messageCollector.report(LOGGING, "Exception on loading scripting plugin: $e")
         false
@@ -200,8 +214,11 @@ private fun tryLoadScriptingPluginFromCurrentClassLoader(
 @OptIn(ExperimentalCompilerApi::class)
 private fun processScriptPluginCliOptions(pluginOptions: List<String>, configuration: CompilerConfiguration) {
     val cmdlineProcessorClass =
-        if (pluginOptions.isEmpty()) null
-        else PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_COMMANDLINE_PROCESSOR_NAME)!!
+        if (pluginOptions.isEmpty()) {
+            null
+        } else {
+            PluginCliParser::class.java.classLoader.loadClass(SCRIPT_PLUGIN_COMMANDLINE_PROCESSOR_NAME)!!
+        }
     val cmdlineProcessor = cmdlineProcessorClass?.getDeclaredConstructor()?.newInstance() as? CommandLineProcessor
     if (cmdlineProcessor != null) {
         processCompilerPluginsOptions(configuration, pluginOptions, listOf(cmdlineProcessor))
@@ -210,14 +227,14 @@ private fun processScriptPluginCliOptions(pluginOptions: List<String>, configura
 
 // https://github.com/JetBrains/kotlin/blob/v2.4.0/compiler/cli/cli-jvm/src/org/jetbrains/kotlin/cli/jvm/K2JVMCompiler.kt#L182-L193
 private fun MutableList<String>.addPlatformOptions(arguments: K2JVMCompilerArguments) {
-    if (arguments.scriptTemplates?.isNotEmpty() == true) {
-        add("plugin:kotlin.scripting:script-templates=${arguments.scriptTemplates!!.joinToString(",")}")
+    if (arguments.scriptTemplates.isNotEmpty()) {
+        add("plugin:kotlin.scripting:script-templates=${arguments.scriptTemplates.joinToString(",")}")
     }
-    if (arguments.scriptResolverEnvironment?.isNotEmpty() == true) {
+    if (arguments.scriptResolverEnvironment.isNotEmpty()) {
         add(
-            "plugin:kotlin.scripting:script-resolver-environment=${arguments.scriptResolverEnvironment!!.joinToString(
-                ","
-            )}"
+            "plugin:kotlin.scripting:script-resolver-environment=${
+                arguments.scriptResolverEnvironment.joinToString(",")
+            }"
         )
     }
 }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -45,6 +45,8 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
     // This lateinit var can be changed to val if https://github.com/JetBrains/kotlin/pull/5703 is merged
     private lateinit var sourceModule: KaSourceModule
 
+    private val disposable: Disposable = Disposer.newDisposable()
+
     private val configuration: CompilerConfiguration = createCompilerConfiguration(
         projectSpec.inputPaths.toList(),
         compilerSpec.classpath,
@@ -54,9 +56,8 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
         compilerSpec.jdkHome,
         compilerSpec.freeCompilerArgs,
         printStream,
+        disposable,
     )
-
-    private val disposable: Disposable = Disposer.newDisposable()
 
     override val languageVersionSettings: LanguageVersionSettings
         get() = configuration.languageVersionSettings
@@ -70,6 +71,8 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
             // Required for autocorrect support
             registerProjectService(TreeAspect::class.java)
             registerProjectService(PomModel::class.java, DetektPomModel(project))
+
+            registerCompilerPluginServices(configuration)
 
             configuration.putIfAbsent(CommonConfigurationKeys.MODULE_NAME, "<no module name provided>")
 

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -18,12 +18,14 @@ public abstract class dev/detekt/gradle/Detekt : org/gradle/api/tasks/SourceTask
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
+	public abstract fun getKotlinPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getPluginOptions ()Lorg/gradle/api/provider/ListProperty;
 	public fun getReports ()Ldev/detekt/gradle/extensions/DetektReports;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 	public final fun reports (Lorg/gradle/api/Action;)V
@@ -48,12 +50,14 @@ public abstract class dev/detekt/gradle/DetektCreateBaselineTask : org/gradle/ap
 	public abstract fun getIgnoreFailures ()Lorg/gradle/api/provider/Property;
 	public abstract fun getJdkHome ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getJvmTarget ()Lorg/gradle/api/provider/Property;
+	public abstract fun getKotlinPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getLanguageVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getMultiPlatformEnabled ()Lorg/gradle/api/provider/Property;
 	public abstract fun getNoJdk ()Lorg/gradle/api/provider/Property;
 	public abstract fun getOptIn ()Lorg/gradle/api/provider/ListProperty;
 	public abstract fun getParallel ()Lorg/gradle/api/provider/Property;
 	public abstract fun getPluginClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
+	public abstract fun getPluginOptions ()Lorg/gradle/api/provider/ListProperty;
 	public fun getSource ()Lorg/gradle/api/file/FileTree;
 }
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -153,6 +153,7 @@ dependencies {
     implementation(libs.sarif4k)
 
     testKitRuntimeOnly(libs.kotlin.gradle.plugin)
+    testKitRuntimeOnly(libs.kotlinx.serialization.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.builtInKotlin.plugin)
     testKitGradleMinVersionRuntimeOnly(libs.kotlin.gradle.plugin) {

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
@@ -17,4 +17,15 @@ class CompilerPluginsTests {
         assertThat(result.output)
             .doesNotContainPattern("There were [0-9]+ compiler errors found during analysis".toRegex().toPattern())
     }
+    @Test
+    fun `detekt works with BuildConfig`() {
+        val result = GradleRunner.create()
+            .withResourceDir("android-buildconfig")
+            .withPluginClasspath()
+            .withArguments("detektMain")
+            .build()
+
+        assertThat(result.output)
+            .doesNotContainPattern("There were [0-9]+ compiler errors found during analysis".toRegex().toPattern())
+    }
 }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
@@ -1,0 +1,20 @@
+package dev.detekt.gradle
+
+import dev.detekt.gradle.testkit.withResourceDir
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.jupiter.api.Test
+
+class CompilerPluginsTests {
+    @Test
+    fun `detekt works with @Parzelize`() {
+        val result = GradleRunner.create()
+            .withResourceDir("android-parcelize")
+            .withPluginClasspath()
+            .withArguments("detektMain")
+            .build()
+
+        assertThat(result.output)
+            .doesNotContainPattern("There were [0-9]+ compiler errors found during analysis".toRegex().toPattern())
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CompilerPluginsTests.kt
@@ -11,18 +11,31 @@ class CompilerPluginsTests {
         val result = GradleRunner.create()
             .withResourceDir("android-parcelize")
             .withPluginClasspath()
-            .withArguments("detektMain")
+            .withArguments("detektRelease")
             .build()
 
         assertThat(result.output)
             .doesNotContainPattern("There were [0-9]+ compiler errors found during analysis".toRegex().toPattern())
     }
+
     @Test
     fun `detekt works with BuildConfig`() {
         val result = GradleRunner.create()
             .withResourceDir("android-buildconfig")
             .withPluginClasspath()
-            .withArguments("detektMain")
+            .withArguments("detektRelease")
+            .build()
+
+        assertThat(result.output)
+            .doesNotContainPattern("There were [0-9]+ compiler errors found during analysis".toRegex().toPattern())
+    }
+
+    @Test
+    fun `detekt works with ViewBinding`() {
+        val result = GradleRunner.create()
+            .withResourceDir("android-viewbinding")
+            .withPluginClasspath()
+            .withArguments("detektRelease")
             .build()
 
         assertThat(result.output)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/JvmSpec.kt
@@ -14,12 +14,14 @@ class JvmSpec {
             .withArguments("detektMain")
             .buildAndFail()
 
-        assertThat(result.output).contains("failed with 4 issues.")
+        assertThat(result.output).doesNotContain("unresolved reference")
+        assertThat(result.output).contains("failed with 5 issues.")
         assertThat(result.output.normalizePaths()).contains(
             "src/main/kotlin/Errors.kt:7:9 Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
             "src/main/kotlin/Errors.kt:12:16 Do not directly exit the process outside the `main` function. Throw an exception instead. [ExitOutsideMain]",
-            "src/main/kotlin/Caller.kt:5:18 The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in the detekt config. [ForbiddenMethodCall]",
-            "src/main/kotlin/Caller.kt:6:9 Callee()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
+            "src/main/kotlin/Caller.kt:7:18 The method `jvm.src.main.kotlin.Callee.forbiddenMethod` has been forbidden in the detekt config. [ForbiddenMethodCall]",
+            "src/main/kotlin/Caller.kt:8:9 Callee()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
+            "src/main/kotlin/Caller.kt:9:9 Book.serializer()?.toString() contains an unnecessary safe call operator [UnnecessarySafeCall]",
         )
     }
 

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/build.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("com.android.library")
+    id("dev.detekt")
+}
+
+android {
+    namespace = "com.example.myapplication"
+    compileSdk {
+        version = release(36) {
+            minorApiLevel = 1
+        }
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/settings.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/src/main/kotlin/Foo.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-buildconfig/src/main/kotlin/Foo.kt
@@ -1,0 +1,5 @@
+@file:Suppress("InvalidPackageDeclaration")
+
+package com.example.myapplication
+
+fun foo(): Boolean = BuildConfig.DEBUG

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/build.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.plugin.parcelize")
+    id("dev.detekt")
+}
+
+android {
+    namespace = "com.example.myapplication"
+    compileSdk {
+        version = release(36) {
+            minorApiLevel = 1
+        }
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/settings.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/src/main/kotlin/Foo.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-parcelize/src/main/kotlin/Foo.kt
@@ -1,0 +1,9 @@
+@file:Suppress("InvalidPackageDeclaration")
+
+package com.example.myapplication
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class Foo(val i: Int) : Parcelable

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/build.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("com.android.library")
+    id("dev.detekt")
+}
+
+android {
+    namespace = "com.example.myapplication"
+    compileSdk {
+        version = release(36) {
+            minorApiLevel = 1
+        }
+    }
+
+    defaultConfig {
+        minSdk = 24
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/settings.gradle.kts
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+        google()
+        mavenCentral()
+    }
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/src/main/kotlin/Foo.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/src/main/kotlin/Foo.kt
@@ -1,0 +1,9 @@
+@file:Suppress("InvalidPackageDeclaration")
+
+package com.example.myapplication
+
+import com.example.myapplication.databinding.FooBinding
+
+fun foo(binding: FooBinding) {
+    binding.theid.text = "Hello"
+}

--- a/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/src/main/res/layout/foo.xml
+++ b/detekt-gradle-plugin/src/functionalTest/resources/android-viewbinding/src/main/res/layout/foo.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+          android:layout_width="match_parent"
+          android:layout_height="match_parent"
+          android:id="@+id/theid"
+/>

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/build.gradle
@@ -1,11 +1,16 @@
 plugins {
     id("org.jetbrains.kotlin.jvm")
+    id("org.jetbrains.kotlin.plugin.serialization")
     id("dev.detekt")
 }
 
 repositories {
     mavenLocal()
     mavenCentral()
+}
+
+detekt {
+    debug = true
 }
 
 tasks.detektMain {
@@ -21,4 +26,8 @@ kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.10.0")
 }

--- a/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
+++ b/detekt-gradle-plugin/src/functionalTest/resources/jvm/src/main/kotlin/Caller.kt
@@ -1,8 +1,14 @@
 package jvm.src.main.kotlin
 
+import kotlinx.serialization.Serializable
+
 class Caller {
     fun method() {
         Callee().forbiddenMethod()
-        Callee()?.toString() // Callee class is excluded but AA still knows that Callee() returns non-nulltable
+        Callee()?.toString() // Callee class is excluded but AA still knows that Callee() returns non-nullable
+        Book.serializer()?.toString() // serializer() is created by compiler plugin but AA still knows that serializer() returns non-nullable
     }
 }
+
+@Serializable
+data class Book(val name: String, val author: String)

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -26,11 +26,13 @@ import dev.detekt.gradle.invoke.FriendPathArgs
 import dev.detekt.gradle.invoke.InputArgument
 import dev.detekt.gradle.invoke.JdkHomeArgument
 import dev.detekt.gradle.invoke.JvmTargetArgument
+import dev.detekt.gradle.invoke.KotlinPluginClasspathArgument
 import dev.detekt.gradle.invoke.LanguageVersionArgument
 import dev.detekt.gradle.invoke.MultiPlatformEnabledArgument
 import dev.detekt.gradle.invoke.NoJdkArgument
 import dev.detekt.gradle.invoke.OptInArguments
 import dev.detekt.gradle.invoke.ParallelArgument
+import dev.detekt.gradle.invoke.PluginOptionsArgument
 import dev.detekt.gradle.plugin.isWorkerApiEnabled
 import org.gradle.api.Action
 import org.gradle.api.Incubating
@@ -59,6 +61,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
+import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 import javax.inject.Inject
 
 @CacheableTask
@@ -129,6 +132,12 @@ abstract class Detekt @Inject constructor(
 
     @get:Input
     abstract val multiPlatformEnabled: Property<Boolean>
+
+    @get:Classpath
+    abstract val kotlinPluginClasspath: ConfigurableFileCollection
+
+    @get:Nested
+    abstract val pluginOptions: ListProperty<CompilerPluginConfig>
 
     @get:Input
     abstract val ignoreFailures: Property<Boolean>
@@ -201,6 +210,8 @@ abstract class Detekt @Inject constructor(
             NoJdkArgument(noJdk.get()),
             ExplicitApiArgument(explicitApi.orNull),
             MultiPlatformEnabledArgument(multiPlatformEnabled.get()),
+            KotlinPluginClasspathArgument(kotlinPluginClasspath),
+            PluginOptionsArgument(pluginOptions.get())
         ).plus(convertCustomReportsToArguments()).flatMap(CliArgument::toArgument)
             .plus("-no-stdlib")
             .plus("-no-reflect")

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
@@ -41,6 +41,7 @@ import org.gradle.api.tasks.IgnoreEmptyDirectories
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
@@ -50,6 +51,7 @@ import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
+import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 import javax.inject.Inject
 
 @CacheableTask
@@ -114,6 +116,12 @@ abstract class DetektCreateBaselineTask @Inject constructor(
 
     @get:Input
     abstract val multiPlatformEnabled: Property<Boolean>
+
+    @get:Classpath
+    abstract val kotlinPluginClasspath: ConfigurableFileCollection
+
+    @get:Nested
+    abstract val pluginOptions: ListProperty<CompilerPluginConfig>
 
     @get:Input
     @get:Optional

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -5,6 +5,7 @@ import dev.detekt.gradle.extensions.FailOnSeverity
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
+import org.jetbrains.kotlin.gradle.plugin.CompilerPluginConfig
 import java.io.File
 
 private const val DEBUG_PARAMETER = "--debug"
@@ -65,6 +66,24 @@ internal data class ClasspathArgument(val fileCollection: FileCollection) : CliA
             )
         } else {
             listOf(ANALYSIS_MODE, "light")
+        }
+}
+
+internal data class KotlinPluginClasspathArgument(val fileCollection: FileCollection) : CliArgument {
+    override fun toArgument() =
+        fileCollection.flatMap {
+            listOf("-Xplugin", it.absolutePath)
+        }
+}
+
+internal data class PluginOptionsArgument(val list: List<CompilerPluginConfig>) : CliArgument {
+    override fun toArgument() =
+        list.flatMap { config ->
+            config.allOptions().flatMap { (pluginId, pluginOptions) ->
+                pluginOptions.flatMap { option ->
+                    listOf("-P", "plugin:${pluginId}:${option.key}=${option.value}")
+                }
+            }
         }
 }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -57,6 +57,9 @@ internal fun Project.registerJvmCompilationDetektTask(
             detektTask.explicitApi.convention(mapExplicitArgMode())
         }
 
+        detektTask.kotlinPluginClasspath.conventionCompat(siblingTask.map { it.pluginClasspath })
+        detektTask.pluginOptions.convention(siblingTask.flatMap { it.pluginOptions })
+
         detektTask.baseline.convention(
             project.layout.file(
                 extension.baseline.flatMap {
@@ -114,6 +117,9 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         if (compilation.name == "main") {
             createBaselineTask.explicitApi.convention(mapExplicitArgMode())
         }
+
+        createBaselineTask.kotlinPluginClasspath.conventionCompat(siblingTask.map { it.pluginClasspath })
+        createBaselineTask.pluginOptions.convention(siblingTask.flatMap { it.pluginOptions })
 
         createBaselineTask.baseline.convention(
             project.layout.file(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.grad
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+kotlinx-serialization-gradle-plugin = { module = "org.jetbrains.kotlin.plugin.serialization:org.jetbrains.kotlin.plugin.serialization.gradle.plugin", version.ref = "kotlin" }
 
 # This represents the oldest AGP 9 version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.


### PR DESCRIPTION
Fixes https://github.com/detekt/detekt/issues/7531. Check the final commit for the changes.

The implementation is fairly simple, except that I've had to copy a fair bit of code into `KotlinEnvironmentUtils.kt` as `loadPlugins` in `CliCompiler` is protected and can't be called directly. There's probably a better way to do this but it works for now.

I used this test (which I've cherry-picked in this PR) https://github.com/detekt/detekt/issues/7531#issuecomment-3955835011 and also the sample project (updated to newer Gradle & Kotlin versions) here to verify: https://github.com/detekt/detekt/issues/7531#issuecomment-2282663259

I haven't tested with any other compiler plugins, though I have confirmed that the compiler options are correctly parsed and passed to detekt's `CompilerConfiguration` so hopefully no additional work is required for other plugins.