### PR TITLE
Update ktlint documentation links

### DIFF
--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/KtlintWrapperProvider.kt
@@ -111,7 +111,7 @@ import dev.detekt.rules.ktlintwrapper.wrappers.Wrapping
 import com.pinterest.ktlint.rule.engine.core.api.RuleSetId as KtlintRuleSetId
 
 /**
- * This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+ * This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
  *
  * **Note: The `ktlint` rule set is not included in the detekt-cli or Gradle plugin.**
  *

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationOnSeparateLine.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationOnSeparateLine.kt
@@ -12,7 +12,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-formatting) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-formatting) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/AnnotationSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#annotation-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ArgumentListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ArgumentListWrapping.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#argument-list-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#argument-list-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BackingPropertyNaming.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BackingPropertyNaming.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#backing-property-naming)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#backing-property-naming)
  * for documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BinaryExpressionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BinaryExpressionWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#binary-expression-wrapping) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#binary-expression-wrapping) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBeforeDeclaration.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBeforeDeclaration.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-before-declarations) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-before-declarations) for
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBetweenWhenConditions.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlankLineBetweenWhenConditions.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#blank-lines-between-when-conditions)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/#blank-lines-between-when-conditions)
  * for documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlockCommentInitialStarAlignment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/BlockCommentInitialStarAlignment.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#block-comment-initial-star-alignment) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#block-comment-initial-star-alignment) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainMethodContinuation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainMethodContinuation.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#chain-method-continuation)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#chain-method-continuation)
  * for documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ChainWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#chain-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#chain-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassName.kt
@@ -5,7 +5,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#class-naming) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#class-naming) for
  * documentation.
  */
 internal class ClassName(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassSignature.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ClassSignature.kt
@@ -14,7 +14,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#class-signature) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#class-signature) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/CommentWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#comment-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ConditionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ConditionWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#condition-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#condition-wrapping) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverListWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#context-receiver-list-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#context-receiver-list-wrapping) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverMapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ContextReceiverMapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#content-receiver-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#content-receiver-wrapping) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumEntryNameCase.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumEntryNameCase.kt
@@ -12,7 +12,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#enum-entry) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#enum-entry) for documentation.
  */
 @AutoCorrectable(since = "1.4.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/EnumWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#enum-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#enum-wrapping) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ExpressionOperandWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ExpressionOperandWrapping.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#expression-operand-wrapping) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/#expression-operand-wrapping) for
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Filename.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Filename.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#file-name) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#file-name) for documentation.
  *
  * This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
  * from the standard rules, make sure to enable just one.

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FinalNewline.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FinalNewline.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#final-newline) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#final-newline) for documentation.
  *
  * This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
  * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunKeywordSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunKeywordSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#fun-keyword-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#fun-keyword-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionExpressionBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionExpressionBody.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-expression-body)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-expression-body)
  * for documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionLiteral.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionLiteral.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-literal) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-literal) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionName.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-naming) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-naming) for
  * documentation.
  */
 internal class FunctionName(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionReturnTypeSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionReturnTypeSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-return-type-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-return-type-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionSignature.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionSignature.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-signature) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-signature) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionStartOfBodySpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionStartOfBodySpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-start-of-body-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-start-of-body-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeModifierSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeModifierSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-type-modifier-spacing)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-type-modifier-spacing)
  * for documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeReferenceSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/FunctionTypeReferenceSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-type-reference-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#function-type-reference-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseBracing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseBracing.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-bracing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-bracing) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 internal class IfElseBracing(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/IfElseWrapping.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#if-else-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 internal class IfElseWrapping(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ImportOrdering.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ImportOrdering.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#import-ordering) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#import-ordering) for documentation.
  *
  * For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
  */

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Indentation.kt
@@ -12,7 +12,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#indentation) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#indentation) for documentation.
  */
 @ActiveByDefault(since = "1.19.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Kdoc.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Kdoc.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#kdoc) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/#kdoc) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 internal class Kdoc(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/KdocWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/KdocWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#kdoc-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#kdoc-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MaximumLineLength.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MaximumLineLength.kt
@@ -12,7 +12,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#max-line-length) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#max-line-length) for documentation.
  *
  * This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
  * from the standard rules, make sure to enable just one or keep them aligned.

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MixedConditionOperators.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MixedConditionOperators.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 internal class MixedConditionOperators(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierListSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-list-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-list-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.23.0")
 @AutoCorrectable(since = "1.20.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierOrdering.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ModifierOrdering.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-order) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#modifier-order) for documentation.
  *
  * This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
  * from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultiLineIfElse.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultiLineIfElse.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-if-else) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-if-else) for documentation.
  */
 @AutoCorrectable(since = "1.0.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineExpressionWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineExpressionWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-expression-wrapping) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-expression-wrapping) for
  * documentation.
  *
  * Although this is a standard rule it is not enabled by default like other standard ktlint rules. ktlint only enables

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineLoop.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/MultilineLoop.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-loop) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#multiline-loop) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineBeforeRbrace.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineBeforeRbrace.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-before) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-before) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineInList.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLineInList.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-list) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-list) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 internal class NoBlankLineInList(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLinesInChainedMethodCalls.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoBlankLinesInChainedMethodCalls.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-chained-method-calls) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-blank-lines-in-chained-method-calls) for
  * documentation.
  */
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveBlankLines.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveBlankLines.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-blank-lines) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-blank-lines) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveComments.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoConsecutiveComments.kt
@@ -5,7 +5,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-comments) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-consecutive-comments) for documentation.
  */
 internal class NoConsecutiveComments(config: Config) :
     KtlintRule(config, "Disallow consecutive comments in most cases.") {

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyClassBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyClassBody.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-class-bodies) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-class-bodies) for documentation.
  *
  * This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
  * from the standard rules, make sure to enable just one.

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFile.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFile.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-file) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-file) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 internal class NoEmptyFile(config: Config) : KtlintRule(config, "Kotlin files must contain at least one declaration") {

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInClassBody.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInClassBody.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-first-line-at-start-in-class-body)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-empty-first-line-at-start-in-class-body)
  * for documentation.
  */
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInMethodBlock.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoEmptyFirstLineInMethodBlock.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-leading-empty-lines-in-method-blocks) for
  * documentation.
  */
 @AutoCorrectable(since = "1.4.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakAfterElse.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakAfterElse.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-after-else) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-after-else) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakBeforeAssignment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoLineBreakBeforeAssignment.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-before-assignment) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-line-break-before-assignment) for
  * documentation.
  */
 @ActiveByDefault(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoMultipleSpaces.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoMultipleSpaces.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-multi-spaces) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-multi-spaces) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSemicolons.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSemicolons.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-semicolons) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-semicolons) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSingleLineBlockComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoSingleLineBlockComment.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-single-line-block-comment) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-single-line-block-comment) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 internal class NoSingleLineBlockComment(config: Config) : KtlintRule(config, "Reports single block line comments") {

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoTrailingSpaces.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoTrailingSpaces.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-trailing-whitespaces) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-trailing-whitespaces) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnitReturn.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnitReturn.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unit-as-return-type) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unit-as-return-type) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnusedImports.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoUnusedImports.kt
@@ -9,7 +9,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unused-imports) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-unused-imports) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoWildcardImports.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NoWildcardImports.kt
@@ -9,7 +9,7 @@ import dev.detekt.api.config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-wildcard-imports) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#no-wildcard-imports) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 internal class NoWildcardImports(config: Config) : KtlintRule(config, "Detects wildcard imports") {

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NullableTypeSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/NullableTypeSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#nullable-type-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#nullable-type-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PackageName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PackageName.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#package-name) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#package-name) for
  * documentation.
  */
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-list-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-list-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterListWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-list-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-list-wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ParameterWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#parameter-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyName.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyName.kt
@@ -9,7 +9,7 @@ import dev.detekt.api.config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#property-naming) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#property-naming) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/PropertyWrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#property-wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#property-wrapping) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundAngleBrackets.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundAngleBrackets.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#angle-bracket-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#angle-bracket-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundColon.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundColon.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#colon-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#colon-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundComma.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundComma.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#comma-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#comma-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundCurly.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundCurly.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#curly-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#curly-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDot.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDot.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#dot-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#dot-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDoubleColon.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundDoubleColon.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#double-colon-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#double-colon-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.10.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundKeyword.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundKeyword.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#keyword-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#keyword-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundOperators.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundOperators.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#operator-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#operator-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundParens.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundParens.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#parenthesis-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#parenthesis-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundRangeOperator.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundRangeOperator.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#range-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#range-spacing) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundSquareBrackets.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundSquareBrackets.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#square-brackets-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/#square-brackets-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundUnaryOperator.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingAroundUnaryOperator.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#unary-operator-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#unary-operator-spacing) for documentation.
  */
 @AutoCorrectable(since = "1.16.0")
 @ActiveByDefault(since = "1.22.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithAnnotations.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declarations-with-annotations)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declarations-with-annotations)
  * for documentation.
  */
 @AutoCorrectable(since = "1.10.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithComments.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenDeclarationsWithComments.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declaration-with-comments)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#blank-line-between-declaration-with-comments)
  * for documentation.
  */
 @AutoCorrectable(since = "1.10.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/SpacingBetweenFunctionNameAndOpeningParenthesis.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
  * documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StatementWrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StatementWrapping.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#statement-wrapping) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#statement-wrapping) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplate.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplate.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template) for documentation.
  */
 @ActiveByDefault(since = "1.0.0")
 @AutoCorrectable(since = "1.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplateIndent.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/StringTemplateIndent.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template-indent) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#string-template-indent) for documentation.
  */
 @AutoCorrectable(since = "1.23.0")
 internal class StringTemplateIndent(config: Config) :

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ThenSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ThenSpacing.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#then-spacing) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#then-spacing) for documentation.
  */
 @ActiveByDefault(since = "2.0.0")
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnCallSite.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnCallSite.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-call-site) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-call-site) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnDeclarationSite.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TrailingCommaOnDeclarationSite.kt
@@ -10,7 +10,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#trailing-comma-on-declaration-site) for documentation.
  *
  * The default config comes from ktlint and follows these conventions:
  * - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TryCatchFinallySpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TryCatchFinallySpacing.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#try-catch-finally-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#try-catch-finally-spacing) for
  * documentation.
  */
 @AutoCorrectable(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentComment.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeArgumentListSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#type-argument-list-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#type-argument-list-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterComment.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterListSpacing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/TypeParameterListSpacing.kt
@@ -11,7 +11,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#type-parameter-list-spacing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#type-parameter-list-spacing) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/UnnecessaryParenthesesBeforeTrailingLambda.kt
@@ -7,7 +7,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
  * for documentation.
  */
 @ActiveByDefault(since = "1.23.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueArgumentComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueArgumentComment.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueParameterComment.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/ValueParameterComment.kt
@@ -6,7 +6,7 @@ import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/) for
  * documentation.
  */
 @ActiveByDefault(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/WhenEntryBracing.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/WhenEntryBracing.kt
@@ -10,7 +10,7 @@ import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.rules.ktlintwrapper.KtlintRule
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/experimental/#when-entry-bracing) for
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/experimental/#when-entry-bracing) for
  * documentation.
  */
 @AutoCorrectable(since = "2.0.0")

--- a/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Wrapping.kt
+++ b/detekt-rules-ktlint-wrapper/src/main/kotlin/dev/detekt/rules/ktlintwrapper/wrappers/Wrapping.kt
@@ -13,7 +13,7 @@ import dev.detekt.rules.ktlintwrapper.KtlintRule
 import dev.detekt.rules.ktlintwrapper.configWithAndroidVariants
 
 /**
- * See [ktlint docs](https://pinterest.github.io/ktlint/<ktlintVersion/>/rules/standard/#wrapping) for documentation.
+ * See [ktlint docs](https://ktlint.github.io/ktlint/<ktlintVersion/>/rules/standard/#wrapping) for documentation.
  */
 @ActiveByDefault(since = "1.20.0")
 @AutoCorrectable(since = "1.20.0")

--- a/website/versioned_docs/version-1.21.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.21.0/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 Note: Issues reported by this rule set can only be suppressed on file level (`@file:Suppress("detekt.rule")`).
 Note: The formatting rule set is not included by default in the detekt-cli or gradle plugin.

--- a/website/versioned_docs/version-1.22.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.22.0/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 Note: Issues reported by this rule set can only be suppressed on file level (`@file:Suppress("detekt.rule")`).
 Note: The formatting rule set is not included in the detekt-cli or gradle plugin.
@@ -17,19 +17,19 @@ in the command line interface.
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -45,26 +45,26 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: No
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#comment-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -76,20 +76,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming&gt;MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -98,7 +98,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style&gt;NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -113,20 +113,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#fun-keyword-spacing) for documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -151,21 +151,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -179,7 +179,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -197,7 +197,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#kdoc-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -209,7 +209,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style&gt;MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -229,13 +229,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#modifier-list-spacing) for documentation.
 
 **Active by default**: No
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style&gt;ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -244,88 +244,88 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -337,28 +337,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#no-underscores-in-package-names) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#no-underscores-in-package-names) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -376,100 +376,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#para
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: No
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -488,7 +488,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -507,28 +507,28 @@ trailing comma usage yet.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: No
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.47.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.47.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.0/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.0/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,7 +52,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#block-comment-initial-star-alignment)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#block-comment-initial-star-alignment)
 for
 documentation.
 
@@ -60,7 +60,7 @@ documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -72,20 +72,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -97,7 +97,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#content-receiver-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#content-receiver-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -114,20 +114,20 @@ documentation.
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -139,7 +139,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -148,7 +148,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -163,20 +163,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -189,7 +189,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -214,21 +214,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -240,7 +240,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -252,7 +252,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see
 the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.49.1/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
@@ -267,7 +267,7 @@ the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.49.1/ktlint-
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -285,7 +285,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -297,7 +297,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -317,14 +317,14 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#modifier-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#modifier-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -333,7 +333,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -345,7 +345,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -358,47 +358,47 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#no-blank-lines-in-list) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#no-blank-lines-in-list) for
 documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-consecutive-blank-lines) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-consecutive-blank-lines) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#disallow-consecutive-comments) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#disallow-consecutive-comments) for
 documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -411,39 +411,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#no-single-line-block-comments) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#no-single-line-block-comments) for
 documentation.
 
 **Active by default**: No
@@ -456,25 +456,25 @@ documentation.
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -486,28 +486,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -523,7 +523,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -539,14 +539,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -562,87 +562,87 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis)
 for
 documentation.
 
@@ -650,13 +650,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#string-template-indent) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#string-template-indent) for
 documentation.
 
 **Active by default**: No
@@ -669,7 +669,7 @@ documentation.
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -688,7 +688,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -707,7 +707,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -720,7 +720,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -733,7 +733,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -746,14 +746,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.49.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.49.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.1/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.1/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -113,20 +113,20 @@ documentation.
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -138,7 +138,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -147,7 +147,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -162,20 +162,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -188,7 +188,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -213,21 +213,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -239,7 +239,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -251,7 +251,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see
 the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
@@ -266,7 +266,7 @@ the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -284,7 +284,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -296,7 +296,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -316,14 +316,14 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -332,7 +332,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -344,7 +344,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -357,47 +357,47 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for
 documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for
 documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -410,39 +410,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for
 documentation.
 
 **Active by default**: No
@@ -455,25 +455,25 @@ documentation.
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -485,28 +485,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -522,7 +522,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -538,14 +538,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -561,87 +561,87 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis)
 for
 documentation.
 
