### PR TITLE
DRY - `YamlConfig`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/BaseConfig.kt
@@ -1,10 +1,6 @@
 package dev.detekt.core.config
 
-import dev.detekt.core.config.YamlConfig.Companion.CONFIG_SEPARATOR
 import kotlin.reflect.KClass
-
-private fun YamlConfig.keySequence(key: String): String =
-    if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key"
 
 fun YamlConfig.valueOrDefaultInternal(
     key: String,

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/YamlConfig.kt
@@ -23,11 +23,7 @@ class YamlConfig internal constructor(
     override fun subConfig(key: String): YamlConfig {
         @Suppress("UNCHECKED_CAST")
         val subProperties = properties.getOrElse(key) { emptyMap<String, Any>() } as Map<String, Any>
-        return YamlConfig(
-            subProperties,
-            if (parentPath == null) key else "$parentPath $CONFIG_SEPARATOR $key",
-            this,
-        )
+        return YamlConfig(subProperties, keySequence(key), this)
     }
 
     override fun subConfigKeys(): Set<String> = properties.keys
@@ -55,7 +51,6 @@ class YamlConfig internal constructor(
         validateConfig(this, baseline, excludePatterns)
 
     companion object {
-        const val CONFIG_SEPARATOR: String = ">"
         private const val YAML_DOC_LIMIT = 102_400 // limit the YAML size to 100 kB
 
         // limit the anchors/aliases for collections to prevent attacks from for untrusted sources
@@ -88,6 +83,8 @@ class YamlConfig internal constructor(
             )
     }
 }
+
+internal fun YamlConfig.keySequence(key: String): String = if (parentPath == null) key else "$parentPath > $key"
 
 internal class InvalidConfigurationError(throwable: Throwable) :
     RuntimeException(


### PR DESCRIPTION
We had this String `"$parentPath $CONFIG_SEPARATOR $key"` duplicated. And the `CONFIG_SEPARATOR`. Now we only have the string once in an internal function. In #9049 this function will be changed to `private`.

Note: This PR is a try to reduce the size of #9049