### PR TITLE
Fix a potential bug on `Config.getListOrDefault`

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/ConfigProperty.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/ConfigProperty.kt
@@ -83,14 +83,15 @@ private fun <T : Any> getValueOrDefault(config: Config, propertyName: String, de
     }
 }
 
-private fun Config.getListOrDefault(propertyName: String, defaultValue: List<*>): List<String> =
-    if (defaultValue.all { it is String }) {
+private fun Config.getListOrDefault(propertyName: String, defaultValue: List<*>): List<String> {
+    val value = valueOrDefault(propertyName, defaultValue)
+    return if (value.all { it is String }) {
         @Suppress("UNCHECKED_CAST")
-        val defaultValueAsListOfStrings = defaultValue as List<String>
-        valueOrDefault(propertyName, defaultValueAsListOfStrings)
+        value as List<String>
     } else {
         error("Only lists of strings are supported. '$propertyName' is invalid. ")
     }
+}
 
 private fun Config.getValuesWithReasonOrDefault(
     propertyName: String,


### PR DESCRIPTION
We were checking with the `.all { it is String }` that the default value had all its values as `String`. And then we assumed that the value returned from `valueOrDefault` was all Strings too. And we couldn't assume that.

This PR fixes that.