### PR TITLE
Enable writing annotations to Kotlin metadata

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
             // Only enable progressive mode in non-DGP modules. DGP doesn't compile with latest language version so
             // progressive mode is not appropriate.
             progressiveMode = true
+            freeCompilerArgs.add("-Xannotations-in-metadata")
         } else {
             freeCompilerArgs.add("-Xjvm-default=all")
         }

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
 
     testImplementation(libs.assertj.core)
     testImplementation(libs.kctfork.core)
+    testCompileOnly(libs.jetbrains.annotations)
 }
 
 shadow {

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     testImplementation(testFixtures(projects.detektApi))
     testImplementation(libs.classgraph)
     testImplementation(libs.assertj.core)
+    testCompileOnly(libs.jetbrains.annotations)
     testRuntimeOnly(libs.slf4j.simple)
 }
 

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
+    testCompileOnly(libs.jetbrains.annotations)
 }
 
 val generateCliOptions = tasks.register<JavaExec>("generateCliOptions") {

--- a/detekt-psi-utils/build.gradle.kts
+++ b/detekt-psi-utils/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     testImplementation(libs.assertj.core)
     testImplementation(projects.detektTestJunit)
     testImplementation(projects.detektTestUtils)
+    testCompileOnly(libs.jetbrains.annotations)
 }
 
 detekt {

--- a/detekt-rules-comments/build.gradle.kts
+++ b/detekt-rules-comments/build.gradle.kts
@@ -12,4 +12,5 @@ dependencies {
     testImplementation(projects.detektTestAssertj)
     testImplementation(libs.assertj.core)
     testImplementation(projects.detektApi)
+    testCompileOnly(libs.jetbrains.annotations)
 }

--- a/detekt-rules-coroutines/build.gradle.kts
+++ b/detekt-rules-coroutines/build.gradle.kts
@@ -17,4 +17,5 @@ dependencies {
     testImplementation(libs.assertj.core)
 
     testRuntimeOnly(libs.kotlinx.coroutinesTest)
+    testCompileOnly(libs.jetbrains.annotations)
 }

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     testImplementation(libs.classgraph)
 
     testRuntimeOnly(libs.slf4j.nop)
+    testCompileOnly(libs.jetbrains.annotations)
+
     extraDepsToPackage(libs.slf4j.nop)
 }
 

--- a/detekt-rules-style/build.gradle.kts
+++ b/detekt-rules-style/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     testImplementation(projects.detektTestJunit)
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
+    testCompileOnly(libs.jetbrains.annotations)
 }

--- a/detekt-test/build.gradle.kts
+++ b/detekt-test/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+    compileOnly(libs.jetbrains.annotations)
     api(projects.detektApi)
     implementation(testFixtures(projects.detektApi))
     api(projects.detektTestUtils)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,8 @@ assertj-core = { module = "org.assertj:assertj-core", version = "3.27.7" }
 assertj-coreMinimum = { module = "org.assertj:assertj-core", version = "3.27.4" }
 classgraph = { module = "io.github.classgraph:classgraph", version = "4.8.184" }
 jcommander = { module = "org.jcommander:jcommander", version = "1.85" }
-jetbrains-annotations = { module = "org.jetbrains:annotations", version = "26.1.0" }
+# Version must align to dependency used by Kotlin on compile classpath due to our use of Gradle's consistent resolution
+jetbrains-annotations = { module = "org.jetbrains:annotations", version = "23.0.0" }
 kctfork-core = { module = "dev.zacsweers.kctfork:core", version = "0.12.1" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }


### PR DESCRIPTION
Writing annotations to Kotlin metadata is enabled by default in language version 2.4. When enabled the dependency analysis plugin flags some new issues. In the Kotlin 2.4 PR the flag will be removed, but the other changes here are necessary.

https://kotlinlang.org/docs/whatsnew22.html#support-for-reading-and-writing-annotations-in-kotlin-metadata
https://youtrack.jetbrains.com/issue/KT-75736/Enable-reading-writing-annotations-in-metadata-on-JVM-by-default