### PR TITLE
Fix MissingSuperCall false positive when annotation is in grandparent

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/MissingSuperCall.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/MissingSuperCall.kt
@@ -71,8 +71,10 @@ class MissingSuperCall(config: Config) :
                 it.annotations.any { ann -> ann.classId?.asSingleFqName() in mustInvokeSuperAnnotations }
             }?.callableId ?: return
 
-            val hasSuperCall = function.anyDescendantOfType<KtQualifiedExpression> {
-                it.resolveToCall()?.singleFunctionCallOrNull()?.symbol?.callableId == superFunctionId
+            val hasSuperCall = function.anyDescendantOfType<KtQualifiedExpression> { expression ->
+                val symbol = expression.resolveToCall()?.singleFunctionCallOrNull()?.symbol
+                    ?: return@anyDescendantOfType false
+                (symbol.allOverriddenSymbols + symbol).any { it.callableId == superFunctionId }
             }
 
             if (!hasSuperCall) {

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/MissingSuperCallSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/MissingSuperCallSpec.kt
@@ -114,6 +114,35 @@ class MissingSuperCallSpec(private val env: KotlinEnvironmentContainer) {
     }
 
     @Test
+    fun `super super methods has the annotation 2`() {
+        val subject = MissingSuperCall(
+            TestConfig("mustInvokeSuperAnnotations" to listOf("Ann"))
+        )
+
+        val code = """
+            annotation class Ann
+            open class Foo {
+                @Ann
+                open fun x() {}
+            }
+            open class Bar: Foo() {
+                override fun x() {
+                    super.x()
+                    println("Bar")
+                }
+            }
+            class Baz: Bar() {
+                override fun x() {
+                    super.x()
+                    println("Baz")
+                }
+            }
+        """.trimIndent()
+        val actual = subject.lintWithContext(env, code)
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
     fun `super methods has no annotation`() {
         val subject = MissingSuperCall(
             TestConfig("mustInvokeSuperAnnotations" to listOf("Ann"))


### PR DESCRIPTION
Fixes #9468. All the context there.