### PR TITLE
fix: handle trailing commas in @Configuration annotation parsing in JS generator

### DIFF
--- a/website/scripts/generate-docs.mjs
+++ b/website/scripts/generate-docs.mjs
@@ -446,7 +446,8 @@ function extractConfigAnnotationDesc(src, annotationIdx) {
   const parenIdx = src.indexOf('(', annotationIdx);
   if (parenIdx === -1) return '';
   const closeIdx = findMatchingParen(src, parenIdx);
-  const raw = src.substring(parenIdx + 1, closeIdx).trim();
+  // Strip trailing comma (Kotlin allows trailing commas in argument lists)
+  const raw = src.substring(parenIdx + 1, closeIdx).trim().replace(/,\s*$/, '');
   // Remove surrounding quotes and handle concatenation
   const unquoted = raw.replace(/^"|"$/g, '').replace(/"[ \t]*\+[ \t\r\n]*"/g, '');
   return unquoted.trim();


### PR DESCRIPTION
Written by Copilot:

The `verify-generators-parity` CI job was failing because the JS generator (`node website/scripts/generate-docs.mjs`, used by Cloudflare Pages) produced different output than the Kotlin generator (`./gradlew generateDocumentation`, used by GitHub Pages) for the `ignoredFullyQualifiedNames` configuration description in `UnnecessaryFullyQualifiedName`.

**Root cause:** Kotlin 1.4+ allows trailing commas in argument lists. The `@Configuration` annotation uses a multi-line string concatenation with a trailing comma inside the annotation parentheses:

```kotlin
@Configuration(
    "fully qualified names that are ignored, for example `['java.lang.String', ...]`",
)
```

The JS generator's `extractConfigAnnotationDesc` function extracted the raw content between `(` and `)`, which ended with `",` due to the trailing comma. The `/^"|"$/g` regex failed to strip the trailing `"` (because the last character was `,`, not `"`), leaving a spurious `",` in the generated output.

**Fix:** Strip any trailing comma (and surrounding whitespace) from the raw annotation argument before the quote-removal step in `extractConfigAnnotationDesc` in `website/scripts/generate-docs.mjs`.