### PR TITLE
Stop Renovate creating PRs for org.jetbrains:annotations

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,7 @@
   ],
   "ignoreDeps": [
     "com.android.tools.build:gradle-api",
+    "org.jetbrains:annotations",
     "org.jetbrains.kotlin:kotlin-gradle-plugin-api",
     "org.junit.jupiter:junit-jupiter-api"
   ],


### PR DESCRIPTION
We need to declare this dependency in multiple places with the Kotlin 2.4 release due to changes in how annotations are included in Kotlin metadata. Kotlin compiler depends on an older version. Because we use consistent dependency resolution we need to align the version in libs.versions.toml with the version Kotlin compiler depends on, so we don't want Renovate suggesting updates that will cause the build to fail.