### PR TITLE
Remove irrelevant test for YamlConfig

### DIFF
--- a/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/config/CompositeConfigSpec.kt
@@ -2,7 +2,6 @@ package dev.detekt.core.config
 
 import dev.detekt.core.yamlConfigFromContent
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 
 class CompositeConfigSpec {
@@ -91,15 +90,6 @@ class CompositeConfigSpec {
         val config = compositeConfig.subConfig("style").subConfig("MagicNumber")
         val value = config.valueOrDefault("ignoreNumbers", emptyList<String>())
         assertThat(value).isEqualTo(listOf("-1", "0", "1", "2", "100", "1000"))
-    }
-
-    @Test
-    fun `should fail with a meaningful exception when boolean property is invalid`() {
-        val config = compositeConfig.subConfig("style").subConfig("LargeClass")
-
-        assertThatThrownBy { config.valueOrDefault("active", true) }
-            .isInstanceOf(IllegalArgumentException::class.java)
-            .hasMessageContaining("The string doesn't represent a boolean value: truuu")
     }
 
     @Test


### PR DESCRIPTION
This test have no sense inside `CompositeConfigSpec` It is just testing something related with `YamlConfig`. And that test already exist on `YamlConfigSpec`.

Note: This PR is a try to reduce the size of #9049