@@ -649,13 +649,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for
 documentation.
 
 **Active by default**: No
@@ -668,7 +668,7 @@ documentation.
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -687,7 +687,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -706,7 +706,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -719,7 +719,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -732,7 +732,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -745,14 +745,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.3/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.3/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-underscores-in-package-names) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-underscores-in-package-names) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.4/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.4/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.5/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.5/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.6/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.6/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.7/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.7/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-1.23.8/rules/formatting.md
+++ b/website/versioned_docs/version-1.23.8/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#anno
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -52,14 +52,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#argu
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -71,20 +71,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#chai
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#classobject-naming) for
 documentation.
 
 **Active by default**: No
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -96,7 +96,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comm
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#content-receiver-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -112,20 +112,20 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### DiscouragedCommentLocation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#discouraged-comment-location) for
 documentation.
 
 **Active by default**: No
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#enum-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -137,7 +137,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -146,7 +146,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -161,20 +161,20 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -187,7 +187,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#function-signature) for
 documentation.
 
 **Active by default**: No
@@ -212,21 +212,21 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/a6ca5b2edf95cc70a138a9470cfb6c4fd5d9d3ce/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/ImportOrderingRule.kt)
 
@@ -264,7 +264,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -282,7 +282,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#inde
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -294,7 +294,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#kdoc
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned. The pro of this rule is that it can
@@ -314,13 +314,13 @@ auto-correct the issue.
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -329,7 +329,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -341,7 +341,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#mult
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -354,44 +354,44 @@ documentation.
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#disallow-empty-lines-at-start-of-class-body)
 for documentation.
 
 **Active by default**: No
