### PR TITLE
fixed the issue of guard clauses

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/Junk.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/Junk.kt
@@ -8,7 +8,6 @@ import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtIfExpression
-import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtSuperExpression
@@ -34,7 +33,7 @@ inline fun <reified T : KtExpression> KtNamedFunction.yieldStatementsSkippingGua
         this@yieldStatementsSkippingGuardClauses.bodyBlockExpression?.statements?.forEach {
             if (firstNonGuardFound) {
                 yield(it)
-            } else if (!it.isGuardClause<T>() && !it.isSuperCall() && !it.isScopedAssignment()) {
+            } else if (!it.isGuardClause<T>() && !it.isSuperCall() && !it.isLocalVariableDeclaration()) {
                 firstNonGuardFound = true
                 yield(it)
             }
@@ -43,8 +42,7 @@ inline fun <reified T : KtExpression> KtNamedFunction.yieldStatementsSkippingGua
 
 fun KtExpression.isSuperCall(): Boolean = (this as? KtDotQualifiedExpression)?.receiverExpression is KtSuperExpression
 
-fun KtExpression.isScopedAssignment(): Boolean =
-    this is KtProperty && !isVar && (initializer as? KtNameReferenceExpression)?.getReferencedName() == name
+fun KtExpression.isLocalVariableDeclaration(): Boolean = this is KtProperty
 
 inline fun <reified T : KtExpression> KtExpression.isGuardClause(): Boolean {
     val descendantExpr = this.findDescendantOfType<T>() ?: return false

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
@@ -186,11 +186,11 @@ class ReturnCountSpec {
     inner class `a file with guard clauses interleaved with local variable declarations` {
         private val code = """
             fun test(a: Int?, b: Int?): Int {
-                val first = compute(a)
+                val first = a.toString()
                 if (a == null) return 0
-                val second = compute(b)
+                val second = b.toString()
                 if (b == null) return 1
-                return first + second
+                return first.length + second.length
             }
         """.trimIndent()
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ReturnCountSpec.kt
@@ -183,6 +183,33 @@ class ReturnCountSpec {
     }
 
     @Nested
+    inner class `a file with guard clauses interleaved with local variable declarations` {
+        private val code = """
+            fun test(a: Int?, b: Int?): Int {
+                val first = compute(a)
+                if (a == null) return 0
+                val second = compute(b)
+                if (b == null) return 1
+                return first + second
+            }
+        """.trimIndent()
+
+        @Test
+        fun `should not count guard clauses that follow local variable declarations`() {
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to true))
+                .lint(code)
+            assertThat(findings).isEmpty()
+        }
+
+        @Test
+        fun `should count the returns when the guard clause option is disabled`() {
+            val findings = ReturnCount(TestConfig(EXCLUDE_GUARD_CLAUSES to false))
+                .lint(code)
+            assertThat(findings).hasSize(1)
+        }
+    }
+
+    @Nested
     inner class `a file with multiple guard clauses` {
         val code = """
             var x = 1
@@ -725,7 +752,7 @@ class ReturnCountSpec {
         }
 
         @Test
-        fun `should not ignore scoped assignments that don't use the same name`() {
+        fun `should ignore local variable declarations that don't use the same name`() {
             val code = """
                 open class A {
                     var data: ByteArray = ByteArray(0)
@@ -749,7 +776,7 @@ class ReturnCountSpec {
                     MAX to 1,
                 )
             ).lint(code)
-            assertThat(findings).hasSize(1)
+            assertThat(findings).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
@@ -208,6 +208,33 @@ class ThrowsCountSpec {
     }
 
     @Nested
+    inner class `guard clauses interleaved with local variable declarations` {
+        val codeWithGuardClause = """
+            fun test(a: Int?, b: Int?): Int {
+                val first = compute(a)
+                if (a == null) throw IllegalArgumentException()
+                val second = compute(b)
+                if (b == null) throw IllegalArgumentException()
+                throw IllegalStateException((first + second).toString())
+            }
+        """.trimIndent()
+
+        @Test
+        fun `should not count guard clauses that follow local variable declarations`() {
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to true)
+            val subject = ThrowsCount(config)
+            assertThat(subject.lint(codeWithGuardClause)).isEmpty()
+        }
+
+        @Test
+        fun `should count the throws when the guard clause option is disabled`() {
+            val config = TestConfig(EXCLUDE_GUARD_CLAUSES to false)
+            val subject = ThrowsCount(config)
+            assertThat(subject.lint(codeWithGuardClause)).hasSize(1)
+        }
+    }
+
+    @Nested
     inner class `reports a too-complicated if statement for being a guard clause` {
         val codeWithIfCondition = """
             fun test(x: Int): Int {

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ThrowsCountSpec.kt
@@ -211,11 +211,11 @@ class ThrowsCountSpec {
     inner class `guard clauses interleaved with local variable declarations` {
         val codeWithGuardClause = """
             fun test(a: Int?, b: Int?): Int {
-                val first = compute(a)
+                val first = a.toString()
                 if (a == null) throw IllegalArgumentException()
-                val second = compute(b)
+                val second = b.toString()
                 if (b == null) throw IllegalArgumentException()
-                throw IllegalStateException((first + second).toString())
+                throw IllegalStateException(first + second)
             }
         """.trimIndent()
 


### PR DESCRIPTION
Fixes #8993 

## Problem

When `excludeGuardClauses = true` then ReturnCount and ThrowsCount should not count guard clauses but if function was starting with normal local variable declaration then the guard clause coming after it  was counted as well which results in false positive.

Root cause lies in file Junk.kt method `yieldStatementsSkippingGuardClauses` which keeps flag firstNonGuardFound. The moment statement isn't guard clause, this flag becomes true and after that every statement is counted. A local val/var declaration was treated as such a non-guard statement, so it was ending the guard section too early.

## Fix

We generalized the exisiting `isScopedAssignment` helper into `isLocalVariableDeclaration` , earlier only `val x = x` was transparent now it's valid for any local var/val declaration. Also added the test cases to both ReturnCountSpec.kt and ThrowsCountSpec.kt for guard clauses interleaved with local variable declarations and one existing test updated. 
The one updated test "(should not ignore scoped .... )" reflects this a differently named local like val data1= data no longer ends the guard section. This maybe slightly broadens #7931 @eygraber 

## Testing

First Reproduced bug as a failing test using issue's scenario before the fix it failed with same message from issue after the fix, new tests pass and all exisiting ReturnCount/ThrowsCount test still pass.

@schalkms 