### PR TITLE
Restrict ImplicitUnitReturnType to public API functions

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnType.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnType.kt
@@ -8,6 +8,7 @@ import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.hasImplicitUnitReturnType
+import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.psi.KtNamedFunction
 
 /**
@@ -15,6 +16,9 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  * Changing the type of the expression accidentally, changes the functions return type.
  * This may lead to backward incompatibility.
  * Use a block statement to make clear this function will never return a value.
+ *
+ * Only functions that are part of the public API are reported, as the implicit return type
+ * is only relevant there. Private, internal and local functions are not reported.
  *
  * <noncompliant>
  * fun errorProneUnit() = println("Hello Unit")
@@ -29,6 +33,9 @@ import org.jetbrains.kotlin.psi.KtNamedFunction
  *
  * // explicit Unit is compliant by default; can be configured to enforce block statement
  * fun safeUnitReturn(): Unit = println("Hello Unit")
+ *
+ * // private, internal and local functions are not reported
+ * private fun privateUnit() = println("Hello Unit")
  * </compliant>
  *
  */
@@ -45,8 +52,14 @@ class ImplicitUnitReturnType(config: Config) :
     @Configuration("if functions with explicit `Unit` return type should be allowed")
     private val allowExplicitReturnType: Boolean by config(true)
 
+    @Suppress("ReturnCount")
     override fun visitNamedFunction(function: KtNamedFunction) {
         super.visitNamedFunction(function)
+
+        if (function.isLocal) return
+        analyze(function) {
+            if (!isPublicApi(function.symbol)) return
+        }
 
         if (allowExplicitReturnType && function.hasDeclaredReturnType()) {
             return

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnTypeSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ImplicitUnitReturnTypeSpec.kt
@@ -65,4 +65,71 @@ class ImplicitUnitReturnTypeSpec(private val env: KotlinEnvironmentContainer) {
         val findings = subject.lintWithContext(env, code)
         assertThat(findings).isEmpty()
     }
+
+    @Test
+    fun `does not report non-public functions`() {
+        val code = """
+            private fun privateUnit() = println("Hello Unit")
+            internal fun internalUnit() = println("Hello Unit")
+        """.trimIndent()
+
+        val findings = subject.lintWithContext(env, code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports protected functions`() {
+        val code = """
+            open class C {
+                protected fun protectedUnit() = println("Hello Unit")
+            }
+        """.trimIndent()
+
+        val findings = subject.lintWithContext(env, code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `does not report local functions`() {
+        val code = """
+            fun outer() {
+                fun localUnit() = println("Hello Unit")
+            }
+        """.trimIndent()
+
+        val findings = subject.lintWithContext(env, code)
+
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `reports public overrides`() {
+        val code = """
+            open class Base {
+                open fun base(): Unit = println("Hello Unit")
+            }
+            class Derived : Base() {
+                override fun base() = println("Hello Unit")
+            }
+        """.trimIndent()
+
+        val findings = subject.lintWithContext(env, code)
+
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `does not report public members of private classes`() {
+        val code = """
+            private class Hidden {
+                fun publicButHidden() = println("Hello Unit")
+            }
+        """.trimIndent()
+
+        val findings = subject.lintWithContext(env, code)
+
+        assertThat(findings).isEmpty()
+    }
 }


### PR DESCRIPTION
Fixes #9422.

`ImplicitUnitReturnType` reported every function with an implicit `Unit` return type, including private, internal and local ones.
That clashes with `OptionalUnit` under `allRules`, where a non-public function gets flagged by both rules at once and you can only satisfy one.
The implicit return type only matters for the public API, so the rule now skips the rest via `isPublicApi`, the same check `LibraryCodeMustSpecifyReturnType` uses.
cortinico suggested this direction on the issue.

Added tests for the affected visibility cases, including overrides and members of private classes.

AI-assisted (Claude), reviewed and tested locally.
