### PR TITLE
Fix false positive in UnnecessaryFullyQualifiedName for nested types

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -262,17 +262,12 @@ class UnnecessaryFullyQualifiedName(config: Config) :
     }
 
     context(session: KaSession)
-    private fun hasOuterClassCollision(element: KtElement, symbol: KaClassSymbol): Boolean {
+    private fun hasOuterClassCollision(element: KtElement, symbol: KaClassSymbol): Boolean =
         // If any class in the outer chain has a name collision, the FQN can't be simplified
         // because the import path through the outer class would be ambiguous.
-        for (outerClassId in generateSequence(symbol.classId?.outerClassId) { it.outerClassId }) {
-            val outerClass = with(session) {
-                findClass(outerClassId)
-            } ?: return false
-            if (hasNameCollision(element, outerClass)) return true
-        }
-        return false
-    }
+        generateSequence(symbol.classId?.outerClassId) { it.outerClassId }
+            .mapNotNull { with(session) { findClass(it) } }
+            .any { hasNameCollision(element, it) }
 
     private fun isShadowedByTypeParameter(element: KtElement, name: Name): Boolean =
         element.parents

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -233,12 +233,7 @@ class UnnecessaryFullyQualifiedName(config: Config) :
 
     context(session: KaSession)
     private fun hasNameCollision(element: KtElement, resolvedSymbol: KaSymbol): Boolean {
-        val simpleName = when (resolvedSymbol) {
-            is KaClassSymbol -> resolvedSymbol.classId?.shortClassName
-            is KaConstructorSymbol -> resolvedSymbol.containingClassId?.shortClassName
-            is KaCallableSymbol -> resolvedSymbol.callableId?.callableName
-            else -> null
-        } ?: return false
+        val simpleName = resolvedSymbol.collisionCheckName() ?: return false
 
         if (resolvedSymbol !is KaCallableSymbol && isShadowedByTypeParameter(element, simpleName)) return true
 
@@ -248,11 +243,14 @@ class UnnecessaryFullyQualifiedName(config: Config) :
         } else {
             resolvedSymbol
         }
-        return findLocalSymbols(element, symbol, simpleName).any { it != symbol }
+
+        if (findLocalSymbols(element, simpleName).any { it != symbol }) return true
+        if (symbol is KaClassSymbol && hasOuterClassCollision(element, symbol)) return true
+        return false
     }
 
     context(session: KaSession)
-    private fun findLocalSymbols(element: KtElement, resolvedSymbol: KaSymbol, name: Name): Sequence<KaSymbol> {
+    private fun findLocalSymbols(element: KtElement, name: Name): Sequence<KaSymbol> {
         // Default imports are overridden by an added explicit import, so a default symbol with the same
         // name is not a real collision (only explicit imports are).
         val scope = with(session) {
@@ -260,7 +258,20 @@ class UnnecessaryFullyQualifiedName(config: Config) :
                 it !is KaScopeKind.DefaultSimpleImportingScope && it !is KaScopeKind.DefaultStarImportingScope
             }
         }
-        return if (resolvedSymbol is KaCallableSymbol) scope.callables(name) else scope.classifiers(name)
+        return scope.classifiers(name) + scope.callables(name)
+    }
+
+    context(session: KaSession)
+    private fun hasOuterClassCollision(element: KtElement, symbol: KaClassSymbol): Boolean {
+        // If any class in the outer chain has a name collision, the FQN can't be simplified
+        // because the import path through the outer class would be ambiguous.
+        for (outerClassId in generateSequence(symbol.classId?.outerClassId) { it.outerClassId }) {
+            val outerClass = with(session) {
+                findClass(outerClassId)
+            } ?: return false
+            if (hasNameCollision(element, outerClass)) return true
+        }
+        return false
     }
 
     private fun isShadowedByTypeParameter(element: KtElement, name: Name): Boolean =
@@ -268,6 +279,14 @@ class UnnecessaryFullyQualifiedName(config: Config) :
             .filterIsInstance<KtTypeParameterListOwner>()
             .flatMap { it.typeParameters }
             .any { it.nameAsName == name }
+
+    private fun KaSymbol.collisionCheckName(): Name? =
+        when (this) {
+            is KaClassSymbol -> classId?.shortClassName
+            is KaConstructorSymbol -> containingClassId?.shortClassName
+            is KaCallableSymbol -> callableId?.callableName
+            else -> null
+        }
 
     private fun KaSymbol.packageFqName(): String? =
         when (this) {

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1229,6 +1229,31 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code, annotationCode, interfaceCode)).isEmpty()
         }
+
+        @Test
+        fun `does not report deeply nested type when a top-level outer class name is claimed`() {
+            val code = """
+                import foo.bar1.Outer
+
+                fun main() {
+                    foo.bar2.Outer.Middle.Leaf()
+                }
+            """.trimIndent()
+            val importedOuter = """
+                package foo.bar1
+                class Outer
+            """.trimIndent()
+            val otherOuter = """
+                package foo.bar2
+                class Outer {
+                    class Middle {
+                        class Leaf
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, importedOuter, otherOuter)).isEmpty()
+        }
     }
 
     // https://github.com/detekt/detekt/issues/9282

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1194,6 +1194,41 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code, annotationCode, interfaceCode)).isEmpty()
         }
+
+        @Test
+        fun `does not report when there is another import`() {
+            val code = """
+                import foo.bar1.Foo
+
+                fun main() {
+                    Foo()
+                    foo.bar2.Foo(
+                        foo.bar2.Foo.Color("dark")
+                    )
+                    foo.bar2.Foo(
+                        foo.bar2.Foo.Color.white
+                    )
+                }  
+            """.trimIndent()
+            val annotationCode = """
+                package foo.bar1
+                fun Foo() {}
+            """.trimIndent()
+            val interfaceCode = """
+                package foo.bar2
+                data class Foo(
+                    val color: Color
+                ) {
+                    class Color(name: String) {
+                        companion object {
+                            val white = Color("white")
+                        }
+                    }    
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, annotationCode, interfaceCode)).isEmpty()
+        }
     }
 
     // https://github.com/detekt/detekt/issues/9282


### PR DESCRIPTION
Fixes #9466 

When you have an import that already claims a name, the rule was still flagging nested type references as unnecessary. If `import foo.bar1.Foo` is in scope, flagging `foo.bar2.Foo.Color(...)` and suggesting you import Foo is wrong. Food is already taken.

The collision check only looked at the leaf symbol (`Color`) and never asked whether the outer class (`Foo`) was actually open to import. The scope lookup also had a bug where it checked classifiers or callables depending on symbol type, but Kotlin import don't partition that way. A function and a class with the same name block each other the same way.

Fixed by checking both classifers and callables in the scope lookup, and adding `hasOuterClassCollision` which walks up the outer class chain and runs the full collision check at ech level