@@ -404,39 +404,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#no-single-line-block-comments) for documentation.
 
 **Active by default**: No
 
@@ -448,25 +448,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -478,28 +478,28 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#no-w
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -515,7 +515,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -531,14 +531,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#para
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#property-naming) for
 documentation.
 
 **Active by default**: No
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -554,100 +554,100 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#prop
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -659,7 +659,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -678,7 +678,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -697,7 +697,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -710,7 +710,7 @@ documentation.
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -723,7 +723,7 @@ documentation.
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/experimental/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: No
@@ -736,14 +736,14 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/0.50.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.0/rules/formatting.md
+++ b/website/versioned_docs/version-2.0.0-alpha.0/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -56,14 +56,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -80,14 +80,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: No
@@ -100,14 +100,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -128,7 +128,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -140,14 +140,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -164,13 +164,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -182,7 +182,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -194,7 +194,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -210,7 +210,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -226,7 +226,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -240,7 +240,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -252,7 +252,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -265,7 +265,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -274,7 +274,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -289,13 +289,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -312,7 +312,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -329,14 +329,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -349,7 +349,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -374,28 +374,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -407,7 +407,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -419,7 +419,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -433,7 +433,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -449,13 +449,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: No
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -467,7 +467,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -488,13 +488,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
 
 **Active by default**: No
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -506,7 +506,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -515,7 +515,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -527,7 +527,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -544,7 +544,7 @@ documentation.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -556,38 +556,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -596,13 +596,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -615,39 +615,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -659,25 +659,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -689,21 +689,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -716,7 +716,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -732,7 +732,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -748,7 +748,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -761,7 +761,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -777,25 +777,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -807,77 +807,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -890,13 +890,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -908,7 +908,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#strin
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -927,7 +927,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -946,7 +946,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -959,14 +959,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -979,14 +979,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -999,28 +999,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1033,7 +1033,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.0/rules/ktlint.md
+++ b/website/versioned_docs/version-2.0.0-alpha.0/rules/ktlint.md
@@ -6,7 +6,7 @@ permalink: ktlint.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `ktlint` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -28,7 +28,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -40,13 +40,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -66,14 +66,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -90,14 +90,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: No
@@ -110,14 +110,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -138,7 +138,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -150,14 +150,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -174,13 +174,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -192,7 +192,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -204,7 +204,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -220,7 +220,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -236,7 +236,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -262,7 +262,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -275,7 +275,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -284,7 +284,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -299,13 +299,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -322,7 +322,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -339,14 +339,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -359,7 +359,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -384,28 +384,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -417,7 +417,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -429,7 +429,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -443,7 +443,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -459,13 +459,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: No
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -477,7 +477,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -498,13 +498,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
 
 **Active by default**: No
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -516,7 +516,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -525,7 +525,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -537,7 +537,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -554,7 +554,7 @@ documentation.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -566,38 +566,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -606,13 +606,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -625,39 +625,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -669,25 +669,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -699,21 +699,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -726,7 +726,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -742,7 +742,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -758,7 +758,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -771,7 +771,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -787,25 +787,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -817,77 +817,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -900,13 +900,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -918,7 +918,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#strin
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -937,7 +937,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -956,7 +956,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -969,14 +969,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -989,14 +989,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1009,28 +1009,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1043,7 +1043,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.1/rules/formatting.md
+++ b/website/versioned_docs/version-2.0.0-alpha.1/rules/formatting.md
@@ -6,7 +6,7 @@ permalink: formatting.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `formatting` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -18,7 +18,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -30,13 +30,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -56,14 +56,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -80,14 +80,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: No
@@ -100,14 +100,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -128,7 +128,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -140,14 +140,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -164,13 +164,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -182,7 +182,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -194,7 +194,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -210,7 +210,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -226,7 +226,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -240,7 +240,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -252,7 +252,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -265,7 +265,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -274,7 +274,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -289,13 +289,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -312,7 +312,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -329,14 +329,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -349,7 +349,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -374,28 +374,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -407,7 +407,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -419,7 +419,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -433,7 +433,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -449,13 +449,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: No
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -467,7 +467,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -488,13 +488,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
 
 **Active by default**: No
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -506,7 +506,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -515,7 +515,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -527,7 +527,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -544,7 +544,7 @@ documentation.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -556,38 +556,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -596,13 +596,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -615,39 +615,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -659,25 +659,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -689,21 +689,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -716,7 +716,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -732,7 +732,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -748,7 +748,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -761,7 +761,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -777,25 +777,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -807,77 +807,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -890,13 +890,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -908,7 +908,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#strin
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -927,7 +927,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -946,7 +946,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -959,14 +959,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -979,14 +979,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -999,28 +999,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1033,7 +1033,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.1/rules/ktlint.md
+++ b/website/versioned_docs/version-2.0.0-alpha.1/rules/ktlint.md
@@ -6,7 +6,7 @@ permalink: ktlint.html
 toc: true
 folder: documentation
 ---
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `ktlint` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -28,7 +28,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -40,13 +40,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -66,14 +66,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -90,14 +90,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: No
@@ -110,14 +110,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -138,7 +138,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -150,14 +150,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -174,13 +174,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -192,7 +192,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -204,7 +204,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -220,7 +220,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -236,7 +236,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -250,7 +250,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -262,7 +262,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -275,7 +275,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -284,7 +284,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -299,13 +299,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -322,7 +322,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -339,14 +339,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -359,7 +359,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -384,28 +384,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -417,7 +417,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -429,7 +429,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -443,7 +443,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -459,13 +459,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: No
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -477,7 +477,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -498,13 +498,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/) for documentation.
 
 **Active by default**: No
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -516,7 +516,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -525,7 +525,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -537,7 +537,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 Although this is a standard rule it is not enabled by default like other standard ktlint rules. ktlint only enables
@@ -558,7 +558,7 @@ intellij_idea by default.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -570,38 +570,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -610,13 +610,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -629,39 +629,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -673,25 +673,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -703,21 +703,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -730,7 +730,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -746,7 +746,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -762,7 +762,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -775,7 +775,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -791,25 +791,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -821,77 +821,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: No
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -904,13 +904,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -922,7 +922,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#strin
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -941,7 +941,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -960,7 +960,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -973,14 +973,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -993,14 +993,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1013,28 +1013,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1047,7 +1047,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.7.1/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/rules/ktlint.md
+++ b/website/versioned_docs/version-2.0.0-alpha.2/rules/ktlint.md
@@ -8,7 +8,7 @@ folder: documentation
 ---
 Rule Set ID: `ktlint`
 
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `ktlint` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -30,7 +30,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -42,13 +42,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -68,14 +68,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -92,14 +92,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: No
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -112,14 +112,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: No
@@ -140,7 +140,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -152,14 +152,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -176,13 +176,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -194,7 +194,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -206,7 +206,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -222,7 +222,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -252,7 +252,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -264,7 +264,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -277,7 +277,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -286,7 +286,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -301,13 +301,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -324,7 +324,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -341,14 +341,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -361,7 +361,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -386,28 +386,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -419,7 +419,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -431,7 +431,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -445,7 +445,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -461,13 +461,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -479,7 +479,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -500,13 +500,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -518,7 +518,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -527,7 +527,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -539,7 +539,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 Although this is a standard rule it is not enabled by default like other standard ktlint rules. ktlint only enables
@@ -560,7 +560,7 @@ intellij_idea by default.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -572,38 +572,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -612,13 +612,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: No
@@ -631,39 +631,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: No
 
