### PR TITLE
Stop accepting unsupported API or language versions passed to CLI

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/ArgumentConverters.kt
@@ -13,23 +13,27 @@ import java.nio.file.Path
 import kotlin.io.path.exists
 import kotlin.io.path.isDirectory
 
+private val supportedLanguageVersions = LanguageVersion.entries
+    .filterNot(LanguageVersion::isUnsupported)
+    .joinToString { it.toString() }
 class ApiVersionConverter : IStringConverter<ApiVersion> {
     override fun convert(value: String): ApiVersion {
         val languageVersion = LanguageVersion.fromFullVersionString(value)
-        requireNotNull(languageVersion) {
-            val validValues = LanguageVersion.entries.joinToString { it.toString() }
-            "\"$value\" passed to --api-version, expected one of [$validValues]"
+        require(languageVersion != null && !languageVersion.isUnsupported) {
+            "\"$value\" passed to --api-version, expected one of [$supportedLanguageVersions]"
         }
         return ApiVersion.createByLanguageVersion(languageVersion)
     }
 }
 
 class LanguageVersionConverter : IStringConverter<LanguageVersion> {
-    override fun convert(value: String): LanguageVersion =
-        requireNotNull(LanguageVersion.fromFullVersionString(value)) {
-            val validValues = LanguageVersion.entries.joinToString { it.toString() }
-            "\"$value\" passed to --language-version, expected one of [$validValues]"
+    override fun convert(value: String): LanguageVersion {
+        val languageVersion = LanguageVersion.fromFullVersionString(value)
+        require(languageVersion != null && !languageVersion.isUnsupported) {
+            "\"$value\" passed to --language-version, expected one of [$supportedLanguageVersions]"
         }
+        return languageVersion
+    }
 }
 
 class JvmTargetConverter : IStringConverter<JvmTarget> {

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -368,29 +368,47 @@ internal class CliArgsSpec {
         }
 
         @Test
-        fun `--api-version is accepted`() {
-            val spec = parseArguments(arrayOf("--api-version", "1.9")).toSpec()
-            assertThat(spec.compilerSpec.apiVersion).isEqualTo("1.9")
+        fun `supported --api-version is accepted`() {
+            val spec = parseArguments(arrayOf("--api-version", "2.5")).toSpec()
+            assertThat(spec.compilerSpec.apiVersion).isEqualTo("2.5")
+        }
+
+        @Test
+        fun `unsupported --api-version returns error message`() {
+            assertThatIllegalArgumentException()
+                .isThrownBy { parseArguments(arrayOf("--api-version", "1.9")) }
+                .withMessageStartingWith("\"1.9\" passed to --api-version, expected one of [2.0, 2.1, 2.2, 2.3, 2.4, ")
         }
 
         @Test
         fun `invalid --api-version returns error message`() {
             assertThatIllegalArgumentException()
-                .isThrownBy { parseArguments(arrayOf("--api-version", "0.1")) }
-                .withMessageStartingWith("\"0.1\" passed to --api-version, expected one of [1.0, 1.1, 1.2, 1.3, 1.4, ")
+                .isThrownBy { parseArguments(arrayOf("--api-version", "x")) }
+                .withMessageStartingWith("\"x\" passed to --api-version, expected one of [2.0, 2.1, 2.2, 2.3, 2.4, ")
         }
 
         @Test
-        fun `--language-version is accepted`() {
-            val spec = parseArguments(arrayOf("--language-version", "1.6")).toSpec()
-            assertThat(spec.compilerSpec.languageVersion).isEqualTo("1.6")
+        fun `supported --language-version is accepted`() {
+            val spec = parseArguments(arrayOf("--language-version", "2.5")).toSpec()
+            assertThat(spec.compilerSpec.languageVersion).isEqualTo("2.5")
+        }
+
+        @Test
+        fun `unsupported --language-version returns error message`() {
+            assertThatIllegalArgumentException()
+                .isThrownBy { parseArguments(arrayOf("--language-version", "1.9")) }
+                .withMessageStartingWith(
+                    "\"1.9\" passed to --language-version, expected one of [2.0, 2.1, 2.2, 2.3, 2.4, "
+                )
         }
 
         @Test
         fun `invalid --language-version returns error message`() {
             assertThatIllegalArgumentException()
-                .isThrownBy { parseArguments(arrayOf("--language-version", "2")) }
-                .withMessageStartingWith("\"2\" passed to --language-version, expected one of [1.0, 1.1, 1.2, 1.3, ")
+                .isThrownBy { parseArguments(arrayOf("--language-version", "x")) }
+                .withMessageStartingWith(
+                    "\"x\" passed to --language-version, expected one of [2.0, 2.1, 2.2, 2.3, 2.4, "
+                )
         }
 
         @Test


### PR DESCRIPTION
Kotlin 2.4 stopped supporting API and language versions 1.9 and below, see [KT-80590](https://youtrack.jetbrains.com/issue/KT-80590). This PR updates the CLI arguments so it only accepts API & language versions that are supported by the compiler (currently 2.0 to 2.5).

Fixes #8048 