### PR TITLE
fix: exclude gradle-public-api from published POM

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -130,7 +130,7 @@ val testKitGradleMinVersionRuntimeOnly = configurations.register("testKitGradleM
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
-    compileOnlyApi(libs.gradle.publicApi) {
+    compileOnly(libs.gradle.publicApi) {
         capabilities {
             // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
             requireCapability("org.gradle.experimental:gradle-public-api-internal")

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -136,6 +136,11 @@ dependencies {
             requireCapability("org.gradle.experimental:gradle-public-api-internal")
         }
     }
+    testFixturesCompileOnly(libs.gradle.publicApi) {
+        capabilities {
+            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+        }
+    }
 
     implementation(libs.sarif4k)
 

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -130,15 +130,23 @@ val testKitGradleMinVersionRuntimeOnly = configurations.register("testKitGradleM
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
-    compileOnly(libs.gradle.publicApi) {
-        capabilities {
-            // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
-            requireCapability("org.gradle.experimental:gradle-public-api-internal")
-        }
-    }
-    testFixturesCompileOnly(libs.gradle.publicApi) {
-        capabilities {
-            requireCapability("org.gradle.experimental:gradle-public-api-internal")
+
+    // gradle-public-api is consumed compile-only across every source set: production code,
+    // tests, fixtures, and functional tests all rely on Gradle types provided by the runtime
+    // (the user's Gradle distribution or the embedded TestKit). compileOnly keeps it out of
+    // the published POM (compileOnlyApi would re-add it as a compile-scope dep). See #9396.
+    listOf(
+        "compileOnly",
+        "testCompileOnly",
+        "testFixturesCompileOnly",
+        "functionalTestCompileOnly",
+        "functionalTestMinSupportedGradleCompileOnly",
+    ).forEach { configurationName ->
+        configurationName(libs.gradle.publicApi) {
+            capabilities {
+                // https://github.com/gradle/gradle/issues/29483#issuecomment-2791668178
+                requireCapability("org.gradle.experimental:gradle-public-api-internal")
+            }
         }
     }
 


### PR DESCRIPTION
`compileOnlyApi` causes the vanniktech maven publish plugin to emit `gradle-public-api` as `compile` scope in the POM, requiring consumers to configure the Gradle libs-releases repository. Since this dependency is only used internally and is always provided by the Gradle runtime, `compileOnly` is the correct scope — which excludes it from the POM.

Fixes #9396