### PR TITLE
Fix UseDataClass false positive for properties with a custom accessor

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UseDataClass.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UseDataClass.kt
@@ -84,12 +84,12 @@ class UseDataClass(config: Config) :
                 }
                 val containsPropertyOrPropertyParameters = properties.isNotEmpty() || propertyParameters.isNotEmpty()
                 val containsVars = properties.any { it.isVar } || propertyParameters.any { it.isMutable }
-                val containsDelegatedProperty = properties.any { it.hasDelegate() }
+                val containsPropertyWithLogic = properties.any { it.hasLogic() }
                 val containsNonPropertyParameter = klass.extractConstructorNonPropertyParameters().isNotEmpty()
                 val containsOnlyPropertyParameters =
                     containsPropertyOrPropertyParameters && !containsNonPropertyParameter
 
-                if (containsFunctions && !containsDelegatedProperty && containsOnlyPropertyParameters) {
+                if (containsFunctions && !containsPropertyWithLogic && containsOnlyPropertyParameters) {
                     if (allowVars && containsVars) {
                         return
                     }
@@ -143,6 +143,11 @@ class UseDataClass(config: Config) :
             ?.parameters
             ?.filter { !it.isPropertyParameter() }
             .orEmpty()
+
+    // A property that is delegated, has a custom getter (a computed property), or a custom setter with a
+    // body holds logic rather than data, so the class is not a pure data holder. A visibility-only accessor
+    // such as `private set` is intentionally ignored.
+    private fun KtProperty.hasLogic(): Boolean = hasDelegate() || getter != null || setter?.hasBody() == true
 
     private fun KaSession.isDefaultFunction(
         function: KtNamedFunction,

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UseDataClassSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UseDataClassSpec.kt
@@ -154,6 +154,31 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
+
+        @Test
+        fun `does not report a class with a computed property that has a custom getter - #5339`() {
+            val code = """
+                class NoDataClassCandidateWithComputedProperty(private val root: String) {
+                    val startTime: Int
+                        get() = root.length
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a class with a property that has a custom setter with a body - #5339`() {
+            val code = """
+                class NoDataClassCandidateWithCustomSetter(private val sink: StringBuilder) {
+                    var lastMessage: String = ""
+                        set(value) {
+                            field = value
+                            sink.append(value)
+                        }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
     }
 
     @Nested
@@ -240,6 +265,17 @@ class UseDataClassSpec(val env: KotlinEnvironmentContainer) {
                 class DataClass(override val i: Int): SimpleInterface
             """.trimIndent()
 
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does report a class whose only property has a visibility-only setter - #5339`() {
+            val code = """
+                class DataClassCandidateWithPrivateSetter(val i: Int) {
+                    var mutable: Int = 0
+                        private set
+                }
+            """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }


### PR DESCRIPTION
## Problem

`UseDataClass` flags classes whose only members are **computed properties** (a custom `get()`/`set()`), even though a computed property is behaviour, not data:

```kotlin
class ScheduleItem(private val root: String) {
    val startTime: Int
        get() = root.length
}
// > UseDataClass: The class ScheduleItem defines no functionality and only holds data.
```

This was reported in #5339 (e.g. Android `ViewModel`s and Selenium page objects). Such a class cannot meaningfully become a `data class` — its "values" are derived, not stored.

## Cause

`visitKlass` collects body properties via `filterIsInstance<KtProperty>()` but never inspects their accessors, so a property with a custom getter/setter was counted as plain data.

## Fix

The rule already skipped **delegated** properties (`by …`). This widens that same "not plain data" check to custom accessors:

```kotlin
private fun KtProperty.hasLogic(): Boolean = hasDelegate() || getter != null || setter?.hasBody() == true
```

- `getter != null` — a computed property (matches the existing idiom in `NullCheckOnMutableProperty`).
- `setter?.hasBody()` — a setter with real logic; a visibility-only accessor such as `private set` is intentionally **not** exempted.

This follows the direction agreed in the issue thread (checking `get()`/`set()` as a sign of logic). The delegate + accessor checks are kept in a single `hasLogic()` helper so the report condition stays within detekt's own `ComplexCondition`/`CyclomaticComplexMethod` limits (self-analysis passes).

## Tests

Two regression tests added (custom getter, custom setter with a body). Both fail on `main` and pass with the fix. `:detekt-rules-style:test` (full module suite) and self-analysis (`detektMain`/`detektTest`) are green locally.

Closes #5339

---

> **AI-assistance disclosure** (per `AGENTS.md`): this change was prepared with the help of Claude (Anthropic) and is credited with a `Co-authored-by:` trailer on the commit. I reviewed, ran, and verified the change and its tests myself.
