### PR TITLE
Expose Glob-to-Regex functions in `psi-utils`

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -310,10 +310,6 @@ public final class dev/detekt/api/SourceLocation : java/lang/Comparable {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class dev/detekt/api/SplitPatternKt {
-	public static final fun simplePatternToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
-}
-
 public final class dev/detekt/api/TextLocation {
 	public fun <init> (II)V
 	public fun equals (Ljava/lang/Object;)Z

--- a/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/suppressors/AnnotationSuppressor.kt
@@ -2,6 +2,7 @@ package dev.detekt.core.suppressors
 
 import dev.detekt.api.Rule
 import dev.detekt.psi.AnnotationExcluder
+import dev.detekt.psi.fullyQualifiedNameGlobToRegex
 import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.psi.KtAnnotated
 import org.jetbrains.kotlin.psi.KtElement
@@ -16,7 +17,7 @@ import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
  */
 internal fun annotationSuppressorFactory(rule: Rule, analysisMode: AnalysisMode): Suppressor? {
     val annotations = rule.config.valueOrDefault("ignoreAnnotated", emptyList<String>()).map {
-        it.qualifiedNameGlobToRegex()
+        it.fullyQualifiedNameGlobToRegex()
     }
     return if (annotations.isNotEmpty()) {
         Suppressor { finding ->
@@ -36,12 +37,3 @@ private fun KtElement.isAnnotatedWith(excluder: AnnotationExcluder): Boolean =
     } else {
         getStrictParentOfType<KtAnnotated>()?.isAnnotatedWith(excluder) ?: false
     }
-
-private fun String.qualifiedNameGlobToRegex(): Regex =
-    this
-        .replace(".", """\.""")
-        .replace("**", "//")
-        .replace("*", "[^.]*")
-        .replace("//", ".*")
-        .replace("?", ".")
-        .toRegex()

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -19,6 +19,10 @@ public final class dev/detekt/psi/FunctionMatcher$Companion {
 	public final fun getNameForGetterOrSetter (Lorg/jetbrains/kotlin/analysis/api/symbols/KaPropertySymbol;Lorg/jetbrains/kotlin/analysis/api/symbols/KaCallableSymbol;)Ljava/lang/String;
 }
 
+public final class dev/detekt/psi/GlobToRegexKt {
+	public static final fun pathGlobToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
+}
+
 public final class dev/detekt/psi/IsPartOfUtilsKt {
 	public static final fun isPartOfString (Lcom/intellij/psi/PsiElement;)Z
 }
@@ -87,10 +91,6 @@ public final class dev/detekt/psi/MethodSignatureKt {
 	public static final fun isHashCodeFunction (Lorg/jetbrains/kotlin/psi/KtFunction;)Z
 	public static final fun isJvmFinalizeFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
 	public static final fun isMainFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
-}
-
-public final class dev/detekt/psi/SplitPatternKt {
-	public static final fun simplePatternToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
 }
 
 public final class dev/detekt/psi/StringExtensionsKt {

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -89,6 +89,10 @@ public final class dev/detekt/psi/MethodSignatureKt {
 	public static final fun isMainFunction (Lorg/jetbrains/kotlin/psi/KtNamedFunction;)Z
 }
 
+public final class dev/detekt/psi/SplitPatternKt {
+	public static final fun simplePatternToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
+}
+
 public final class dev/detekt/psi/StringExtensionsKt {
 	public static final fun lastArgumentMatchesKotlinReferenceUrlSyntax (Ljava/lang/String;)Z
 	public static final fun lastArgumentMatchesMarkdownUrlSyntax (Ljava/lang/String;)Z

--- a/detekt-psi-utils/api/detekt-psi-utils.api
+++ b/detekt-psi-utils/api/detekt-psi-utils.api
@@ -20,6 +20,7 @@ public final class dev/detekt/psi/FunctionMatcher$Companion {
 }
 
 public final class dev/detekt/psi/GlobToRegexKt {
+	public static final fun fullyQualifiedNameGlobToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
 	public static final fun pathGlobToRegex (Ljava/lang/String;)Lkotlin/text/Regex;
 }
 

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/GlobToRegex.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/GlobToRegex.kt
@@ -9,7 +9,7 @@ package dev.detekt.psi
  * '*' matches any zero or more characters
  * '?' matches any one character
  */
-fun String.simplePatternToRegex(): Regex =
+fun String.pathGlobToRegex(): Regex =
     this
         .replace(".", "\\.")
         .replace("*", ".*")

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/GlobToRegex.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/GlobToRegex.kt
@@ -1,7 +1,7 @@
 package dev.detekt.psi
 
 /**
- * Convert a simple pattern String to a Regex
+ * Convert a simple path pattern String to a Regex
  *
  * The simple pattern is a subset of the shell pattern matching or
  * [glob][https://en.wikipedia.org/wiki/Glob_(programming)]
@@ -14,4 +14,13 @@ fun String.pathGlobToRegex(): Regex =
         .replace(".", "\\.")
         .replace("*", ".*")
         .replace("?", ".")
+        .toRegex()
+
+fun String.fullyQualifiedNameGlobToRegex(): Regex =
+    this
+        .replace(".", """\.""")
+        .replace("**", "//")
+        .replace("*", "[^.]*")
+        .replace("?", "[^.]")
+        .replace("//", """.*(?=\.)""")
         .toRegex()

--- a/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/SplitPattern.kt
+++ b/detekt-psi-utils/src/main/kotlin/dev/detekt/psi/SplitPattern.kt
@@ -1,4 +1,4 @@
-package dev.detekt.api
+package dev.detekt.psi
 
 /**
  * Convert a simple pattern String to a Regex

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/FullyQualifiedNameGlobToRegexSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/FullyQualifiedNameGlobToRegexSpec.kt
@@ -1,0 +1,46 @@
+package dev.detekt.psi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class FullyQualifiedNameGlobToRegexSpec {
+    @ParameterizedTest
+    @CsvSource(
+        "Foo,          **.*,            false",
+        "Foo,          *,               true ",
+        "Foo,          **,              false",
+        "Foo,          ???,             true ",
+        "Foo,          ??,              false",
+        "Foo,          ????,            false",
+        "Foo,          *?,              true ",
+        "Foo,          **.Foo,          false",
+        "Foo,          test.Foo,        false",
+        "Foo,          F.o,             false",
+        "Foo,          F?o,             true ",
+        "test.Foo,     **.*,            true ",
+        "test.Foo,     *,               false",
+        "test.Foo,     **,              false",
+        "test.Foo,     ???,             false",
+        "test.Foo,     ??,              false",
+        "test.Foo,     ????,            false",
+        "test.Foo,     test?Foo,        false",
+        "test.Foo,     *?,              false",
+        "test.Foo,     **.Foo,          true ",
+        "test.Foo,     test.Foo,        true ",
+        "test.Foo,     F.o,             false",
+        "test.Foo,     F?o,             false",
+        "test.Foo,     **.F*,           true ",
+        "test.bar.Foo, **.F*,           true ",
+        "test.bar.Foo, **.bar.F*,       true ",
+        "test.bar.Foo, test.**.F*,      true ",
+        "a.b.c.d.Foo,  a.**.d.Foo,      true ",
+        "a.b.c.d.Foo,  a.b.**.d.Foo,    true ",
+        "a.b.c.d.Foo,  a.**.b.c.d.Foo,  false",
+        "a.b.c.d.Foo,  a.**.**.c.d.Foo, false",
+        "a.b.c.d.Foo,  a.**.**.c.d.Foo, false",
+    )
+    fun tests(fullyQualifiedName: String, glob: String, matches: Boolean) {
+        assertThat(glob.fullyQualifiedNameGlobToRegex().matches(fullyQualifiedName)).isEqualTo(matches)
+    }
+}

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/PathGlobToRegexSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/PathGlobToRegexSpec.kt
@@ -5,10 +5,10 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-internal class SimplePatternToRegexSpec {
+internal class PathGlobToRegexSpec {
     @Nested
     inner class `empty pattern` {
-        private val subject = "".simplePatternToRegex()
+        private val subject = "".pathGlobToRegex()
 
         @Test
         fun `matches an empty string`() {
@@ -25,7 +25,7 @@ internal class SimplePatternToRegexSpec {
 
     @Nested
     inner class `blank pattern` {
-        private val subject = " \t".simplePatternToRegex()
+        private val subject = " \t".pathGlobToRegex()
 
         @Test
         fun `matches an empty string`() {
@@ -42,7 +42,7 @@ internal class SimplePatternToRegexSpec {
 
     @Nested
     inner class `Static pattern` {
-        private val subject = "abc".simplePatternToRegex()
+        private val subject = "abc".pathGlobToRegex()
 
         @Test
         fun `matches the same string`() {
@@ -63,7 +63,7 @@ internal class SimplePatternToRegexSpec {
         inner class `single wildcard` {
             @Nested
             inner class `pattern with wildcard at the beginning` {
-                private val subject = "*xyz".simplePatternToRegex()
+                private val subject = "*xyz".pathGlobToRegex()
 
                 @Test
                 fun `matches pattern exactly`() {
@@ -86,7 +86,7 @@ internal class SimplePatternToRegexSpec {
 
             @Nested
             inner class `Pattern with wildcard at the end` {
-                private val subject = "xyz*".simplePatternToRegex()
+                private val subject = "xyz*".pathGlobToRegex()
 
                 @Test
                 fun `matches pattern exactly`() {
@@ -109,7 +109,7 @@ internal class SimplePatternToRegexSpec {
 
             @Nested
             inner class `Pattern with wildcard at the middle` {
-                private val subject = "x*yz".simplePatternToRegex()
+                private val subject = "x*yz".pathGlobToRegex()
 
                 @Test
                 fun `matches pattern exactly`() {
@@ -139,7 +139,7 @@ internal class SimplePatternToRegexSpec {
 
         @Nested
         inner class `multiple wildcards` {
-            private val subject = "x*yz*".simplePatternToRegex()
+            private val subject = "x*yz*".pathGlobToRegex()
 
             @Test
             fun `matches pattern`() {
@@ -155,7 +155,7 @@ internal class SimplePatternToRegexSpec {
         inner class `single wildcard` {
             @Nested
             inner class `pattern with wildcard at the beginning` {
-                private val subject = "?xyz".simplePatternToRegex()
+                private val subject = "?xyz".pathGlobToRegex()
 
                 @Test
                 fun `matches with any character before`() {
@@ -178,7 +178,7 @@ internal class SimplePatternToRegexSpec {
 
             @Nested
             inner class `pattern with wildcard at the end` {
-                private val subject = "xyz?".simplePatternToRegex()
+                private val subject = "xyz?".pathGlobToRegex()
 
                 @Test
                 fun `matches with any character after`() {
@@ -201,7 +201,7 @@ internal class SimplePatternToRegexSpec {
 
             @Nested
             inner class `pattern with wildcard at the middle` {
-                private val subject = "x?yz".simplePatternToRegex()
+                private val subject = "x?yz".pathGlobToRegex()
 
                 @Test
                 fun `matches with any single character`() {
@@ -219,7 +219,7 @@ internal class SimplePatternToRegexSpec {
 
         @Nested
         inner class `multiple wildcards` {
-            private val subject = "x?y?z".simplePatternToRegex()
+            private val subject = "x?y?z".pathGlobToRegex()
 
             @Test
             fun `matches pattern`() {
@@ -233,7 +233,7 @@ internal class SimplePatternToRegexSpec {
     inner class `characters that have a special meaning in regular expression must be escaped` {
         @Nested
         inner class Period {
-            private val subject = "a.b.c".simplePatternToRegex()
+            private val subject = "a.b.c".pathGlobToRegex()
 
             @Test
             fun `matches the same string`() {
@@ -250,7 +250,7 @@ internal class SimplePatternToRegexSpec {
 
         @Nested
         inner class `character classes and quantifiers` {
-            private val subject = """ab\d{2,5}\s\wc""".simplePatternToRegex()
+            private val subject = """ab\d{2,5}\s\wc""".pathGlobToRegex()
 
             @Test
             fun `can be used`() {
@@ -264,7 +264,7 @@ internal class SimplePatternToRegexSpec {
     inner class `invalid pattern` {
         @Test
         fun `fails during creation`() {
-            assertThatThrownBy { """a[b""".simplePatternToRegex() }
+            assertThatThrownBy { """a[b""".pathGlobToRegex() }
                 .isInstanceOf(IllegalArgumentException::class.java)
         }
     }

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/SimplePatternToRegexSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/SimplePatternToRegexSpec.kt
@@ -1,4 +1,4 @@
-package dev.detekt.api
+package dev.detekt.psi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy

--- a/detekt-rules-libraries/build.gradle.kts
+++ b/detekt-rules-libraries/build.gradle.kts
@@ -4,9 +4,11 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
+    compileOnly(projects.detektPsiUtils)
 
     testImplementation(libs.kotlin.compiler)
     testImplementation(projects.detektApi)
+    testRuntimeOnly(projects.detektPsiUtils)
     testImplementation(projects.detektTest)
     testImplementation(projects.detektTestAssertj)
     testImplementation(projects.detektTestJunit)

--- a/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
@@ -33,7 +33,7 @@ class ForbiddenPublicDataClass(config: Config) :
 
     @Configuration("ignores classes in the specified packages.")
     private val ignorePackages: List<Regex> by config(listOf("*.internal", "*.internal.*")) { packages ->
-        packages.distinct().map(String::simplePatternToRegex)
+        packages.distinct().map(String::pathGlobToRegex)
     }
 
     override fun visitClass(klass: KtClass) {

--- a/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**
@@ -18,7 +18,7 @@ class ForbiddenClassName(config: Config) : Rule(config, "Forbidden class name as
 
     @Configuration("List of glob patterns to be disallowed as class names")
     private val forbiddenName: List<Regex> by config(emptyList<String>()) { patterns ->
-        patterns.map(String::simplePatternToRegex)
+        patterns.map(String::pathGlobToRegex)
     }
 
     override fun visitClassOrObject(classOrObject: KtClassOrObject) {

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtClassOrObject
 
 /**

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
@@ -8,7 +8,7 @@ import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.lexer.KtTokens.EQEQEQ

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
@@ -8,7 +8,7 @@ import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.lexer.KtTokens.EQEQEQ
@@ -47,7 +47,7 @@ class AvoidReferentialEquality(config: Config) :
         listOf(
             "kotlin.String"
         )
-    ) { it.map(String::simplePatternToRegex) }
+    ) { it.map(String::pathGlobToRegex) }
 
     override fun visitBinaryExpression(expression: KtBinaryExpression) {
         super.visitBinaryExpression(expression)

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -12,7 +12,7 @@ import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.FunctionMatcher
 import dev.detekt.psi.isCalling
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
@@ -77,7 +77,7 @@ class IgnoredReturnValue(config: Config) :
             "*.CheckReturnValue"
         )
     ) {
-        it.map(String::simplePatternToRegex)
+        it.map(String::pathGlobToRegex)
     }
 
     @Configuration("Annotations to skip this inspection")
@@ -87,7 +87,7 @@ class IgnoredReturnValue(config: Config) :
             "*.CanIgnoreReturnValue"
         )
     ) {
-        it.map(String::simplePatternToRegex)
+        it.map(String::pathGlobToRegex)
     }
 
     @Configuration("List of return types that should not be ignored")
@@ -98,7 +98,7 @@ class IgnoredReturnValue(config: Config) :
             "kotlinx.coroutines.flow.*Flow",
             "java.util.stream.*Stream",
         ),
-    ) { it.map(String::simplePatternToRegex) }
+    ) { it.map(String::pathGlobToRegex) }
 
     @Configuration(
         "List of function signatures which should be ignored by this rule. " +

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -10,9 +10,9 @@ import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
 import dev.detekt.psi.FunctionMatcher
 import dev.detekt.psi.isCalling
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
@@ -6,8 +6,8 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
 import dev.detekt.api.valuesWithReason
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.api.valuesWithReason
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.psi.KtImportDirective
 
 /**
@@ -46,7 +46,7 @@ class ForbiddenImport(config: Config) :
             "It is recommended to also specify a reason."
     )
     private val forbiddenImports: List<Forbidden> by config(valuesWithReason()) { list ->
-        list.map { Forbidden(it.value.simplePatternToRegex(), it.reason) }
+        list.map { Forbidden(it.value.pathGlobToRegex(), it.reason) }
     }
 
     @Configuration(
@@ -54,7 +54,7 @@ class ForbiddenImport(config: Config) :
             "Use this to specify exceptions to the forbidden imports."
     )
     private val allowedImports: List<Regex> by config(emptyList<String>()) { list ->
-        list.map { it.simplePatternToRegex() }
+        list.map { it.pathGlobToRegex() }
     }
 
     override fun visitImportDirective(importDirective: KtImportDirective) {

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -7,10 +7,10 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
 import dev.detekt.psi.isActual
 import dev.detekt.psi.isOpen
 import dev.detekt.psi.isOverride
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.config
 import dev.detekt.psi.isActual
 import dev.detekt.psi.isOpen
 import dev.detekt.psi.isOverride
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -41,7 +41,7 @@ class FunctionOnlyReturningConstant(config: Config) :
     private val ignoreActualFunction: Boolean by config(true)
 
     @Configuration("excluded functions")
-    private val excludedFunctions: List<Regex> by config(emptyList<String>()) { it.map(String::simplePatternToRegex) }
+    private val excludedFunctions: List<Regex> by config(emptyList<String>()) { it.map(String::pathGlobToRegex) }
 
     override fun visitNamedFunction(function: KtNamedFunction) {
         if (isNotIgnored(function) &&

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.psi.simplePatternToRegex
+import dev.detekt.psi.pathGlobToRegex
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -47,7 +47,7 @@ class ReturnCount(config: Config) : Rule(config, "Restrict the number of return 
     private val max: Int by config(2)
 
     @Configuration("define a list of function names to be ignored by this check")
-    private val excludedFunctions: List<Regex> by config(listOf("equals")) { it.map(String::simplePatternToRegex) }
+    private val excludedFunctions: List<Regex> by config(listOf("equals")) { it.map(String::pathGlobToRegex) }
 
     @Configuration("if labeled return statements should be ignored")
     private val excludeLabeled: Boolean by config(false)

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.config
-import dev.detekt.api.simplePatternToRegex
+import dev.detekt.psi.simplePatternToRegex
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtReturnExpression


### PR DESCRIPTION
This PR unblocks #9279

We had 2 similar functions:

`simplePatternToRegex` and `qualifiedNameGlobToRegex`. Both parse a glob pattern to match 2 different concetps. The frist one paths and the second one fully qualified names.

The first one was inside `:detekt-api`. That wasn't their place. It doesn't have sense to have a function like that in our main public api. The other was a private implementation inside `core`. It was fine there but #9279 also needs it so we should move it to a public place where rules could depend on.

I decided to move both to `:detekt-psi-utils`. They are not directly related with psi but I think that `:detekt-psi-utils` is the best fit for these two functions.

I also renamed them to get their names aligned: `pathGlobToRegex` and `fullyQualifiedNameGlobToRegex`.

And because `fullyQualifiedNameGlobToRegex` is now not an implementation detail I added test to it. I found some little issues on the previous implementation so I fixed them.

TL;DR: I think that this PR is good for multiple reasons:
- Simplify `:detekt-api`
- Unblocks #9279 without duplicate anycode
- Align names for 2 similar functions
- Better tests for `fullyQualifiedNameGlobToRegex`