### PR TITLE
fix(gradle): resolve generated classes under AGP built-in Kotlin

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
@@ -636,6 +636,7 @@ class DetektAndroidBuiltInKotlinSpec {
                 fun libDetektMain() {
                     gradleRunner.runTasksAndCheckResult(":app:detektMain") { buildResult ->
                         assertThat(buildResult.output).doesNotContain("UnreachableCode")
+                        assertThat(buildResult.output).doesNotContain("compiler errors found during analysis")
                     }
                 }
 
@@ -644,6 +645,57 @@ class DetektAndroidBuiltInKotlinSpec {
                 fun libDetektTest() {
                     gradleRunner.runTasksAndCheckResult(":app:detektTest") { buildResult ->
                         assertThat(buildResult.output).doesNotContain("UnreachableCode")
+                        assertThat(buildResult.output).doesNotContain("compiler errors found during analysis")
+                    }
+                }
+            }
+
+            @Nested
+            inner class `analysis classpath includes generated sources` {
+                val projectLayout = ProjectLayout(
+                    numberOfSourceFilesInRootPerSourceDir = 0,
+                ).apply {
+                    addSubmodule(
+                        name = "app",
+                        numberOfSourceFilesPerSourceDir = 0,
+                        numberOfFindings = 0,
+                        buildFileContent = joinGradleBlocks(
+                            appPluginBlock(pluginApplied),
+                            ANDROID_BLOCK_WITH_GENERATED_SOURCES,
+                            DETEKT_BASELINE_BLOCK,
+                        ),
+                        srcDirs = listOf("src/main/java"),
+                    )
+                }
+                val gradleRunner = createGradleRunnerAndSetupProject(projectLayout, propertyEnabled, dryRun = false)
+                    .also {
+                        it.projectFile("app/src/main/java").mkdirs()
+                        it.projectFile("app/src/main/res/values").mkdirs()
+                        it.writeProjectFile("app/src/main/AndroidManifest.xml", manifestContent)
+                        it.writeProjectFile("app/src/main/res/values/strings.xml", SAMPLE_STRING_RESOURCE)
+                        it.writeProjectFile("app/src/main/java/Sample.kt", SAMPLE_USING_GENERATED_SOURCES)
+                    }
+
+                // Regression for AGP built-in Kotlin: classes compiled from generated Java sources
+                // (BuildConfig, and view binding in real projects) must be on detekt's type-resolution
+                // classpath, else detekt logs "compiler errors found during analysis" and silently
+                // degrades type-aware rules. (R already resolves via the Kotlin compile classpath.)
+                // --rerun-tasks so the always-on build cache cannot mask a regression with a cached
+                // result; the load-bearing assertion is the absence of the "compiler errors found
+                // during analysis" header, which detekt prints unconditionally on unresolved symbols.
+                @Test
+                @DisplayName("task :app:detektMain resolves generated BuildConfig")
+                fun detektMainResolvesGeneratedClasses() {
+                    gradleRunner.runTasksAndCheckResult(":app:detektMain", "--rerun-tasks") { buildResult ->
+                        assertThat(buildResult.output).doesNotContain("compiler errors found during analysis")
+                    }
+                }
+
+                @Test
+                @DisplayName("task :app:detektBaselineMain resolves generated BuildConfig")
+                fun detektBaselineMainResolvesGeneratedClasses() {
+                    gradleRunner.runTasksAndCheckResult(":app:detektBaselineMain", "--rerun-tasks") { buildResult ->
+                        assertThat(buildResult.output).doesNotContain("compiler errors found during analysis")
                     }
                 }
             }
@@ -791,6 +843,49 @@ private val SAMPLE_ACTIVITY_USING_VIEW_BINDING = """
         }
     }
     
+""".trimIndent() // Last line to prevent NewLineAtEndOfFile.
+
+@Language("gradle.kts")
+private val ANDROID_BLOCK_WITH_GENERATED_SOURCES = """
+    android {
+        compileSdk = 34
+        namespace = "dev.detekt.app"
+        defaultConfig {
+            applicationId = "dev.detekt.app"
+            minSdk = 24
+        }
+        buildFeatures {
+            buildConfig = true
+        }
+    }
+""".trimIndent()
+
+@Language("gradle.kts")
+private val DETEKT_BASELINE_BLOCK = """
+    detekt {
+        baseline = file("build/detekt-baseline.xml")
+    }
+""".trimIndent()
+
+@Language("xml")
+private val SAMPLE_STRING_RESOURCE = """
+    <?xml version="1.0" encoding="utf-8"?>
+    <resources>
+        <string name="app_name">detekt</string>
+    </resources>
+""".trimIndent()
+
+@Language("kotlin")
+private val SAMPLE_USING_GENERATED_SOURCES = """
+    import dev.detekt.app.BuildConfig
+    import dev.detekt.app.R
+
+    object Sample {
+        // BuildConfig is generated into a class directory; R is generated into a class jar.
+        fun isDebug(): Boolean = BuildConfig.DEBUG
+        fun appNameRes(): Int = R.string.app_name
+    }
+
 """.trimIndent() // Last line to prevent NewLineAtEndOfFile.
 
 private fun appPluginBlock(applyBuiltInPlugin: Boolean) =

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
@@ -676,13 +676,6 @@ class DetektAndroidBuiltInKotlinSpec {
                         it.writeProjectFile("app/src/main/java/Sample.kt", SAMPLE_USING_GENERATED_SOURCES)
                     }
 
-                // Regression for AGP built-in Kotlin: classes compiled from generated Java sources
-                // (BuildConfig, and view binding in real projects) must be on detekt's type-resolution
-                // classpath, else detekt logs "compiler errors found during analysis" and silently
-                // degrades type-aware rules. (R already resolves via the Kotlin compile classpath.)
-                // --rerun-tasks so the always-on build cache cannot mask a regression with a cached
-                // result; the load-bearing assertion is the absence of the "compiler errors found
-                // during analysis" header, which detekt prints unconditionally on unresolved symbols.
                 @Test
                 @DisplayName("task :app:detektMain resolves generated BuildConfig")
                 fun detektMainResolvesGeneratedClasses() {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -35,8 +35,10 @@ import dev.detekt.gradle.plugin.isWorkerApiEnabled
 import org.gradle.api.Action
 import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
@@ -90,6 +92,18 @@ abstract class Detekt @Inject constructor(
 
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
+
+    /**
+     * Classes compiled from this project's generated sources (e.g. BuildConfig and view binding),
+     * folded into [classpath] so generated types resolve under AGP built-in Kotlin. Empty for
+     * JVM/KMP. Internal wiring: AGP only exposes these via `ScopedArtifact.CLASSES`, whose `toGet`
+     * requires task-owned [ListProperty] sinks.
+     */
+    @get:Internal
+    internal abstract val generatedClassesJars: ListProperty<RegularFile>
+
+    @get:Internal
+    internal abstract val generatedClassesDirs: ListProperty<Directory>
 
     @get:Input
     @get:Optional

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -93,12 +93,6 @@ abstract class Detekt @Inject constructor(
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
 
-    /**
-     * Classes compiled from this project's generated sources (e.g. BuildConfig and view binding),
-     * folded into [classpath] so generated types resolve under AGP built-in Kotlin. Empty for
-     * JVM/KMP. Internal wiring: AGP only exposes these via `ScopedArtifact.CLASSES`, whose `toGet`
-     * requires task-owned [ListProperty] sinks.
-     */
     @get:Internal
     internal abstract val generatedClassesJars: ListProperty<RegularFile>
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
@@ -28,8 +28,10 @@ import dev.detekt.gradle.invoke.ParallelArgument
 import dev.detekt.gradle.plugin.isWorkerApiEnabled
 import org.gradle.api.Incubating
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileTree
+import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
@@ -83,6 +85,18 @@ abstract class DetektCreateBaselineTask @Inject constructor(
 
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
+
+    /**
+     * Classes compiled from this project's generated sources (e.g. BuildConfig and view binding),
+     * folded into [classpath] so generated types resolve under AGP built-in Kotlin. Empty for
+     * JVM/KMP. Internal wiring: AGP only exposes these via `ScopedArtifact.CLASSES`, whose `toGet`
+     * requires task-owned [ListProperty] sinks.
+     */
+    @get:Internal
+    internal abstract val generatedClassesJars: ListProperty<RegularFile>
+
+    @get:Internal
+    internal abstract val generatedClassesDirs: ListProperty<Directory>
 
     @get:Console
     abstract val debug: Property<Boolean>

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
@@ -86,12 +86,6 @@ abstract class DetektCreateBaselineTask @Inject constructor(
     @get:Internal
     abstract val friendPaths: ConfigurableFileCollection
 
-    /**
-     * Classes compiled from this project's generated sources (e.g. BuildConfig and view binding),
-     * folded into [classpath] so generated types resolve under AGP built-in Kotlin. Empty for
-     * JVM/KMP. Internal wiring: AGP only exposes these via `ScopedArtifact.CLASSES`, whose `toGet`
-     * requires task-owned [ListProperty] sinks.
-     */
     @get:Internal
     internal abstract val generatedClassesJars: ListProperty<RegularFile>
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -1,7 +1,9 @@
 package dev.detekt.gradle.plugin.internal
 
+import com.android.build.api.artifact.ScopedArtifact
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Component
+import com.android.build.api.variant.ScopedArtifacts
 import com.android.build.api.variant.Variant
 import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.plugin.DetektPlugin
@@ -28,18 +30,30 @@ internal object DetektAndroidCompilations {
     ) {
         val kotlin = sources.kotlin?.all ?: return
         val source = project.objects.fileCollection().from(kotlin)
+        val componentArtifacts = artifacts
         kotlinAndroid.target.compilations.matching { it.name == name }
             .configureEach { compilation ->
-                project.registerJvmCompilationDetektTask(
+                val detektTask = project.registerJvmCompilationDetektTask(
                     extension = extension,
                     compilation = compilation,
                     source = source,
                 )
-                project.registerJvmCompilationCreateBaselineTask(
+                val baselineTask = project.registerJvmCompilationCreateBaselineTask(
                     extension = extension,
                     compilation = compilation,
                     source = source,
                 )
+                // Put this component's compiled classes (including classes compiled from generated
+                // Java sources such as BuildConfig and view binding) on detekt's type-resolution
+                // classpath. Built-in Kotlin excludes generated sources from the analyzed source set,
+                // so without their classes type resolution fails on those symbols. ScopedArtifact.CLASSES
+                // (PROJECT scope) also wires the compile dependency.
+                componentArtifacts.forScope(ScopedArtifacts.Scope.PROJECT)
+                    .use(detektTask)
+                    .toGet(ScopedArtifact.CLASSES, { it.generatedClassesJars }, { it.generatedClassesDirs })
+                componentArtifacts.forScope(ScopedArtifacts.Scope.PROJECT)
+                    .use(baselineTask)
+                    .toGet(ScopedArtifact.CLASSES, { it.generatedClassesJars }, { it.generatedClassesDirs })
             }
     }
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/DetektAndroidCompilations.kt
@@ -43,11 +43,6 @@ internal object DetektAndroidCompilations {
                     compilation = compilation,
                     source = source,
                 )
-                // Put this component's compiled classes (including classes compiled from generated
-                // Java sources such as BuildConfig and view binding) on detekt's type-resolution
-                // classpath. Built-in Kotlin excludes generated sources from the analyzed source set,
-                // so without their classes type resolution fails on those symbols. ScopedArtifact.CLASSES
-                // (PROJECT scope) also wires the compile dependency.
                 componentArtifacts.forScope(ScopedArtifacts.Scope.PROJECT)
                     .use(detektTask)
                     .toGet(ScopedArtifact.CLASSES, { it.generatedClassesJars }, { it.generatedClassesDirs })

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -9,6 +9,7 @@ import dev.detekt.gradle.plugin.DetektPlugin
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
 import org.jetbrains.kotlin.gradle.dsl.ExplicitApiMode
 import org.jetbrains.kotlin.gradle.dsl.KotlinBaseExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
@@ -20,19 +21,23 @@ internal fun Project.registerJvmCompilationDetektTask(
     compilation: KotlinCompilation<*>,
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
-) {
+): TaskProvider<Detekt> {
     val taskSuffix =
         if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
-    tasks.register(
+    return tasks.register(
         DetektPlugin.DETEKT_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
         Detekt::class.java
     ) { detektTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         detektTask.source(source)
+        // classpath also carries this project's generated classes (populated for Android variants in
+        // DetektAndroidCompilations; empty for JVM/KMP), so type resolution can resolve generated types.
         detektTask.classpath.conventionCompat(
             compilation.output.classesDirs,
-            siblingTask.map { it.libraries }
+            siblingTask.map { it.libraries },
+            detektTask.generatedClassesJars,
+            detektTask.generatedClassesDirs
         )
         detektTask.friendPaths.conventionCompat(
             compilation.output.classesDirs,
@@ -78,19 +83,23 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     compilation: KotlinCompilation<*>,
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
-) {
+): TaskProvider<DetektCreateBaselineTask> {
     val taskSuffix =
         if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
-    tasks.register(
+    return tasks.register(
         DetektPlugin.BASELINE_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
         DetektCreateBaselineTask::class.java,
     ) { createBaselineTask ->
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         createBaselineTask.source(source)
+        // classpath also carries this project's generated classes (populated for Android variants in
+        // DetektAndroidCompilations; empty for JVM/KMP), so type resolution can resolve generated types.
         createBaselineTask.classpath.conventionCompat(
             compilation.output.classesDirs,
-            siblingTask.map { it.libraries }
+            siblingTask.map { it.libraries },
+            createBaselineTask.generatedClassesJars,
+            createBaselineTask.generatedClassesDirs
         )
         createBaselineTask.friendPaths.conventionCompat(
             compilation.output.classesDirs,

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -31,8 +31,6 @@ internal fun Project.registerJvmCompilationDetektTask(
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         detektTask.source(source)
-        // classpath also carries this project's generated classes (populated for Android variants in
-        // DetektAndroidCompilations; empty for JVM/KMP), so type resolution can resolve generated types.
         detektTask.classpath.conventionCompat(
             compilation.output.classesDirs,
             siblingTask.map { it.libraries },
@@ -93,8 +91,6 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         val siblingTask = compilation.compileTaskProvider.map { it as KotlinJvmCompile }
 
         createBaselineTask.source(source)
-        // classpath also carries this project's generated classes (populated for Android variants in
-        // DetektAndroidCompilations; empty for JVM/KMP), so type resolution can resolve generated types.
         createBaselineTask.classpath.conventionCompat(
             compilation.output.classesDirs,
             siblingTask.map { it.libraries },


### PR DESCRIPTION
Fixes #9402

## Problem

Under AGP built-in Kotlin, the type-resolution tasks (`detektMain` / `detektDebug` and the matching `detektBaseline*` tasks) run with an incomplete classpath: the variant's compiled generated classes (BuildConfig, and other javac-compiled generated Java like view binding) are not on the analysis classpath. So detekt can't resolve references to those generated types, logs `compiler errors found during analysis`, and emits false positives from type-resolution rules such as `UnusedPrivateFunction` and `RedundantSuspendModifier`. This has been the case since built-in Kotlin support landed in #9100.

The only workaround is keeping the legacy `kotlin-android` plugin plus `android.builtInKotlin=false` / `android.newDsl=false`, all of which are removed in AGP 10.

## Fix

Put each Android variant's compiled classes onto the detekt and baseline task classpaths via `Artifacts.forScope(PROJECT).use(task).toGet(ScopedArtifact.CLASSES, ...)`, folded into the existing `classpath`. AGP only exposes the compiled generated classes through `ScopedArtifact.CLASSES`, and its `toGet` requires `ListProperty` sinks on the consuming task, so the two sinks (`generatedClassesJars` / `generatedClassesDirs`) are kept `internal`. This also establishes the compile dependency so the generated classes exist when detekt runs. JVM and KMP compilations are unaffected.

## Tests

- New functional tests assert `detektMain` and `detektBaselineMain` resolve generated `BuildConfig`.
- Strengthen the existing built-in-Kotlin "javac intermediates" (view binding) test, which previously only asserted `doesNotContain("UnreachableCode")`, a check that passes even when types are unresolved.

## Related

- Builds on #8320 (built-in Kotlin task registration).
- Should also resolve #9304 (types from excluded files become resolvable via the classpath) and remove the #9293 "compiler errors found during analysis" noise.
