### PR TITLE
fix(ImplicitDefaultLocale): ignore locale-independent format conversions

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
@@ -14,7 +14,10 @@ import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
 
 /**
@@ -57,6 +60,13 @@ class ImplicitDefaultLocale(config: Config) :
             val symbol = expression.resolveToCall()?.singleFunctionCallOrNull()?.symbol ?: return
             if (symbol.callableId != formatCallId) return
             if (symbol.valueParameters.firstOrNull()?.returnType?.symbol?.classId == localeClassId) return
+
+            // Don't report when the format string is a compile-time constant whose conversions are
+            // all locale-independent (e.g. hexadecimal `%x`), as the default locale can't affect the
+            // result. See https://github.com/detekt/detekt/issues/3821
+            val formatString = expression.formatStringOrNull()
+            if (formatString != null && formatString.hasOnlyLocaleIndependentConversions()) return
+
             report(
                 Finding(
                     Entity.from(expression),
@@ -66,11 +76,44 @@ class ImplicitDefaultLocale(config: Config) :
         }
     }
 
+    /**
+     * The constant format string of the call, or `null` when it can't be resolved to a compile-time
+     * constant (e.g. it's a variable or contains string interpolation).
+     */
+    private fun KtQualifiedExpression.formatStringOrNull(): String? {
+        // `"…".format(…)`: the format string is the receiver.
+        receiverExpression.constantStringValueOrNull()?.let { return it }
+        // `String.format("…", …)`: the format string is the first argument.
+        val call = selectorExpression as? KtCallExpression
+        return call?.valueArguments?.firstOrNull()?.getArgumentExpression()?.constantStringValueOrNull()
+    }
+
+    private fun KtExpression.constantStringValueOrNull(): String? {
+        val template = this as? KtStringTemplateExpression ?: return null
+        if (template.hasInterpolation()) return null
+        return template.entries.joinToString("") { it.text }
+    }
+
+    private fun String.hasOnlyLocaleIndependentConversions(): Boolean =
+        conversionRegex.findAll(this)
+            .map { it.groupValues[CONVERSION_GROUP_INDEX] }
+            .all { it in localeIndependentConversions }
+
     companion object {
         private val formatCallIds = listOf(
             CallableId(FqName("kotlin.text"), Name.identifier("format")),
         ).associateBy { it.callableName.asString() }
 
         private val localeClassId = ClassId(FqName("java.util"), Name.identifier("Locale"))
+
+        // Matches a Java `Formatter` format specifier; group CONVERSION_GROUP_INDEX holds the
+        // conversion, e.g. `d`, `X`, `tY` (date/time) or `%`.
+        private val conversionRegex = Regex("""%(?:\d+\$)?[-#+ 0,(]*\d*(?:\.\d+)?([tT][a-zA-Z]|[a-zA-Z%])""")
+        private const val CONVERSION_GROUP_INDEX = 1
+
+        // Conversions whose output never depends on the default locale.
+        private val localeIndependentConversions = setOf(
+            "x", "X", "o", "a", "A", "b", "B", "h", "H", "s", "c", "n", "%",
+        )
     }
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
@@ -77,4 +77,105 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `does not report String_format with a hexadecimal conversion - issue 3821`() {
+        val code = """
+            fun x() {
+                String.format("0x%08X", 255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a format extension call with a hexadecimal conversion`() {
+        val code = """
+            fun x() {
+                "0x%08x".format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a format string with only locale-independent conversions`() {
+        val code = """
+            fun x() {
+                "hex %x, octal %o, bool %b, char %c, str %s".format(255, 64, true, 'A', "y")
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a literal percent conversion`() {
+        val code = """
+            fun x() {
+                "100%% done".format()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a format string without conversions`() {
+        val code = """
+            fun x() {
+                "plain text".format()
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports a locale-dependent floating point conversion`() {
+        val code = """
+            fun x() {
+                String.format("%.2f", 1.0)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports a locale-dependent date time conversion`() {
+        val code = """
+            fun x() {
+                "%tY".format(0L)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports when locale-independent and locale-dependent conversions are mixed`() {
+        val code = """
+            fun x() {
+                "id 0x%X count %d".format(255, 1)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports when the format string is built with interpolation`() {
+        val code = """
+            fun x(prefix: String) {
+                "${'$'}prefix %x".format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports when the format string is not a compile-time constant`() {
+        val code = """
+            fun x() {
+                val pattern = "%x"
+                pattern.format(255)
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocaleSpec.kt
@@ -1,10 +1,10 @@
 package dev.detekt.rules.potentialbugs
 
 import dev.detekt.api.Config
+import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
 import dev.detekt.test.utils.KotlinEnvironmentContainer
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 @KotlinCoreEnvironmentTest
@@ -18,7 +18,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 String.format("%d", 1)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -51,7 +53,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 "%d".format(1)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -135,7 +139,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 String.format("%.2f", 1.0)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -145,7 +151,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 "%tY".format(0L)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -155,7 +163,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 "id 0x%X count %d".format(255, 1)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -165,7 +175,9 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 "${'$'}prefix %x".format(255)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(2, 5)
     }
 
     @Test
@@ -176,6 +188,8 @@ class ImplicitDefaultLocaleSpec(private val env: KotlinEnvironmentContainer) {
                 pattern.format(255)
             }
         """.trimIndent()
-        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasStartSourceLocation(3, 5)
     }
 }


### PR DESCRIPTION
## What this changes

`ImplicitDefaultLocale` flagged every `String.format(...)` / `"…".format(...)` call that didn't pass an explicit `Locale`, regardless of the format string. That produced false positives for format strings whose conversions are locale-independent, e.g. hexadecimal formatting:

```kotlin
String.format("0x%08X", value) // reported, but the default locale can't affect %X
```

Fixes #3821.

## How

When the format string is a compile-time constant, the rule now extracts its conversion specifiers and skips reporting if **all** of them are locale-independent (`x`, `X`, `o`, `a`, `A`, `b`, `B`, `h`, `H`, `s`, `c`, `n` and the literal `%`).

Anything that could depend on the locale still reports:
- locale-sensitive conversions (`d`, `e`, `f`, `g`, date/time `t`/`T`, …),
- a format string mixing independent and dependent conversions,
- a format string that is a variable or uses string interpolation (it can't be verified statically).

This revives the approach reviewed in #9012, applying the two suggestions from that review: the specifier regex is created once in the companion object, and the redundant empty-list check is dropped (`all {}` is already `true` for an empty list).

## Tests

Added regression tests in `ImplicitDefaultLocaleSpec` covering both call forms (`String.format(...)` and the `.format(...)` extension), the locale-independent conversions, mixed independent/dependent conversions, floating-point and date/time conversions, the literal `%%`, a format string without conversions, and the interpolated / non-constant fallbacks. `./gradlew :detekt-rules-potential-bugs:test :detekt-rules-potential-bugs:detektMain :detekt-rules-potential-bugs:detektTest` passes locally.

## Note on tooling

This change was prepared with AI assistance (Claude). I reviewed the rule behaviour, the locale-sensitivity of each conversion, and verified the change against the test suite and detekt's self-analysis.
