### PR TITLE
Fix CognitiveComplexMethod false positive for object literal methods

### DIFF
--- a/detekt-metrics/src/main/kotlin/dev/detekt/metrics/CognitiveComplexity.kt
+++ b/detekt-metrics/src/main/kotlin/dev/detekt/metrics/CognitiveComplexity.kt
@@ -17,6 +17,7 @@ import org.jetbrains.kotlin.psi.KtForExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtObjectLiteralExpression
 import org.jetbrains.kotlin.psi.KtParenthesizedExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -25,6 +26,7 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 import org.jetbrains.kotlin.psi.psiUtil.collectDescendantsOfType
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 
 /**
  * Kotlin implementation of the cognitive complexity metric.
@@ -135,12 +137,15 @@ class CognitiveComplexity private constructor() : DetektVisitor() {
         }
 
         override fun visitNamedFunction(function: KtNamedFunction) {
-            if (function != givenFunction) {
-                nestAround { super.visitNamedFunction(function) }
-            } else {
+            if (function == givenFunction) {
                 super.visitNamedFunction(function)
+            } else if (!isInsideObjectLiteral(function)) {
+                nestAround { super.visitNamedFunction(function) }
             }
         }
+
+        private fun isInsideObjectLiteral(function: KtNamedFunction) =
+            function.getStrictParentOfType<KtObjectLiteralExpression>() != null
 
         override fun visitCatchSection(catchClause: KtCatchClause) {
             addComplexity()

--- a/detekt-metrics/src/test/kotlin/dev/detekt/metrics/CognitiveComplexitySpec.kt
+++ b/detekt-metrics/src/test/kotlin/dev/detekt/metrics/CognitiveComplexitySpec.kt
@@ -164,6 +164,34 @@ class CognitiveComplexitySpec {
         assertThat(CognitiveComplexity.calculate(code)).isEqualTo(2)
     }
 
+    @Test
+    fun `does not count functions declared inside an object literal`() {
+        val code = compileContentForTest(
+            """
+                fun main() = object {
+                    fun run() { if (true) {} }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
+    }
+
+    @Test
+    fun `does not count functions in an object literal returned from a function`() {
+        val code = compileContentForTest(
+            """
+                fun makeRunnable(): Runnable {
+                    return object : Runnable {
+                        override fun run() { if (true) {} }
+                    }
+                }
+            """.trimIndent()
+        )
+
+        assertThat(CognitiveComplexity.calculate(code)).isEqualTo(0)
+    }
+
     @Nested
     inner class `binary expressions` {
 


### PR DESCRIPTION
Fixes #5560.

`CognitiveComplexMethod` counted functions declared inside an anonymous object literal toward the outer function's complexity, so a function returning an `object : Foo { ... }` was scored as if that object's methods were its own. `CyclomaticComplexity` already skips these via `isInsideObjectLiteral`. This adds the same guard to `CognitiveComplexity`, which is what arturbosch suggested on the issue.

Added two regression tests, one for a bare anonymous object and one for an object returned from a function.

AI-assisted (Claude), reviewed and tested locally.
