### PR TITLE
Fix `CanBeNonNullable` false negative on local variables

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/CanBeNonNullable.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/CanBeNonNullable.kt
@@ -22,7 +22,6 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaVariableSymbol
 import org.jetbrains.kotlin.analysis.api.types.KaTypeParameterType
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallExpression
@@ -83,6 +82,11 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
  *         get() = 5
  * }
  *
+ * fun foo() {
+ *     var a: Int? = 5
+ *     a = 6
+ * }
+ *
  * fun foo(a: Int?) {
  *     val b = a!! + 2
  * }
@@ -111,6 +115,11 @@ import org.jetbrains.kotlin.util.OperatorNameConventions
  * class A {
  *     val a: Int
  *         get() = 5
+ * }
+ *
+ * fun foo() {
+ *     var a: Int = 5
+ *     a = 6
  * }
  *
  * fun foo(a: Int) {
@@ -474,7 +483,7 @@ class CanBeNonNullable(config: Config) :
         // the declaration, so they could potentially be marked as non-nullable
         // if the file does not encounter these properties being assigned
         // a nullable value.
-        private val candidateProps = mutableMapOf<FqName, KtProperty>()
+        private val candidateProps = mutableSetOf<KtProperty>()
 
         override fun visitKtFile(file: KtFile) {
             file.collectCandidateProps()
@@ -482,7 +491,7 @@ class CanBeNonNullable(config: Config) :
             // Any candidate properties that were not removed during the inspection
             // of the Kotlin file were never assigned nullable values in the code,
             // thus they can be converted to non-nullable.
-            candidateProps.forEach { (_, property) ->
+            candidateProps.forEach { property ->
                 report(
                     Finding(
                         Entity.from(property),
@@ -494,41 +503,43 @@ class CanBeNonNullable(config: Config) :
 
         private fun KtFile.collectCandidateProps() {
             forEachDescendantOfType<KtProperty> { property ->
-                val fqName = property.fqName
-                if (fqName != null && property.isCandidate()) {
-                    candidateProps[fqName] = property
+                // Locals have no FqName, so admit them explicitly.
+                if ((property.fqName != null || property.isLocal) && property.isCandidate()) {
+                    candidateProps.add(property)
                 }
             }
         }
 
         override fun visitBinaryExpression(expression: KtBinaryExpression) {
             if (expression.operationToken == KtTokens.EQ) {
-                val fqName = expression.left
+                val assignedProperty = expression.left
                     ?.let {
                         analyze(it) {
                             it.resolveToCall()
                                 ?.singleVariableAccessCall()
                                 ?.symbol
-                                ?.callableId
-                                ?.asSingleFqName()
+                                ?.psi as? KtProperty
                         }
                     }
                 if (
-                    fqName != null &&
-                    candidateProps.containsKey(fqName) &&
+                    assignedProperty != null &&
+                    assignedProperty in candidateProps &&
                     expression.right?.isNullableType() == true
                 ) {
-                    // A candidate property has been assigned a nullable value
-                    // in the file's code, so it can be removed from the map of
-                    // candidates for flagging.
-                    candidateProps.remove(fqName)
+                    // Assigned a nullable value, so it can't be made non-nullable.
+                    candidateProps.remove(assignedProperty)
                 }
             }
             super.visitBinaryExpression(expression)
         }
 
+        private fun KtProperty.isExcludedMember(): Boolean =
+            isOpen() || isAbstract() || containingClass()?.isInterface() == true
+
         private fun KtProperty.isCandidate(): Boolean {
-            if (isOpen() || isAbstract() || containingClass()?.isInterface() == true) return false
+            // containingClass() crosses function boundaries, so without the isLocal check a local
+            // var inside an interface's default method would be wrongly excluded.
+            if (!isLocal && isExcludedMember()) return false
             val propertyType = this.typeReference ?: return false
 
             analyze(propertyType) {
@@ -539,7 +550,7 @@ class CanBeNonNullable(config: Config) :
                 getter?.isNullableType() != true &&
                 delegate?.returnsNullable() != true
             val cannotSetViaNonPrivateMeans =
-                !isVar || (isPrivate() || (setter?.isPrivate() == true))
+                isLocal || !isVar || (isPrivate() || (setter?.isPrivate() == true))
             return isSetToNonNullable && cannotSetViaNonPrivateMeans
         }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/CanBeNonNullableSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/CanBeNonNullableSpec.kt
@@ -933,6 +933,73 @@ class CanBeNonNullableSpec(val env: KotlinEnvironmentContainer) {
     }
 
     @Nested
+    inner class `evaluating local properties` {
+        @Test
+        fun `reports when a local var is never assigned a nullable value`() {
+            val code = """
+                fun baz() {
+                    var g: Int? = 1
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports when a local var is only ever reassigned non-nullable values`() {
+            val code = """
+                fun baz() {
+                    var g: Int? = 1
+                    g = 2
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports a local val with a non-nullable initializer`() {
+            val code = """
+                fun baz() {
+                    val g: Int? = 1
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report when a local var is reassigned a nullable value`() {
+            val code = """
+                fun baz() {
+                    var g: Int? = 1
+                    g = null
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report when a local var is initialized with null`() {
+            val code = """
+                fun baz() {
+                    var g: Int? = null
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a local var inside an interface default method`() {
+            val code = """
+                interface Foo {
+                    fun bar() {
+                        var g: Int? = 1
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+    }
+
+    @Nested
     inner class `nullable function parameters` {
         @Nested
         inner class `using a de-nullifier` {


### PR DESCRIPTION
Fixes #8498.

`CanBeNonNullable` ignored local variables, so a nullable local that's never null wasn't reported:

```kotlin
fun foo() {
    var a: Int? = 5 // never null, but not reported before
    a = 6
}
```

Locals have no `FqName` and were filtered out before analysis. The candidate set is now keyed by the declaration itself, and locals skip the member-only guards (visibility, `open`/`abstract`, interface) that don't apply to a function-scoped variable. The interface guard keeps an `!isLocal` check because `containingClass()` crosses function boundaries and would otherwise exclude a `var` in an interface default method.

Tests cover the new positives and the false-positive guards, and the full self-analysis passes with no new findings.
