### PR TITLE
fix: false positive on private extension functions

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateFunction.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateFunction.kt
@@ -113,25 +113,22 @@ private class UnusedFunctionVisitor(private val allowedNames: Regex) : DetektVis
                         } else {
                             emptyList()
                         }
-                        val referenceSymbols = (references + referencesViaOperator)
+                        val referencePsis = (references + referencesViaOperator)
                             .mapNotNull {
                                 analyze(it) {
-                                    it.resolveToCall()?.singleFunctionCallOrNull()?.symbol
+                                    val symbol = it.resolveToCall()?.singleFunctionCallOrNull()?.symbol
                                         ?: it.mainReference.resolveToSymbol() as? KaFunctionSymbol
+                                    symbol?.psi
                                 }
                             }
                             .let {
                                 if (functionNameAsName in OperatorNameConventions.DELEGATED_PROPERTY_OPERATORS) {
-                                    it + propertyDelegateSymbols
+                                    it + propertyDelegateSymbols.mapNotNull { symbol -> symbol.psi }
                                 } else {
                                     it
                                 }
                             }
-                        functions.filterNot {
-                            analyze(it) {
-                                it.symbol in referenceSymbols
-                            }
-                        }
+                        functions.filterNot { it in referencePsis }
                     }
 
                     references.isEmpty() -> functions

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivateFunctionSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivateFunctionSpec.kt
@@ -717,6 +717,40 @@ class UnusedPrivateFunctionSpec(val env: KotlinEnvironmentContainer) {
             """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
+
+        @Test
+        fun `Does not report used private extension functions on Java classes`() {
+            val code = """
+                import java.io.File
+                
+                class Test {
+                    private fun File.foo() {}
+                    private fun String.foo() {}
+                    
+                    fun bar(files: List<File>, strings: List<String>) {
+                        files.forEach { it.foo() }
+                        strings.forEach { it.foo() }
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `Does not report used private overloaded functions referenced via callable reference`() {
+            val code = """
+                class Test {
+                    private fun foo() {}
+                    private fun foo(x: Int) {}
+                    
+                    fun bar() {
+                        val ref1: () -> Unit = ::foo
+                        val ref2: (Int) -> Unit = ::foo
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Nested


### PR DESCRIPTION
### Problem

Under detekt 2.0.0-alpha04 (following the migration of `UnusedPrivateFunction` to the Kotlin Analysis API), overloaded private extension functions whose receiver is a Java class (or a generated class like those from Protobuf) are incorrectly flagged as unused.

This happens because the Analysis API's overload resolution evaluates a call to a private extension function with a Java receiver type, creating a type-substituted/adapted symbol. When comparing this substituted symbol against the unsubstituted declaration symbol using structural equality (`it.symbol in referenceSymbols`), the equality check fails. Consequently, detekt believes the function is unused even though it is called.

### Solution

Replaced the structural comparison of compiler `KaFunctionSymbol`s (`it.symbol in referenceSymbols`) with underlying PSI element comparison (`it in referencePsis`). Since both the declaration and the reference point to the exact same PSI element (`KtFunction`), comparing the PSI elements is direct, robust, and unaffected by type substitutions/adaptations.

Also added a regression test case to `UnusedPrivateFunctionSpec.kt` verifying this scenario using a Java class (`java.io.File`) receiver.

Resolves: #9413

