### PR TITLE
Update test to avoid typealias to compiler-required annotation

### DIFF
--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenAnnotationSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenAnnotationSpec.kt
@@ -215,13 +215,13 @@ class ForbiddenAnnotationSpec(val env: KotlinEnvironmentContainer) {
     @Test
     fun `should report aliased annotations`() {
         val code = """
-            typealias Dep = java.lang.Deprecated
-            @Dep
-            fun f() = Unit
+            typealias Doc = java.lang.annotation.Documented
+            @Doc
+            annotation class AnnotationClass
         """.trimIndent()
         val findings = ForbiddenAnnotation(Config.empty).lintWithContext(env, code)
         assertThat(findings).singleElement()
-            .hasTextLocation("@Dep")
+            .hasTextLocation("@Doc")
     }
 
     @Test


### PR DESCRIPTION
Required for Kotlin 2.4

https://youtrack.jetbrains.com/issue/KT-79369/Forbid-typealiasing-for-all-compiler-required-annotations