### PR TITLE
Fix PrintStackTrace nested call detection

### DIFF
--- a/detekt-rules-exceptions/src/main/kotlin/dev/detekt/rules/exceptions/PrintStackTrace.kt
+++ b/detekt-rules-exceptions/src/main/kotlin/dev/detekt/rules/exceptions/PrintStackTrace.kt
@@ -47,6 +47,7 @@ class PrintStackTrace(config: Config) :
     Rule(config, "Do not print a stack trace. These debug statements should be removed or replaced with a logger.") {
 
     override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
         val callNameExpression = expression.getCallNameExpression()
         if (callNameExpression?.text == "dumpStack" &&
             callNameExpression.getReceiverExpression()?.text == "Thread"
@@ -56,6 +57,7 @@ class PrintStackTrace(config: Config) :
     }
 
     override fun visitCatchSection(catchClause: KtCatchClause) {
+        super.visitCatchSection(catchClause)
         catchClause.catchBody?.forEachDescendantOfType<KtNameReferenceExpression> {
             if (it.text == catchClause.catchParameter?.name && hasPrintStacktraceCallExpression(it)) {
                 report(Finding(Entity.from(it), description))

--- a/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/PrintStackTraceSpec.kt
+++ b/detekt-rules-exceptions/src/test/kotlin/dev/detekt/rules/exceptions/PrintStackTraceSpec.kt
@@ -26,6 +26,22 @@ class PrintStackTraceSpec {
         }
 
         @Test
+        fun `prints a stacktrace in nested call expression`() {
+            val code = """
+                fun x() {
+                    run {
+                        try {
+                            check(false)
+                        } catch (e: IllegalStateException) {
+                            e.printStackTrace()
+                        }
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
         fun `does not print a stacktrace`() {
             val code = """
                 fun x() {


### PR DESCRIPTION
## What changed
- Continue visiting nested call expressions and catch sections in the PrintStackTrace rule.
- Add regression coverage for a printStackTrace call inside a nested call expression.

Fixes #9345

## Verification
- ./gradlew.bat --no-daemon --console=plain :detekt-rules-exceptions:test --tests dev.detekt.rules.exceptions.PrintStackTraceSpec