### PR TITLE
Fail tests on Gradle warnings

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidBuiltInKotlinSpec.kt
@@ -841,4 +841,5 @@ private fun createGradleRunnerAndSetupProject(
         "android.builtInKotlin" to gradleKotlinPropertyEnabled.toString(),
     ),
     dryRun = dryRun,
+    failOnGradleWarnings = false, // https://issuetracker.google.com/issues/495889752
 ).also { it.setupProject() }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektAndroidSpec.kt
@@ -898,4 +898,5 @@ private fun createGradleRunnerAndSetupProject(projectLayout: ProjectLayout, dryR
             "android.newDsl" to "false",
         ),
         dryRun = dryRun,
+        failOnGradleWarnings = false, // https://issuetracker.google.com/issues/495889752
     ).also { it.setupProject() }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -544,6 +544,7 @@ private fun setupProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGrad
 
 private fun setupAndroidProject(projectLayoutAction: ProjectLayout.() -> Unit): DslGradleRunner {
     val gradleRunner = setupProject { projectLayoutAction() }
+        .also { it.failOnGradleWarnings = false } // https://issuetracker.google.com/issues/495889752
     gradleRunner.writeProjectFile("shared/src/androidMain/AndroidManifest.xml", manifestContent)
     gradleRunner.writeProjectFile("shared/src/androidDebug/AndroidManifest.xml", manifestContent)
     gradleRunner.writeProjectFile("shared/src/androidRelease/AndroidManifest.xml", manifestContent)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektReportMergeSpec.kt
@@ -15,7 +15,7 @@ class DetektReportMergeSpec {
         val buildFileContent = """
             ${builder.gradlePlugins.reIndent()}
             
-            val sarifReportMerge by tasks.registering(dev.detekt.gradle.report.ReportMergeTask::class) {
+            val sarifReportMerge = tasks.register<dev.detekt.gradle.report.ReportMergeTask>("sarifReportMerge") {
                 output.set(project.layout.buildDirectory.file("reports/detekt/merge.sarif"))
             }
             
@@ -87,7 +87,7 @@ class DetektReportMergeSpec {
         val buildFileContent = """
             ${builder.gradlePlugins.reIndent()}
             
-            val checkstyleReportMerge by tasks.registering(dev.detekt.gradle.report.ReportMergeTask::class) {
+            val checkstyleReportMerge = tasks.register<dev.detekt.gradle.report.ReportMergeTask>("checkstyleReportMerge") {
                 output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
             }
             

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/plugin/DetektBasePluginSpec.kt
@@ -76,6 +76,7 @@ class DetektBasePluginSpec {
                 "android.newDsl" to "false",
             ),
             dryRun = true,
+            failOnGradleWarnings = false, // Test uses deprecated sourceSets collection in Kotlin Android
         ).also {
             it.setupProject()
         }
@@ -120,6 +121,7 @@ class DetektBasePluginSpec {
                 "android.disallowKotlinSourceSets" to "false",
             ),
             dryRun = true,
+            failOnGradleWarnings = false, // https://issuetracker.google.com/issues/495889752
         ).also {
             it.setupProject()
         }
@@ -219,6 +221,7 @@ class DetektBasePluginSpec {
                 }
             """.trimIndent(),
             dryRun = true,
+            failOnGradleWarnings = false, // https://issuetracker.google.com/issues/495889752
         ).also {
             it.setupProject()
         }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/report/ReportMergeSpec.kt
@@ -37,7 +37,7 @@ class ReportMergeSpec {
                 id("dev.detekt")
             }
             
-            val reportMerge by tasks.registering(dev.detekt.gradle.report.ReportMergeTask::class) {
+            val reportMerge = tasks.register<dev.detekt.gradle.report.ReportMergeTask>("reportMerge") {
                 output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
                 outputs.cacheIf { false }
                 outputs.upToDateWhen { false }
@@ -146,7 +146,7 @@ class ReportMergeSpec {
                 id("dev.detekt")
             }
             
-            val reportMerge by tasks.registering(dev.detekt.gradle.report.ReportMergeTask::class) {
+            val reportMerge = tasks.register<dev.detekt.gradle.report.ReportMergeTask>("reportMerge") {
                 output.set(project.layout.buildDirectory.file("reports/detekt/merge.xml"))
                 outputs.cacheIf { false }
                 outputs.upToDateWhen { false }

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/report/ReportMergeSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/report/ReportMergeSpec.kt
@@ -182,6 +182,7 @@ class ReportMergeSpec {
             settingsContent = settingsFile,
             jvmArgs = jvmArgs,
             disableIP = true,
+            failOnGradleWarnings = false, // https://issuetracker.google.com/issues/495889752
         )
 
         gradleRunner.setupProject()

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -23,6 +23,7 @@ constructor(
     val gradleVersionOrNone: String? = null,
     val dryRun: Boolean = false,
     var disableIP: Boolean = false,
+    var failOnGradleWarnings: Boolean = true,
     val jvmArgs: String = "-Xmx2g -XX:MaxMetaspaceSize=1g",
     val gradleProperties: Map<String, String> = emptyMap(),
     val customPluginClasspath: List<File> = emptyList(),
@@ -143,6 +144,9 @@ constructor(
             }
             if (!disableIP) {
                 add("-Dorg.gradle.unsafe.isolated-projects=true")
+            }
+            if (failOnGradleWarnings) {
+                add("--warning-mode=fail")
             }
             addAll(gradleProperties.toList().map { (key, value) -> "-P$key=$value" })
             addAll(tasks)


### PR DESCRIPTION
Helps keep our tests up to date as new Gradle deprecations are introduced, minimising impact of the eventual update to Gradle 10.