### PR TITLE
Fix UnusedPrivateProperty false negative for constructor properties

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
@@ -1,6 +1,7 @@
 package dev.detekt.rules.style
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.PsiTreeUtil
 import dev.detekt.api.ActiveByDefault
 import dev.detekt.api.Alias
 import dev.detekt.api.Config
@@ -21,6 +22,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
 import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstructor
 import org.jetbrains.kotlin.psi.KtFile
@@ -29,11 +31,13 @@ import org.jetbrains.kotlin.psi.KtNamedDeclaration
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
+import org.jetbrains.kotlin.psi.psiUtil.getStrictParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 
@@ -185,12 +189,42 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
                     val psi = it.psi ?: return@forEach
                     when {
                         psi is KtProperty && psi.isTopLevel -> usedTopLevelProperties.add(psi)
-                        psi is KtProperty || (psi is KtParameter && psi.hasValOrVar()) -> usedClassProperties.add(psi)
+
+                        psi is KtProperty -> usedClassProperties.add(psi)
+
+                        psi is KtParameter && psi.hasValOrVar() -> {
+                            if (!expression.isInPropertyInitializer(psi)) {
+                                usedClassProperties.add(psi)
+                            }
+                        }
+
                         else -> usedConstructorParameters.add(psi)
                     }
                 }
         }
     }
+
+    private fun KtReferenceExpression.isInPropertyInitializer(parameter: KtParameter): Boolean {
+        if (isExplicitPropertyReference()) return false
+
+        // Local or nested-class properties can themselves be inside the containing class's property initializer.
+        var property = getStrictParentOfType<KtProperty>()
+        while (property != null) {
+            if (!property.isLocal && property.containingClassOrObject == parameter.containingClassOrObject) {
+                val initializer = property.initializer
+                if (initializer != null && PsiTreeUtil.isAncestor(initializer, this, false)) return true
+            }
+            property = property.getStrictParentOfType<KtProperty>()
+        }
+        return false
+    }
+
+    private fun KtReferenceExpression.isExplicitPropertyReference(): Boolean =
+        when (val parent = parent) {
+            is KtCallableReferenceExpression -> parent.callableReference == this
+            is KtQualifiedExpression -> parent.selectorExpression == this
+            else -> false
+        }
 
     private fun KtConstructor<*>.isExpectClassConstructor() = containingClassOrObject?.isExpect() == true
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -726,6 +726,111 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
         }
 
         @Test
+        fun `reports constructor property used only to initialize another property`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val count: Int = text.length
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports constructor property used by local property inside another property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val count: Int = run {
+                        val local = text.length
+                        local
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports constructor property captured by anonymous object in another property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val holder = object {
+                        val count: Int = text.length
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report constructor property used in a local property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    fun length(): Int {
+                        val count = text.length
+                        return count
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report constructor property referenced with explicit this in a property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val count: Int = this.text.length
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report constructor property accessed on another instance in a property initializer`() {
+            val code = """
+                class Foo(private val text: String, other: Foo?) {
+                    val count: Int = other?.text?.length ?: 0
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report constructor property callable reference in a property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val reference = this::text
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report constructor property referenced by an inner class property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    inner class Bar {
+                        val count: Int = text.length
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report constructor property referenced by a local class property initializer`() {
+            val code = """
+                class Foo(private val text: String) {
+                    fun length(): Int {
+                        class Bar {
+                            val count: Int = text.length
+                        }
+                        return Bar().count
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `does not report unused private property in data class - #6142`() {
             val code = """
                 data class Foo(


### PR DESCRIPTION
Fixes #9467

## Problem

`UnusedPrivateProperty` treats every reference resolving to a primary-constructor property as property usage. During class initialization, however, an unqualified reference can use the constructor parameter without storing it as a property:

```kotlin
class Foo(private val text: String) {
    val count = text.length
}
```

`text` can therefore lose `private val`, but the rule does not report it.

## Fix

Ignore an unqualified constructor-property reference only when it appears inside a non-local property initializer owned by the same class. The ancestor walk also handles nested local properties and anonymous objects inside that initializer.

Preserve references that require the property itself, including:

- method-local property initializers
- `this.text` and qualified access through another instance
- callable property references
- inner- and local-class property initializers outside an enclosing same-class property initializer
- existing init-block and vararg behavior

## Tests

Added nine regression tests covering the issue and the preservation boundaries above.

Validated locally:

- `./gradlew publishToMavenLocal`
- focused `UnusedPrivatePropertySpec`: 65 tests, 0 failures
- `detekt-rules-style`: 4,062 tests, 0 failures/errors (5 existing skips)
- `./gradlew detektMain detektTest detektFunctionalTest detektTestFixtures`
- `./gradlew build -x dokkaGenerate`
- independent final review with Codex gpt-5.5: passed with no logic/security concerns or suggestions

## AI assistance disclosure

This change was prepared with Hermes Agent and independently reviewed with Codex gpt-5.5. I reviewed the issue scope, implementation rationale, edge cases, and validation evidence before approving submission. The commit credits Hermes Agent with a `Co-authored-by:` trailer.
