### PR TITLE
Target JVM 17 in detekt-rules-ktlint-wrapper

### DIFF
--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -100,7 +100,7 @@ testing {
     }
 }
 
-// Pretend AGP API and JUnit targets JVM 8. Required while detekt itself targets JVM 8 while AGP API targets JVM 11 and JUnit 6 targets JVM 17.
+// Pretend AGP API, JUnit and detekt-rules-ktlint-wrapper target JVM 8. Required while detekt itself targets JVM 8 and these dependencies target newer JVM versions.
 dependencies {
     components {
         setOf(
@@ -113,6 +113,7 @@ dependencies {
             "org.junit.platform:junit-platform-commons",
             "org.junit.platform:junit-platform-engine",
             "org.junit.platform:junit-platform-launcher",
+            "dev.detekt:detekt-rules-ktlint-wrapper",
         ).forEach {
             withModule(it) {
                 allVariants {

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -15,6 +15,7 @@ val pluginsJarFiles = configurations.resolvable("pluginsJarFiles") {
     isTransitive = false
 }
 
+@Suppress("MagicNumber")
 dependencies {
     implementation(libs.jcommander)
     implementation(projects.detektApi)
@@ -34,9 +35,17 @@ dependencies {
 
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
-    testRuntimeOnly(projects.detektRulesKtlintWrapper)
+    testRuntimeOnly(projects.detektRulesKtlintWrapper) {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
 
-    pluginsJar(projects.detektRulesKtlintWrapper)
+    pluginsJar(projects.detektRulesKtlintWrapper) {
+        attributes {
+            attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, 17)
+        }
+    }
     pluginsJar(projects.detektRulesLibraries)
     pluginsJar(projects.detektRulesRuleauthors)
 }

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -61,3 +61,20 @@ tasks.jar {
         extraDepsToPackage.get().map { zipTree(it) },
     )
 }
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}

--- a/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
@@ -15,7 +15,7 @@ tasks.shadowJar {
 }
 
 java {
-    targetCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 val javaComponent = components["java"] as AdhocComponentWithVariants


### PR DESCRIPTION
Closes #9451

This updates the detekt-rules-ktlint-wrapper module and the associated
ktlint-repackage subproject to compile and target JVM 17.

Ktlint will only support JVM 17 and higher from its next major release.
Updating our wrapper now ensures it is ready for the next v2 alpha,
allowing early adopters to adapt accordingly.


