### PR TITLE
Switch to vanniktech/gradle-maven-publish-plugin for publishing

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -39,8 +39,8 @@ jobs:
 
       - name: Deploy Snapshot
         env:
-          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PWD: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
-          ORG_GRADLE_PROJECT_SONATYPE_USERNAME: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_PASSWORD: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
-        run: ./gradlew publishToSonatype -Dsnapshot=true --stacktrace
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNING_PWD }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_GRADLE_PROJECT_SONATYPE_PASSWORD }}
+        run: ./gradlew publishToMavenCentral -Dsnapshot=true --stacktrace

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation(libs.develocity.plugin)
     implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.gradleNexus.publish.plugin)
+    implementation(libs.vanniktech.maven.publish.plugin)
     implementation(libs.semver4j)
     implementation(libs.breadmoirai.githubRelease.plugin)
     implementation(libs.dokka.plugin)

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 dependencies {
     implementation(libs.develocity.plugin)
     implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.vanniktech.maven.publish.plugin)
+    implementation(libs.vanniktech.mavenPublish.plugin)
     implementation(libs.semver4j)
     implementation(libs.breadmoirai.githubRelease.plugin)
     implementation(libs.dokka.plugin)

--- a/build-logic/src/main/kotlin/Constants.kt
+++ b/build-logic/src/main/kotlin/Constants.kt
@@ -1,1 +1,0 @@
-const val DETEKT_PUBLICATION = "DetektPublication"

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 plugins {
     id("packaging")
     kotlin("jvm")
-    id("maven-publish")
     id("jacoco")
 }
 
