### PR TITLE
Fix unused import false positive for companion object member extension properties

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedImport.kt
@@ -63,18 +63,18 @@ class UnusedImport(config: Config) :
             staticReferences.mapTo(mutableSetOf()) { it.text.trim('`') }
         }
         private val fqNames: Set<FqName> by lazy {
-            namedReferences.mapNotNullTo(mutableSetOf()) { it.fqNameOrNull() }
+            namedReferences.flatMapTo(mutableSetOf()) { it.fqNamesOrEmpty() }
         }
 
         /**
-         * All [namedReferences] whose [KtReferenceExpression.fqNameOrNull] cannot be resolved
+         * All [namedReferences] whose [KtReferenceExpression.fqNamesOrEmpty] cannot be resolved
          * mapped to their text. String matches to such references shouldn't be marked as unused
          * imports since they could match the unknown value being imported.
          */
         @Suppress("DocumentationOverPrivateProperty")
         private val unresolvedNamedReferencesAsString: Set<String> by lazy {
             namedReferences.mapNotNullTo(mutableSetOf()) {
-                if (it.fqNameOrNull() == null) it.text.trim('`') else null
+                if (it.fqNamesOrEmpty().isEmpty()) it.text.trim('`') else null
             }
         }
 
@@ -85,7 +85,7 @@ class UnusedImport(config: Config) :
                 if (aliasName in (namedReferencesInKDoc + namedReferencesAsString)) return false
                 val identifier = identifier()
                 if (identifier in namedReferencesInKDoc || identifier in staticReferencesAsString) return false
-                val fqNameUsed = importPath?.fqName?.let { it in fqNames } == true
+                val fqNameUsed = importPath?.fqName in fqNames
                 val unresolvedNameUsed = identifier in unresolvedNamedReferencesAsString
 
                 return !fqNameUsed && !unresolvedNameUsed
@@ -160,23 +160,39 @@ class UnusedImport(config: Config) :
         }
 
         @Suppress("ClassOrdering")
-        private val KaSymbol.fqNameForImport: FqName?
+        private val KaSymbol.fqNamesForImport: Set<FqName>
             get() = when (this) {
-                is KaClassLikeSymbol -> when {
-                    this is KaClassSymbol && classKind == KaClassKind.COMPANION_OBJECT ->
-                        classId?.outerClassId
+                is KaClassLikeSymbol ->
+                    setOfNotNull(
+                        when {
+                            this is KaClassSymbol && classKind == KaClassKind.COMPANION_OBJECT ->
+                                classId?.outerClassId
 
-                    else -> classId
-                }?.asSingleFqName()
+                            else -> classId
+                        }?.asSingleFqName()
+                    )
 
-                is KaCallableSymbol -> callableId?.asSingleFqName()
+                is KaCallableSymbol -> callableFqNamesForImport()
 
-                else -> null
+                else -> emptySet()
             }
 
-        private fun KtReferenceExpression.fqNameOrNull(): FqName? =
+        private fun KaCallableSymbol.callableFqNamesForImport(): Set<FqName> {
+            val callableFqName = callableId?.asSingleFqName() ?: return emptySet()
+            val callableName = callableId?.callableName?.asString().orEmpty()
+            val classFqName = callableId?.classId?.asSingleFqName()?.asString()
+
+            val companionCallableFqName =
+                classFqName
+                    ?.takeIf { callableName.isNotEmpty() }
+                    ?.let { FqName("$it.Companion.$callableName") }
+
+            return setOfNotNull(callableFqName, companionCallableFqName)
+        }
+
+        private fun KtReferenceExpression.fqNamesOrEmpty(): Set<FqName> =
             analyze(this) {
-                mainReference.resolveToSymbol()?.fqNameForImport
+                mainReference.resolveToSymbol()?.fqNamesForImport.orEmpty()
             }
     }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
@@ -669,6 +669,30 @@ class UnusedImportSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Test
+    fun `reports unused import when type parameter symbol is present`() {
+        val mainFile =
+            """
+            import x.y.z.Foo
+
+            fun <T> id(value: T): T = value
+
+            fun test() {
+                val value = id("text")
+                println(value)
+            }
+            """.trimIndent()
+        val additionalFile =
+            """
+            package x.y.z
+
+            class Foo
+            """.trimIndent()
+
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).singleElement()
+            .hasTextLocation("import x.y.z.Foo")
+    }
+
+    @Test
     fun `does not report when used in a class literal expression`() {
         val code =
             """
@@ -953,6 +977,38 @@ class UnusedImportSpec(val env: KotlinEnvironmentContainer) {
             package additional
 
             inline val myVal get() = 1
+            """.trimIndent()
+
+        assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()
+    }
+
+    @Test
+    fun `does not report anything for files without imports`() {
+        val mainFile =
+            """
+            fun main() {
+                println("hello")
+            }
+            """.trimIndent()
+
+        assertThat(subject.lintWithContext(env, mainFile)).isEmpty()
+    }
+
+    @Test
+    fun `ignores wildcard imports`() {
+        val mainFile =
+            """
+            import additional.*
+
+            fun test() {
+                println("unused wildcard import is ignored by this rule")
+            }
+            """.trimIndent()
+        val additionalFile =
+            """
+            package additional
+
+            class Something
             """.trimIndent()
 
         assertThat(subject.lintWithContext(env, mainFile, additionalFile)).isEmpty()

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedImportSpec.kt
@@ -786,6 +786,35 @@ class UnusedImportSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Test
+    fun `does not report companion object member extension property import`() {
+        val mainFile =
+            """
+            package x.y.z.handler
+
+            import x.y.z.Input
+            import x.y.z.Foo.Companion.isDisabled
+            import x.y.z.Foo.Companion.isEnabled
+
+            fun handle(input: Input) = input.isEnabled || input.isDisabled
+            """.trimIndent()
+        val additionalFile =
+            """
+            package x.y.z
+
+            data class Input(val value: Int)
+
+            open class Foo {
+                companion object : Foo()
+
+                val Input.isEnabled: Boolean get() = value > 0
+                val Input.isDisabled: Boolean get() = value <= 0
+            }
+            """.trimIndent()
+        val findings = subject.lintWithContext(env, mainFile, additionalFile)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
     fun `does not report named companion object - #8989`() {
         val mainFile =
             """


### PR DESCRIPTION
<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->


Closes https://github.com/detekt/detekt/issues/9333.

- Return `KaCallableSymbol.callableFqNamesForImport()` as a `Set` of `FqName` now since one symbol can map to multiple imports.
- Update unresolved reference names from null check to `isEmpty()` check due to this new return type.
- Refactor `fqNameOrNull` to `fqNamesOrEmpty` to account for multiple imports. 