@@ -675,25 +675,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -705,21 +705,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -732,7 +732,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -748,7 +748,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -764,7 +764,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -777,7 +777,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -793,25 +793,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -823,77 +823,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -906,13 +906,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -924,13 +924,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#strin
 
 ### ThenSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#then-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#then-spacing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -949,7 +949,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -968,7 +968,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -981,14 +981,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1001,14 +1001,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1021,28 +1021,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1055,7 +1055,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 

--- a/website/versioned_docs/version-2.0.0-alpha.3/rules/ktlint.md
+++ b/website/versioned_docs/version-2.0.0-alpha.3/rules/ktlint.md
@@ -8,7 +8,7 @@ folder: documentation
 ---
 Rule Set ID: `ktlint`
 
-This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/.
+This rule set provides wrappers for rules implemented by ktlint - https://ktlint.github.io/ktlint/.
 
 **Note: The `ktlint` rule set is not included in the detekt-cli or Gradle plugin.**
 
@@ -30,7 +30,7 @@ Note: Issues reported by this rule set can only be suppressed on file level (`@f
 
 ### AnnotationOnSeparateLine
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annotation-formatting) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#annotation-formatting) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -42,13 +42,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annot
 
 ### AnnotationSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#annotation-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#annotation-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ArgumentListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#argument-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#argument-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -68,14 +68,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#argum
 
 ### BackingPropertyNaming
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#backing-property-naming)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#backing-property-naming)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### BinaryExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#binary-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#binary-expression-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -92,14 +92,14 @@ documentation.
 
 ### BlankLineBeforeDeclaration
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-before-declarations) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-before-declarations) for
 documentation.
 
 **Active by default**: No
 
 ### BlankLineBetweenWhenConditions
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#blank-lines-between-when-conditions)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#blank-lines-between-when-conditions)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -112,14 +112,14 @@ for documentation.
 
 ### BlockCommentInitialStarAlignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#block-comment-initial-star-alignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#block-comment-initial-star-alignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ChainMethodContinuation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain-method-continuation)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#chain-method-continuation)
 for documentation.
 
 **Active by default**: No
@@ -140,7 +140,7 @@ for documentation.
 
 ### ChainWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#chain-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -152,14 +152,14 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#chain
 
 ### ClassName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#class-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#class-naming) for
 documentation.
 
 **Active by default**: No
 
 ### ClassSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#class-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#class-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -176,13 +176,13 @@ documentation.
 
 ### CommentSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comment-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comment-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### CommentWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comment-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comment-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -194,7 +194,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comme
 
 ### ConditionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#condition-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#condition-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -206,7 +206,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#condi
 
 ### ContextReceiverListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#context-receiver-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#context-receiver-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -222,7 +222,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#conte
 
 ### ContextReceiverMapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#content-receiver-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#content-receiver-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -238,7 +238,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#conte
 
 ### EnumEntryNameCase
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-entry) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#enum-entry) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -252,7 +252,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-
 
 ### EnumWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#enum-wrapping) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -264,7 +264,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#enum-
 
 ### ExpressionOperandWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#expression-operand-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#expression-operand-wrapping) for
 documentation.
 
 **Active by default**: No
@@ -277,7 +277,7 @@ documentation.
 
 ### Filename
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#file-name) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#file-name) for documentation.
 
 This rules overlaps with [naming>MatchingDeclarationName](https://detekt.dev/naming.html#matchingdeclarationname)
 from the standard rules, make sure to enable just one.
@@ -286,7 +286,7 @@ from the standard rules, make sure to enable just one.
 
 ### FinalNewline
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#final-newline) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#final-newline) for documentation.
 
 This rules overlaps with [style>NewLineAtEndOfFile](https://detekt.dev/style.html#newlineatendoffile)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -301,13 +301,13 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### FunKeywordSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#fun-keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#fun-keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionExpressionBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-expression-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-expression-body)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -324,7 +324,7 @@ for documentation.
 
 ### FunctionLiteral
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-literal) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-literal) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -341,14 +341,14 @@ documentation.
 
 ### FunctionName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-naming) for
 documentation.
 
 **Active by default**: No
 
 ### FunctionReturnTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-return-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-return-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
@@ -361,7 +361,7 @@ documentation.
 
 ### FunctionSignature
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-signature) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-signature) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -386,28 +386,28 @@ documentation.
 
 ### FunctionStartOfBodySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-start-of-body-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-start-of-body-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### FunctionTypeModifierSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-type-modifier-spacing)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-type-modifier-spacing)
 for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### FunctionTypeReferenceSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#function-type-reference-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#function-type-reference-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### IfElseBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-else-bracing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#if-else-bracing) for documentation.
 
 **Active by default**: No
 
@@ -419,7 +419,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-el
 
 ### IfElseWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-else-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#if-else-wrapping) for documentation.
 
 **Active by default**: No
 
@@ -431,7 +431,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#if-el
 
 ### ImportOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#import-ordering) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#import-ordering) for documentation.
 
 For defining import layout patterns see the [KtLint Source Code](https://github.com/pinterest/ktlint/blob/0.50.0/ktlint-ruleset-standard/src/main/kotlin/com/pinterest/ktlint/ruleset/standard/rules/ImportOrderingRule.kt)
 
@@ -445,7 +445,7 @@ For defining import layout patterns see the [KtLint Source Code](https://github.
 
 ### Indentation
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#indentation) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#indentation) for documentation.
 
 **Active by default**: Yes - Since v1.19.0
 
@@ -465,13 +465,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#inden
 
 ### Kdoc
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#kdoc) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#kdoc) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### KdocWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#kdoc-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#kdoc-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -483,7 +483,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#kdoc-
 
 ### MaximumLineLength
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#max-line-length) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#max-line-length) for documentation.
 
 This rules overlaps with [style>MaxLineLength](https://detekt.dev/style.html#maxlinelength)
 from the standard rules, make sure to enable just one or keep them aligned.
@@ -504,13 +504,13 @@ from the standard rules, make sure to enable just one or keep them aligned.
 
 ### MixedConditionOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ModifierListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modifier-list-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#modifier-list-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -522,7 +522,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modif
 
 ### ModifierOrdering
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#modifier-order) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#modifier-order) for documentation.
 
 This rules overlaps with [style>ModifierOrder](https://detekt.dev/style.html#modifierorder)
 from the standard rules, make sure to enable just one. The pro of this rule is that it can auto-correct the issue.
@@ -531,7 +531,7 @@ from the standard rules, make sure to enable just one. The pro of this rule is t
 
 ### MultiLineIfElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-if-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-if-else) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
@@ -543,7 +543,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multi
 
 ### MultilineExpressionWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-expression-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-expression-wrapping) for
 documentation.
 
 Although this is a standard rule it is not enabled by default like other standard ktlint rules. ktlint only enables
@@ -564,7 +564,7 @@ intellij_idea by default.
 
 ### MultilineLoop
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multiline-loop) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#multiline-loop) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
@@ -576,38 +576,38 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#multi
 
 ### NoBlankLineBeforeRbrace
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-before) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-before) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoBlankLineInList
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-list) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-list) for documentation.
 
 **Active by default**: No
 
 ### NoBlankLinesInChainedMethodCalls
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-blank-lines-in-chained-method-calls) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoConsecutiveBlankLines
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-blank-lines) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-blank-lines) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoConsecutiveComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-comments) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-consecutive-comments) for documentation.
 
 **Active by default**: No
 
 ### NoEmptyClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-class-bodies) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-class-bodies) for documentation.
 
 This rules overlaps with [empty-blocks>EmptyClassBlock](https://detekt.dev/empty-blocks.html#emptyclassblock)
 from the standard rules, make sure to enable just one.
@@ -616,13 +616,13 @@ from the standard rules, make sure to enable just one.
 
 ### NoEmptyFile
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-file) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-file) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### NoEmptyFirstLineInClassBody
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-empty-first-line-at-start-in-class-body)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-empty-first-line-at-start-in-class-body)
 for documentation.
 
 **Active by default**: No
@@ -635,39 +635,39 @@ for documentation.
 
 ### NoEmptyFirstLineInMethodBlock
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-leading-empty-lines-in-method-blocks) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### NoLineBreakAfterElse
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-line-break-after-else) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-line-break-after-else) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoLineBreakBeforeAssignment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-line-break-before-assignment) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-line-break-before-assignment) for
 documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoMultipleSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-multi-spaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-multi-spaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSemicolons
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-semicolons) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-semicolons) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoSingleLineBlockComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-single-line-block-comment) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-single-line-block-comment) for documentation.
 
 **Active by default**: No
 
@@ -679,25 +679,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-si
 
 ### NoTrailingSpaces
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-trailing-whitespaces) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-trailing-whitespaces) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnitReturn
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-unit-as-return-type) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-unit-as-return-type) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoUnusedImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-unused-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-unused-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### NoWildcardImports
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-wildcard-imports) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#no-wildcard-imports) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -709,21 +709,21 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#no-wi
 
 ### NullableTypeSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#nullable-type-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#nullable-type-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### PackageName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#package-name) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#package-name) for
 documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### ParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -736,7 +736,7 @@ documentation.
 
 ### ParameterListWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-list-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-list-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -752,7 +752,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#param
 
 ### ParameterWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parameter-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parameter-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -768,7 +768,7 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#param
 
 ### PropertyName
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#property-naming) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#property-naming) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -781,7 +781,7 @@ documentation.
 
 ### PropertyWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#property-wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#property-wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
@@ -797,25 +797,25 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#prope
 
 ### SpacingAroundAngleBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#angle-bracket-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#angle-bracket-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundComma
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#comma-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#comma-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundCurly
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#curly-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#curly-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
@@ -827,77 +827,77 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#curly
 
 ### SpacingAroundDot
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#dot-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#dot-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundDoubleColon
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#double-colon-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#double-colon-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingAroundKeyword
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#keyword-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#keyword-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundOperators
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundParens
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#parenthesis-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#parenthesis-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundRangeOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#range-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#range-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### SpacingAroundSquareBrackets
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#square-brackets-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#square-brackets-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### SpacingAroundUnaryOperator
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#unary-operator-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#unary-operator-spacing) for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithAnnotations
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declarations-with-annotations)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declarations-with-annotations)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenDeclarationsWithComments
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declaration-with-comments)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#blank-line-between-declaration-with-comments)
 for documentation.
 
 **Active by default**: Yes - Since v1.22.0
 
 ### SpacingBetweenFunctionNameAndOpeningParenthesis
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#spacing-between-function-name-and-opening-parenthesis) for
 documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### StatementWrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#statement-wrapping) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#statement-wrapping) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -910,13 +910,13 @@ documentation.
 
 ### StringTemplate
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#string-template) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#string-template) for documentation.
 
 **Active by default**: Yes - Since v1.0.0
 
 ### StringTemplateIndent
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#string-template-indent) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#string-template-indent) for documentation.
 
 **Active by default**: No
 
@@ -928,13 +928,13 @@ See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#strin
 
 ### ThenSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#then-spacing) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#then-spacing) for documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TrailingCommaOnCallSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-call-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-call-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -953,7 +953,7 @@ trailing comma usage yet.
 
 ### TrailingCommaOnDeclarationSite
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#trailing-comma-on-declaration-site) for documentation.
 
 The default config comes from ktlint and follows these conventions:
 - [Kotlin coding convention](https://kotlinlang.org/docs/coding-conventions.html#trailing-commas) recommends
@@ -972,7 +972,7 @@ trailing comma usage yet.
 
 ### TryCatchFinallySpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#try-catch-finally-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#try-catch-finally-spacing) for
 documentation.
 
 **Active by default**: No
@@ -985,14 +985,14 @@ documentation.
 
 ### TypeArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeArgumentListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#type-argument-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#type-argument-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1005,14 +1005,14 @@ documentation.
 
 ### TypeParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### TypeParameterListSpacing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#type-parameter-list-spacing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#type-parameter-list-spacing) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
@@ -1025,28 +1025,28 @@ documentation.
 
 ### UnnecessaryParenthesesBeforeTrailingLambda
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#unnecessary-parenthesis-before-trailing-lambda)
 for documentation.
 
 **Active by default**: Yes - Since v1.23.0
 
 ### ValueArgumentComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### ValueParameterComment
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/) for
 documentation.
 
 **Active by default**: Yes - Since v2.0.0
 
 ### WhenEntryBracing
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/experimental/#when-entry-bracing) for
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/experimental/#when-entry-bracing) for
 documentation.
 
 **Active by default**: No
@@ -1059,7 +1059,7 @@ documentation.
 
 ### Wrapping
 
-See [ktlint docs](https://pinterest.github.io/ktlint/1.8.0/rules/standard/#wrapping) for documentation.
+See [ktlint docs](https://ktlint.github.io/ktlint/1.8.0/rules/standard/#wrapping) for documentation.
 
 **Active by default**: Yes - Since v1.20.0
 


### PR DESCRIPTION
Fixes #9353

## Summary
- update ktlint documentation links from `pinterest.github.io/ktlint` to the current `ktlint.github.io/ktlint` base while preserving each documented ktlint version path
- update the ktlint wrapper provider homepage reference to include the new `/ktlint/` base
- regenerate documentation so the versioned docs stay aligned with wrapper KDoc

## Root cause
Ktlint documentation moved to the `https://ktlint.github.io/ktlint/` base path. The detekt ktlint rule docs still pointed at the previous `pinterest.github.io/ktlint` host, so rule links on the docs site could land on stale or moved locations.

## Validation
- `./gradlew.bat generateDocumentation --no-configuration-cache`
- `./gradlew.bat :detekt-rules-ktlint-wrapper:compileKotlin --no-configuration-cache`
- `git diff --check`
- confirmed no remaining `pinterest.github.io/ktlint` links in the repo

## Security
Documentation-only link update. No runtime code, dependency, auth, storage, or network behavior changes.

## AI assistance disclosure
Prepared with AI assistance and local verification; I reviewed the diff and validation output before submitting.