@@ -128,7 +127,6 @@ dependencies {
 
 java {
     withSourcesJar()
-    withJavadocJar()
     sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     if (project.name !in setOf("detekt-gradle-plugin", "detekt-test-junit")) {

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -126,7 +126,6 @@ dependencies {
 }
 
 java {
-    withSourcesJar()
     sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     if (project.name !in setOf("detekt-gradle-plugin", "detekt-test-junit")) {

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -126,6 +126,7 @@ dependencies {
 }
 
 java {
+    withSourcesJar()
     sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     if (project.name !in setOf("detekt-gradle-plugin", "detekt-test-junit")) {

--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -1,56 +1,40 @@
 plugins {
     id("java-library")
-    id("maven-publish")
-    id("signing")
+    id("com.vanniktech.maven.publish")
 }
 
-publishing {
-    // We don't need to configure publishing for the Gradle plugin.
-    if (project.name != "detekt-gradle-plugin") {
-        publications.register<MavenPublication>(DETEKT_PUBLICATION) {
-            from(components["java"])
-        }
-    }
-    publications.withType<MavenPublication> {
-        artifactId = project.name
-        version = Versions.currentOrSnapshot()
-        pom {
-            description = "Static code analysis for Kotlin"
-            name = "detekt"
-            url = "https://detekt.dev"
-            licenses {
-                license {
-                    name = "The Apache Software License, Version 2.0"
-                    url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                    distribution = "repo"
-                }
-            }
-            developers {
-                developer {
-                    id = "detekt Developers"
-                    name = "detekt Developers"
-                    email = "info@detekt.dev"
-                }
-            }
-            scm {
-                url = "https://github.com/detekt/detekt"
-            }
-        }
-    }
-}
-
-val signingKey = "SIGNING_KEY".byProperty
-val signingPwd = "SIGNING_PWD".byProperty
-if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
+val signingKey = providers.gradleProperty("signingInMemoryKey").orNull
+if (signingKey.isNullOrBlank()) {
     logger.info("Signing disabled as the GPG key was not found")
 } else {
     logger.info("GPG Key found - Signing enabled")
 }
 
-signing {
-    useInMemoryPgpKeys(signingKey, signingPwd)
-    sign(publishing.publications)
-    isRequired = !(signingKey.isNullOrBlank() || signingPwd.isNullOrBlank())
+mavenPublishing {
+    publishToMavenCentral()
+    if (!signingKey.isNullOrBlank()) {
+        signAllPublications()
+    }
+    pom {
+        description = "Static code analysis for Kotlin"
+        name = "detekt"
+        url = "https://detekt.dev"
+        licenses {
+            license {
+                name = "The Apache Software License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "repo"
+            }
+        }
+        developers {
+            developer {
+                id = "detekt Developers"
+                name = "detekt Developers"
+                email = "info@detekt.dev"
+            }
+        }
+        scm {
+            url = "https://github.com/detekt/detekt"
+        }
+    }
 }
-
-val String.byProperty: String? get() = providers.gradleProperty(this).orNull

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -2,18 +2,6 @@ import org.semver4j.Semver
 
 plugins {
     id("com.github.breadmoirai.github-release")
-    id("io.github.gradle-nexus.publish-plugin")
-}
-
-nexusPublishing {
-    repositories {
-        create("sonatype") {
-            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
-            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
-            username = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_USERNAME")
-            password = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_PASSWORD")
-        }
-    }
 }
 
 val releaseArtifacts = configurations.dependencyScope("releaseArtifacts")
@@ -105,15 +93,12 @@ tasks.register("publishToMavenLocal") {
     dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToMavenLocal"))
 }
 
-tasks.register("publishToSonatype") {
-    description = "Publish included builds to Sonatype"
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToSonatype"))
+tasks.register("publishToMavenCentral") {
+    description = "Publish included builds to Maven Central"
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishToMavenCentral"))
 }
 
-tasks.named("closeSonatypeStagingRepository").configure {
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":closeSonatypeStagingRepository"))
-}
-
-tasks.named("releaseSonatypeStagingRepository").configure {
-    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":releaseSonatypeStagingRepository"))
+tasks.register("publishAndReleaseToMavenCentral") {
+    description = "Publish and release included builds to Maven Central"
+    dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":publishAndReleaseToMavenCentral"))
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -46,7 +46,7 @@ shadow {
 }
 
 publishing {
-    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+    publications.withType<MavenPublication>().configureEach {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -46,7 +46,7 @@ shadow {
 }
 
 publishing {
-    publications.named<MavenPublication>("maven") {
+    publications.withType<MavenPublication>().configureEach {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -46,7 +46,7 @@ shadow {
 }
 
 publishing {
-    publications.withType<MavenPublication>().configureEach {
+    publications.named<MavenPublication>("maven") {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -47,7 +47,9 @@ shadow {
 
 publishing {
     publications.withType<MavenPublication>().configureEach {
-        artifact(tasks.shadowJar)
+        if (name == "maven") {
+            artifact(tasks.shadowJar)
+        }
     }
 }
 

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ shadow {
 }
 
 publishing {
-    publications.named<MavenPublication>(DETEKT_PUBLICATION) {
+    publications.withType<MavenPublication>().configureEach {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -37,7 +37,9 @@ shadow {
 
 publishing {
     publications.withType<MavenPublication>().configureEach {
-        artifact(tasks.shadowJar)
+        if (name == "maven") {
+            artifact(tasks.shadowJar)
+        }
     }
 }
 

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ shadow {
 }
 
 publishing {
-    publications.withType<MavenPublication>().configureEach {
+    publications.named<MavenPublication>("maven") {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -36,7 +36,7 @@ shadow {
 }
 
 publishing {
-    publications.named<MavenPublication>("maven") {
+    publications.withType<MavenPublication>().configureEach {
         artifact(tasks.shadowJar)
     }
 }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -20,9 +20,7 @@ plugins {
     id("dev.detekt") version "2.0.0-alpha.3"
     id("org.jetbrains.kotlinx.binary-compatibility-validator") version "0.18.1"
     id("org.jetbrains.dokka") version "2.2.0"
-    id("signing")
     id("com.github.gmazzo.buildconfig") version "6.0.10"
-    id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
 
 group = "dev.detekt"
@@ -32,17 +30,6 @@ buildConfig {
     buildConfigField("DETEKT_VERSION", project.version.toString())
     buildConfigField("DETEKT_COMPILER_PLUGIN_VERSION", project.version.toString())
     buildConfigField("KOTLIN_IMPLEMENTATION_VERSION", libs.versions.kotlin.get())
-}
-
-nexusPublishing {
-    repositories {
-        create("sonatype") {
-            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
-            snapshotRepositoryUrl = uri("https://central.sonatype.com/repository/maven-snapshots/")
-            username = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_USERNAME")
-            password = providers.environmentVariable("ORG_GRADLE_PROJECT_SONATYPE_PASSWORD")
-        }
-    }
 }
 
 detekt {
@@ -201,20 +188,6 @@ gradlePlugin {
         sourceSets["functionalTest"],
         sourceSets["functionalTestMinSupportedGradle"],
     )
-}
-
-signing {
-    val signingKey = providers.gradleProperty("SIGNING_KEY").orNull
-    val signingPwd = providers.gradleProperty("SIGNING_PWD").orNull
-    if (signingKey.isNullOrBlank() || signingPwd.isNullOrBlank()) {
-        logger.info("Signing disabled as the GPG key was not found")
-    } else {
-        logger.info("GPG Key found - Signing enabled")
-    }
-
-    useInMemoryPgpKeys(signingKey, signingPwd)
-    sign(publishing.publications)
-    isRequired = !(signingKey.isNullOrBlank() || signingPwd.isNullOrBlank())
 }
 
 tasks {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ android-gradle-builtInKotlin-plugin = { module = "com.android.built-in-kotlin:co
 breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
 develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version = "4.4.2" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
-vanniktech-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.36.0" }
+vanniktech-mavenPublish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.36.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # This represents the oldest AGP 9 version that is supported by detekt.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ android-gradle-builtInKotlin-plugin = { module = "com.android.built-in-kotlin:co
 breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
 develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version = "4.4.2" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
-gradleNexus-publish-plugin = { module = "io.github.gradle-nexus:publish-plugin", version = "2.0.0" }
+vanniktech-maven-publish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.36.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 # This represents the oldest AGP 9 version that is supported by detekt.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,8 +2,9 @@
 set -e
 gradle publishToMavenLocal
 gradle build
-gradle publishToSonatype closeSonatypeStagingRepository --no-configuration-cache
+# Uploads artifacts to Central Portal. After all steps complete, release manually at
+# https://central.sonatype.com/publishing — or replace with publishAndReleaseToMavenCentral to release automatically.
+gradle publishToMavenCentral
 gradle :detekt-gradle-plugin:publishPlugins
 gradle githubRelease --no-configuration-cache
 gradle applyDocVersion
-gradle releaseSonatypeStagingRepository --no-configuration-cache


### PR DESCRIPTION
Fixes #8404

This PR migrates the project to use `vanniktech/gradle-maven-publish-plugin` plugin.

Changes:
- packaging.gradle.kts: replace maven-publish + signing with vanniktech DSL; signing is conditional on signingInMemoryKey property being set
- module.gradle.kts: remove withJavadocJar() (vanniktech handles javadoc); remove explicit maven-publish plugin application
- releasing.gradle.kts: remove nexusPublishing block; replace publishToSonatype/close/release tasks with publishToMavenCentral and publishAndReleaseToMavenCentral
- detekt-gradle-plugin: remove nexus plugin, nexusPublishing block and manual signing block (handled by packaging convention plugin)
- detekt-cli/detekt-compiler-plugin: use withType<MavenPublication>() instead of named(DETEKT_PUBLICATION) since publication name changed
- CI: rename env vars to vanniktech's conventions (same secrets, new names)
- scripts/release.sh: update task names