### PR TITLE
Reduce scope of `@Suppress("UNCHECKED_CAST")`

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/AllRulesConfig.kt
@@ -6,7 +6,6 @@ import dev.detekt.core.config.validation.ValidatableConfiguration
 import dev.detekt.core.config.validation.validateConfig
 import dev.detekt.core.util.indentCompat
 
-@Suppress("UNCHECKED_CAST")
 internal data class AllRulesConfig(
     private val wrapped: Config,
     private val deprecatedRules: Set<DeprecatedRule>,
@@ -19,12 +18,14 @@ internal data class AllRulesConfig(
     override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T =
+        @Suppress("UNCHECKED_CAST")
         when (key) {
             Config.ACTIVE_KEY -> if (isDeprecated()) false as T else wrapped.valueOrDefault(key, true) as T
             else -> wrapped.valueOrDefault(key, default)
         }
 
     override fun <T : Any> valueOrNull(key: String): T? =
+        @Suppress("UNCHECKED_CAST")
         when (key) {
             Config.ACTIVE_KEY -> if (isDeprecated()) false as T else wrapped.valueOrNull(key) ?: true as? T
             else -> wrapped.valueOrNull(key)

--- a/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/config/DisabledAutoCorrectConfig.kt
@@ -6,7 +6,6 @@ import dev.detekt.core.config.validation.ValidatableConfiguration
 import dev.detekt.core.config.validation.validateConfig
 import dev.detekt.core.util.indentCompat
 
-@Suppress("UNCHECKED_CAST")
 class DisabledAutoCorrectConfig(private val wrapped: Config, override val parent: Config? = null) :
     Config,
     ValidatableConfiguration {
@@ -16,12 +15,14 @@ class DisabledAutoCorrectConfig(private val wrapped: Config, override val parent
     override fun subConfigKeys(): Set<String> = wrapped.subConfigKeys()
 
     override fun <T : Any> valueOrDefault(key: String, default: T): T =
+        @Suppress("UNCHECKED_CAST")
         when (key) {
             Config.AUTO_CORRECT_KEY -> false as T
             else -> wrapped.valueOrDefault(key, default)
         }
 
     override fun <T : Any> valueOrNull(key: String): T? =
+        @Suppress("UNCHECKED_CAST")
         when (key) {
             Config.AUTO_CORRECT_KEY -> false as T
             else -> wrapped.valueOrNull(key)

--- a/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
+++ b/detekt-test/src/main/kotlin/dev/detekt/test/TestConfig.kt
@@ -3,21 +3,23 @@ package dev.detekt.test
 import dev.detekt.api.Config
 import dev.detekt.api.ValueWithReason
 
-@Suppress("UNCHECKED_CAST")
 class TestConfig private constructor(override val parent: Config?, private val values: Map<String, Any>) : Config {
     constructor(parent: Config?, vararg pairs: Pair<String, Any>) : this(parent, pairs.toMap())
 
     constructor(vararg pairs: Pair<String, Any>) : this(Config.empty, *pairs)
 
     override fun subConfig(key: String): TestConfig {
+        @Suppress("UNCHECKED_CAST")
         val value = values.getOrDefault(key, emptyMap<String, Any>()) as Map<String, Any>
         return TestConfig(this, value)
     }
 
     override fun subConfigKeys(): Set<String> = values.keys
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : Any> valueOrDefault(key: String, default: T) = values.getOrDefault(key, default) as T
 
+    @Suppress("UNCHECKED_CAST")
     override fun <T : Any> valueOrNull(key: String): T? = values[key] as? T
 }
 


### PR DESCRIPTION
The `UNCHECKED_CAST` warning is a big deal. It can lead to crashes in runtime. In some places it have sense but we shouldn't suppress those cases at class level. We should reduce the scope of the suppress even if that makes us to have multiple `@Suppress` in the same class. With #9049 I will remove some of those `@Suppress`.

Note: This PR is a try to reduce the size of #9049