### PR TITLE
fix: prevent ArrayPrimitive crash on unresolved types

### DIFF
--- a/detekt-rules-performance/src/main/kotlin/dev/detekt/rules/performance/ArrayPrimitive.kt
+++ b/detekt-rules-performance/src/main/kotlin/dev/detekt/rules/performance/ArrayPrimitive.kt
@@ -52,12 +52,17 @@ class ArrayPrimitive(config: Config) :
         }
     }
 
+    // Workaround for KT-77222: analyze() throws InvalidFirElementTypeException
+    // when PSI elements have no FIR representation (e.g. unresolved types).
+    // Remove runCatching once the upstream issue is fixed.
     private fun KtCallExpression.returnsArrayPrimitive(): Boolean =
-        analyze(this) {
-            val functionCall = resolveToCall()?.singleFunctionCallOrNull() ?: return false
-            val returnType = functionCall.signature.returnType
-            return returnType.arrayElementType?.isPrimitive == true
-        }
+        runCatching {
+            analyze(this) {
+                val functionCall = resolveToCall()?.singleFunctionCallOrNull() ?: return false
+                val returnType = functionCall.signature.returnType
+                returnType.arrayElementType?.isPrimitive == true
+            }
+        }.getOrDefault(false)
 
     override fun visitNamedDeclaration(declaration: KtNamedDeclaration) {
         super.visitNamedDeclaration(declaration)
@@ -72,10 +77,13 @@ class ArrayPrimitive(config: Config) :
             .forEach { report(Finding(Entity.from(it), description)) }
     }
 
+    // Workaround for KT-77222: see returnsArrayPrimitive above.
     private fun KtTypeReference.isArrayPrimitive(): Boolean =
-        analyze(this) {
-            type.symbol?.classId == StandardClassIds.Array && type.arrayElementType?.isPrimitive == true
-        }
+        runCatching {
+            analyze(this) {
+                type.symbol?.classId == StandardClassIds.Array && type.arrayElementType?.isPrimitive == true
+            }
+        }.getOrDefault(false)
 
     companion object {
         private val factoryMethodFqNames = listOf(

--- a/detekt-rules-performance/src/test/kotlin/dev/detekt/rules/performance/ArrayPrimitiveSpec.kt
+++ b/detekt-rules-performance/src/test/kotlin/dev/detekt/rules/performance/ArrayPrimitiveSpec.kt
@@ -4,6 +4,7 @@ import dev.detekt.api.Config
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
+import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -261,6 +262,33 @@ class ArrayPrimitiveSpec(val env: KotlinEnvironmentContainer) {
         fun isEmptyArrayString() {
             val code = "val a = emptyArray<String>()"
             assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `unresolved types` {
+        @Test
+        fun `does not crash when analysis throws an exception in returnsArrayPrimitive`() {
+            // Resolves #9362
+            val code = "fun foo() { arrayOf(1) }"
+            val ktFile = compileContentForTest(code)
+            val result = subject.visitFile(
+                ktFile,
+                org.jetbrains.kotlin.config.LanguageVersionSettingsImpl.DEFAULT,
+            )
+            assertThat(result).isEmpty()
+        }
+
+        @Test
+        fun `does not crash when analysis throws an exception in isArrayPrimitive`() {
+            // Resolves #9362
+            val code = "fun foo(x: Array<Int>) {}"
+            val ktFile = compileContentForTest(code)
+            val result = subject.visitFile(
+                ktFile,
+                org.jetbrains.kotlin.config.LanguageVersionSettingsImpl.DEFAULT,
+            )
+            assertThat(result).isEmpty()
         }
     }
 }


### PR DESCRIPTION
Resolves #9362 by wrapping type and call analysis calls in runCatching to handle resolution errors gracefully when classpaths are incomplete.