### PR TITLE
Group KotlinAnalysisApiEngine.compile parameters into CompileOptions

### DIFF
--- a/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/suppressors/AnnotationSuppressorSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.core.suppressors
 
 import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
+import dev.detekt.test.utils.CompileOptions
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.compileContentForTest
 import dev.detekt.tooling.api.AnalysisMode
@@ -314,7 +315,13 @@ class AnnotationSuppressorSpec {
             fun getFile() =
                 listOf(
                     Arguments.of(compileContentForTest(code), AnalysisMode.light),
-                    Arguments.of(analysisApiEngine.compile(code, composableFiles), AnalysisMode.full),
+                    Arguments.of(
+                        analysisApiEngine.compile(
+                            code = code,
+                            options = CompileOptions(dependencyCodes = composableFiles)
+                        ),
+                        AnalysisMode.full,
+                    ),
                 )
 
             @ParameterizedTest
@@ -405,13 +412,13 @@ class AnnotationSuppressorSpec {
             )!!
 
             val root = analysisApiEngine.compile(
-                """
+                code = """
                     package foo.bar
                     
                     @Composable
                     fun function() = Unit
                 """.trimIndent(),
-                composableFiles,
+                options = CompileOptions(dependencyCodes = composableFiles),
             )
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -426,13 +433,13 @@ class AnnotationSuppressorSpec {
             )!!
 
             val root = analysisApiEngine.compile(
-                """
+                code = """
                     package foo.bar
                     
                     @androidx.compose.runtime.Composable
                     fun function() = Unit
                 """.trimIndent(),
-                composableFiles,
+                options = CompileOptions(dependencyCodes = composableFiles),
             )
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -447,7 +454,7 @@ class AnnotationSuppressorSpec {
             )!!
 
             val root = analysisApiEngine.compile(
-                """
+                code = """
                     package foo.bar
                     
                     import androidx.compose.runtime.Composable as Bar
@@ -455,7 +462,7 @@ class AnnotationSuppressorSpec {
                     @Bar
                     fun function() = Unit
                 """.trimIndent(),
-                composableFiles,
+                options = CompileOptions(dependencyCodes = composableFiles),
             )
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
@@ -495,7 +502,10 @@ class AnnotationSuppressorSpec {
                 AnalysisMode.full,
             )!!
 
-            val root = analysisApiEngine.compile(code, composableFiles)
+            val root = analysisApiEngine.compile(
+                code = code,
+                options = CompileOptions(dependencyCodes = composableFiles)
+            )
             val ktFunction = root.findChildByClass(KtFunction::class.java)!!
 
             assertThat(suppressor.shouldSuppress(buildFinding(ktFunction))).isTrue()

--- a/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
+++ b/detekt-psi-utils/src/test/kotlin/dev/detekt/psi/AnnotationExcluderSpec.kt
@@ -1,6 +1,7 @@
 package dev.detekt.psi
 
 import dev.detekt.test.junit.KotlinAnalysisApiEngineTest
+import dev.detekt.test.utils.CompileOptions
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.compileContentForTest
 import org.assertj.core.api.Assertions.assertThat
@@ -116,7 +117,10 @@ class AnnotationExcluderSpec(val analysisApiEngine: KotlinAnalysisApiEngine) {
             @Test
             @Disabled("This should be doable but it's not imlemented yet")
             fun `correct with Analysis API`() {
-                val file = analysisApiEngine.compile(code, listOf(helloWorldAnnotationsCode))
+                val file = analysisApiEngine.compile(
+                    code = code,
+                    options = CompileOptions(dependencyCodes = listOf(helloWorldAnnotationsCode)),
+                )
                 val ktAnnotation = file.annotationEntry()
                 val excluder = AnnotationExcluder(file, listOf("Hello\\.World".toRegex()), true)
 
@@ -155,7 +159,10 @@ class AnnotationExcluderSpec(val analysisApiEngine: KotlinAnalysisApiEngine) {
 
             @Test
             fun `correct with Analysis API`() {
-                val file = analysisApiEngine.compile(file, listOf(helloWorldAnnotationsKtFile))
+                val file = analysisApiEngine.compile(
+                    code = file,
+                    options = CompileOptions(dependencyCodes = listOf(helloWorldAnnotationsKtFile)),
+                )
                 val ktAnnotation = file.annotationEntry()
                 val excluder = AnnotationExcluder(file, listOf("foo\\.World".toRegex()), true)
 
@@ -184,15 +191,17 @@ private fun KotlinAnalysisApiEngine.createKtFile(
     """.trimIndent()
     val file = if (enableAnalysisApi) {
         compile(
-            code,
-            listOf(
-                """
-                    package dagger
-                    
-                    annotation class Component {
-                        annotation class Factory
-                    }
-                """.trimIndent(),
+            code = code,
+            options = CompileOptions(
+                dependencyCodes = listOf(
+                    """
+                        package dagger
+                        
+                        annotation class Component {
+                            annotation class Factory
+                        }
+                    """.trimIndent(),
+                ),
             ),
         )
     } else {

--- a/detekt-test-utils/api/detekt-test-utils.api
+++ b/detekt-test-utils/api/detekt-test-utils.api
@@ -7,11 +7,30 @@ public final class dev/detekt/test/utils/CompileExtensionsKt {
 	public static final fun compileForTest (Ljava/nio/file/Path;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
+public final class dev/detekt/test/utils/CompileOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;)Ldev/detekt/test/utils/CompileOptions;
+	public static synthetic fun copy$default (Ldev/detekt/test/utils/CompileOptions;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lorg/jetbrains/kotlin/config/LanguageVersionSettings;ILjava/lang/Object;)Ldev/detekt/test/utils/CompileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDependencyCodes ()Ljava/util/List;
+	public final fun getJavaSourceRoots ()Ljava/util/List;
+	public final fun getJvmClasspathRoots ()Ljava/util/List;
+	public final fun getLanguageVersionSettings ()Lorg/jetbrains/kotlin/config/LanguageVersionSettings;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/detekt/test/utils/KotlinAnalysisApiEngine : java/lang/AutoCloseable {
 	public fun <init> ()V
 	public fun close ()V
-	public final fun compile (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLorg/jetbrains/kotlin/config/LanguageVersionSettings;)Lorg/jetbrains/kotlin/psi/KtFile;
-	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ZLorg/jetbrains/kotlin/config/LanguageVersionSettings;ILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
+	public final fun compile (Ljava/lang/String;Ldev/detekt/test/utils/CompileOptions;Z)Lorg/jetbrains/kotlin/psi/KtFile;
+	public static synthetic fun compile$default (Ldev/detekt/test/utils/KotlinAnalysisApiEngine;Ljava/lang/String;Ldev/detekt/test/utils/CompileOptions;ZILjava/lang/Object;)Lorg/jetbrains/kotlin/psi/KtFile;
 }
 
 public final class dev/detekt/test/utils/KotlinEnvironmentContainer {

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/CompileExtensions.kt
@@ -31,8 +31,10 @@ fun compileContentForTest(
 
     return kotlinAnalysisApiEngine.compile(
         code = content,
-        javaSourceRoots = environment.javaSourceRoots,
-        jvmClasspathRoots = environment.jvmClasspathRoots,
+        options = CompileOptions(
+            javaSourceRoots = environment.javaSourceRoots,
+            jvmClasspathRoots = environment.jvmClasspathRoots,
+        ),
     )
 }
 

--- a/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
+++ b/detekt-test-utils/src/main/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngine.kt
@@ -32,15 +32,10 @@ class KotlinAnalysisApiEngine : AutoCloseable {
      *
      * @throws IllegalStateException if the given code snippet does not compile
      */
-    @Suppress("LongParameterList")
     fun compile(
         @Language("kotlin") code: String,
-        dependencyCodes: List<String> = emptyList(),
-        javaSourceRoots: List<Path> = emptyList(),
-        jvmClasspathRoots: List<Path> =
-            listOf(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath()),
+        options: CompileOptions = CompileOptions(),
         allowCompilationErrors: Boolean = shouldCompileTestSnippets,
-        languageVersionSettings: LanguageVersionSettings = LanguageVersionSettingsImpl.DEFAULT,
     ): KtFile {
         val session = buildStandaloneAnalysisAPISession(disposable) {
             buildKtModuleProvider {
@@ -53,14 +48,14 @@ class KotlinAnalysisApiEngine : AutoCloseable {
                 }
 
                 val additionalLibraries = buildKtLibraryModule {
-                    addBinaryRoots(jvmClasspathRoots.distinct())
+                    addBinaryRoots(options.jvmClasspathRoots.distinct())
                     platform = targetPlatform
                     libraryName = "classpath"
                 }
 
                 val vf = LightVirtualFile("dummy.kt", code)
 
-                val depVfs = dependencyCodes.mapIndexed { index, depCode ->
+                val depVfs = options.dependencyCodes.mapIndexed { index, depCode ->
                     LightVirtualFile("dependency_${index + 1}.kt", depCode)
                 }
 
@@ -70,10 +65,10 @@ class KotlinAnalysisApiEngine : AutoCloseable {
                         addRegularDependency(additionalLibraries)
                         addSourceVirtualFile(vf)
                         addSourceVirtualFiles(depVfs)
-                        addSourceRoots(javaSourceRoots)
+                        addSourceRoots(options.javaSourceRoots)
                         platform = targetPlatform
                         moduleName = "source"
-                        this.languageVersionSettings = languageVersionSettings
+                        languageVersionSettings = options.languageVersionSettings
                     }
                 )
             }
@@ -88,3 +83,11 @@ class KotlinAnalysisApiEngine : AutoCloseable {
         Disposer.dispose(disposable)
     }
 }
+
+data class CompileOptions(
+    val dependencyCodes: List<String> = emptyList(),
+    val javaSourceRoots: List<Path> = emptyList(),
+    val jvmClasspathRoots: List<Path> =
+        listOf(File(CharRange::class.java.protectionDomain.codeSource.location.path).toPath()),
+    val languageVersionSettings: LanguageVersionSettings = LanguageVersionSettingsImpl.DEFAULT,
+)

--- a/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
+++ b/detekt-test-utils/src/test/kotlin/dev/detekt/test/utils/KotlinAnalysisApiEngineTest.kt
@@ -86,15 +86,15 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
         assertThatThrownBy {
             analysisApiEngine.compile(
                 code = code,
+                options = CompileOptions(languageVersionSettings = explicitApi(ExplicitApiMode.STRICT)),
                 allowCompilationErrors = false,
-                languageVersionSettings = explicitApi(ExplicitApiMode.STRICT),
             )
         }.isInstanceOf(IllegalStateException::class.java)
 
         analysisApiEngine.compile(
             code = code,
+            options = CompileOptions(languageVersionSettings = explicitApi(ExplicitApiMode.DISABLED)),
             allowCompilationErrors = false,
-            languageVersionSettings = explicitApi(ExplicitApiMode.DISABLED),
         )
     }
 
@@ -123,7 +123,11 @@ class KotlinAnalysisApiEngineTest(val analysisApiEngine: KotlinAnalysisApiEngine
         """.trimIndent()
 
         val junitApiJar = File(Test::class.java.protectionDomain.codeSource.location.path).toPath()
-        analysisApiEngine.compile(code = code, jvmClasspathRoots = listOf(junitApiJar), allowCompilationErrors = false)
+        analysisApiEngine.compile(
+            code = code,
+            options = CompileOptions(jvmClasspathRoots = listOf(junitApiJar)),
+            allowCompilationErrors = false,
+        )
     }
 
     @Test

--- a/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/RuleExtensions.kt
@@ -4,6 +4,7 @@ import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.RuleName
+import dev.detekt.test.utils.CompileOptions
 import dev.detekt.test.utils.KotlinAnalysisApiEngine
 import dev.detekt.test.utils.KotlinEnvironmentContainer
 import dev.detekt.test.utils.compileContentForTest
@@ -33,8 +34,10 @@ fun Rule.lint(
             KotlinAnalysisApiEngine().use {
                 it.compile(
                     code = content,
-                    jvmClasspathRoots = createEnvironment().jvmClasspathRoots,
-                    languageVersionSettings = languageVersionSettings,
+                    options = CompileOptions(
+                        jvmClasspathRoots = createEnvironment().jvmClasspathRoots,
+                        languageVersionSettings = languageVersionSettings,
+                    ),
                     allowCompilationErrors = false,
                 )
             }
@@ -56,11 +59,13 @@ fun <T> T.lintWithContext(
     KotlinAnalysisApiEngine().use {
         val ktFile = it.compile(
             code = content,
-            dependencyCodes = dependencyContents.toList(),
-            javaSourceRoots = environment.javaSourceRoots,
-            jvmClasspathRoots = environment.jvmClasspathRoots,
-            languageVersionSettings = languageVersionSettings,
-            allowCompilationErrors = allowCompilationErrors || !shouldCompileTestSnippets
+            options = CompileOptions(
+                dependencyCodes = dependencyContents.toList(),
+                javaSourceRoots = environment.javaSourceRoots,
+                jvmClasspathRoots = environment.jvmClasspathRoots,
+                languageVersionSettings = languageVersionSettings,
+            ),
+            allowCompilationErrors = allowCompilationErrors || !shouldCompileTestSnippets,
         )
         visitFile(ktFile, languageVersionSettings).filterSuppressed(this)
     }


### PR DESCRIPTION
Follow-up to https://github.com/detekt/detekt/pull/9305#discussion_r3198192104

## Summary

`KotlinAnalysisApiEngine.compile()` had `@Suppress("LongParameterList")`. Group the compiler-configuration parameters into a `CompileOptions` data class to resolve it.

## Breaking Changes

```diff
- engine.compile(code, dependencyCodes, javaSourceRoots, jvmClasspathRoots)
+ engine.compile(code, CompileOptions(dependencyCodes, javaSourceRoots, jvmClasspathRoots))
```