### PR TITLE
Add support for hash-addressed baseline fragments

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -101,6 +101,13 @@ class CliArgs {
     var baseline: Path? = null
 
     @Parameter(
+        names = ["--baseline-fragments"],
+        description = "Directory containing one hash-addressed baseline ID fragment per XML file.",
+        converter = PathConverter::class
+    )
+    var baselineFragments: Path? = null
+
+    @Parameter(
         names = ["--create-baseline", "-cb"],
         description = "Treats current analysis findings as a smell baseline for future detekt runs."
     )

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/JCommander.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/JCommander.kt
@@ -2,6 +2,8 @@ package dev.detekt.cli
 
 import com.beust.jcommander.JCommander
 import com.beust.jcommander.ParameterException
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
 import kotlin.io.path.notExists
 
@@ -33,22 +35,37 @@ private fun JCommander.usageAsString(): String {
 }
 
 private fun CliArgs.validate(jCommander: JCommander) {
-    var violation: String? = null
     val baseline = baseline
+    val baselineFragments = baselineFragments
+    val violation = when {
+        baseline != null && baselineFragments != null ->
+            "--baseline and --baseline-fragments cannot be used together."
 
-    if (createBaseline && baseline == null) {
-        violation = "Creating a baseline.xml requires the --baseline parameter to specify a path."
-    }
+        createBaseline && baseline == null && baselineFragments == null ->
+            "Creating a baseline requires either --baseline or --baseline-fragments to specify an output path."
 
-    if (!createBaseline && baseline != null) {
-        if (baseline.notExists()) {
-            violation = "The file specified by --baseline should exist '$baseline'."
-        } else if (!baseline.isRegularFile()) {
-            violation = "The path specified by --baseline should be a file '$baseline'."
-        }
+        !createBaseline && baseline != null -> baseline.validationError()
+
+        baselineFragments != null -> baselineFragments.validationError(createBaseline)
+
+        else -> null
     }
 
     if (violation != null) {
         throw HandledArgumentViolation(violation, jCommander.usageAsString())
     }
 }
+
+private fun Path.validationError(): String? =
+    when {
+        notExists() -> "The file specified by --baseline should exist '$this'."
+        !isRegularFile() -> "The path specified by --baseline should be a file '$this'."
+        else -> null
+    }
+
+private fun Path.validationError(createBaseline: Boolean): String? =
+    when {
+        !createBaseline && notExists() -> "The directory specified by --baseline-fragments should exist '$this'."
+        !notExists() && !isDirectory() -> "The path specified by --baseline-fragments should be a directory '$this'."
+        else -> null
+    }

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -44,6 +44,7 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
 
         baseline {
             path = args.baseline
+            fragmentDirectory = args.baselineFragments
             shouldCreateDuringAnalysis = args.createBaseline
         }
 

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -288,10 +288,57 @@ internal class CliArgsSpec {
         inner class `Baseline feature` {
 
             @Test
-            fun `reports an error when using --create-baseline without a --baseline file`() {
+            fun `passes --baseline-fragments directory to the processing spec`() {
+                val directory = resourceAsPath("/cases")
+
+                val spec = parseArguments(arrayOf("--baseline-fragments", directory.toString())).toSpec()
+
+                assertThat(spec.baselineSpec.fragmentDirectory).isEqualTo(directory)
+            }
+
+            @Test
+            fun `reports an error when --baseline-fragments directory does not exist`() {
+                assertThatCode { parseArguments(arrayOf("--baseline-fragments", "nonExistent")) }
+                    .isInstanceOf(HandledArgumentViolation::class.java)
+                    .hasMessage("The directory specified by --baseline-fragments should exist 'nonExistent'.")
+            }
+
+            @Test
+            fun `allows a missing --baseline-fragments directory when creating a baseline`() {
+                val spec = parseArguments(
+                    arrayOf("--create-baseline", "--baseline-fragments", "nonExistent")
+                ).toSpec()
+
+                assertThat(spec.baselineSpec.fragmentDirectory).isEqualTo(Path("nonExistent"))
+                assertThat(spec.baselineSpec.shouldCreateDuringAnalysis).isTrue()
+            }
+
+            @Test
+            fun `reports an error when both baseline storage modes are configured`() {
+                val baseline = resourceAsPath("/configs/baseline-empty.xml")
+                val fragments = resourceAsPath("/cases")
+
+                assertThatCode {
+                    parseArguments(
+                        arrayOf(
+                            "--baseline",
+                            baseline.toString(),
+                            "--baseline-fragments",
+                            fragments.toString(),
+                        )
+                    )
+                }
+                    .isInstanceOf(HandledArgumentViolation::class.java)
+                    .hasMessage("--baseline and --baseline-fragments cannot be used together.")
+            }
+
+            @Test
+            fun `reports an error when using --create-baseline without a baseline storage path`() {
                 assertThatCode { parseArguments(arrayOf("--create-baseline")) }
                     .isInstanceOf(HandledArgumentViolation::class.java)
-                    .hasMessage("Creating a baseline.xml requires the --baseline parameter to specify a path.")
+                    .hasMessage(
+                        "Creating a baseline requires either --baseline or --baseline-fragments to specify an output path."
+                    )
             }
 
             @Test

--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/runners/RunnerSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/runners/RunnerSpec.kt
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.io.TempDir
 import java.io.PrintStream
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.walk
 
 class RunnerSpec {
 
@@ -35,6 +37,25 @@ class RunnerSpec {
         )
 
         assertThat(baseline).content().contains("<SmellBaseline>")
+    }
+
+    @Test
+    fun `creates and reuses hash-addressed baseline fragments`(@TempDir tempDir: Path) {
+        val fragments = tempDir.resolve("baseline.d")
+        val arguments = arrayOf(
+            "--input",
+            inputPath.toString(),
+            "--config-resource",
+            "/configs/valid-config.yml",
+            "--baseline-fragments",
+            fragments.toString(),
+        )
+
+        executeDetekt(*arguments, "--create-baseline")
+
+        assertThat(fragments.walk().filter { it.isRegularFile() && it.fileName.toString().endsWith(".xml") }.toList())
+            .hasSize(1)
+        assertThatCode { executeDetekt(*arguments) }.doesNotThrowAnyException()
     }
 
     @Nested

--- a/detekt-compiler-plugin/build.gradle.kts
+++ b/detekt-compiler-plugin/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 
     testImplementation(libs.assertj.core)
     testImplementation(libs.kctfork.core)
+    testImplementation(libs.kotlin.compiler)
+    testImplementation("org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
     testCompileOnly(libs.jetbrains.annotations)
 }
 

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/DetektCommandLineProcessor.kt
@@ -36,6 +36,12 @@ class DetektCommandLineProcessor : CommandLineProcessor {
             false
         ),
         CliOption(
+            Options.BASELINE_FRAGMENTS,
+            "<path>",
+            "Path to a detekt baseline fragments directory.",
+            false
+        ),
+        CliOption(
             Options.DEBUG,
             "<true|false>",
             "Print debug messages.",
@@ -97,6 +103,8 @@ class DetektCommandLineProcessor : CommandLineProcessor {
     override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
         when (option.optionName) {
             Options.BASELINE -> configuration.put(Keys.BASELINE, Path(value))
+
+            Options.BASELINE_FRAGMENTS -> configuration.put(Keys.BASELINE_FRAGMENTS, Path(value))
 
             Options.CONFIG -> configuration.appendList(Keys.CONFIG, Path(value))
 

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/Keys.kt
@@ -11,6 +11,7 @@ object Options {
     const val CONFIG = "config"
     const val CONFIG_DIGEST: String = "configDigest"
     const val BASELINE: String = "baseline"
+    const val BASELINE_FRAGMENTS: String = "baselineFragments"
     const val USE_DEFAULT_CONFIG: String = "useDefaultConfig"
     const val ALL_RULES: String = "allRules"
     const val DISABLE_DEFAULT_RULE_SETS: String = "disableDefaultRuleSets"
@@ -27,6 +28,7 @@ object Keys {
     val CONFIG = CompilerConfigurationKey.create<List<Path>>(Options.CONFIG)
     val CONFIG_DIGEST = CompilerConfigurationKey.create<String>(Options.CONFIG_DIGEST)
     val BASELINE = CompilerConfigurationKey.create<Path>(Options.BASELINE)
+    val BASELINE_FRAGMENTS = CompilerConfigurationKey.create<Path>(Options.BASELINE_FRAGMENTS)
     val USE_DEFAULT_CONFIG = CompilerConfigurationKey.create<Boolean>(Options.USE_DEFAULT_CONFIG)
     val ALL_RULES = CompilerConfigurationKey.create<Boolean>(Options.ALL_RULES)
     val DISABLE_DEFAULT_RULE_SETS = CompilerConfigurationKey.create<Boolean>(Options.DISABLE_DEFAULT_RULE_SETS)

--- a/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
+++ b/detekt-compiler-plugin/src/main/kotlin/io/github/detekt/compiler/plugin/internal/CompilerConfigToProcessingSpec.kt
@@ -15,6 +15,7 @@ internal fun CompilerConfiguration.toSpec(log: MessageCollector) =
         }
         baseline {
             path = get(Keys.BASELINE)
+            fragmentDirectory = get(Keys.BASELINE_FRAGMENTS)
         }
         logging {
             debug = get(Keys.DEBUG, false)

--- a/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/BaselineFragmentsSpec.kt
+++ b/detekt-compiler-plugin/src/test/kotlin/io/github/detekt/compiler/plugin/BaselineFragmentsSpec.kt
@@ -1,0 +1,24 @@
+package io.github.detekt.compiler.plugin
+
+import io.github.detekt.compiler.plugin.internal.toSpec
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.kotlin.cli.common.messages.MessageCollector
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.junit.jupiter.api.Test
+import kotlin.io.path.Path
+
+class BaselineFragmentsSpec {
+
+    @Test
+    @OptIn(CompilerConfiguration.Internals::class)
+    fun `maps baseline fragments option to processing spec`() {
+        val processor = DetektCommandLineProcessor()
+        val option = processor.pluginOptions.single { it.optionName == Options.BASELINE_FRAGMENTS }
+        val configuration = CompilerConfiguration()
+
+        processor.processOption(option, "baseline.d", configuration)
+
+        assertThat(configuration.toSpec(MessageCollector.NONE).baselineSpec.fragmentDirectory)
+            .isEqualTo(Path("baseline.d"))
+    }
+}

--- a/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineFragmentFormat.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineFragmentFormat.kt
@@ -29,7 +29,10 @@ import kotlin.io.path.outputStream
 import kotlin.io.path.relativeTo
 import kotlin.io.path.walk
 
-internal class BaselineFragmentFormat {
+internal class BaselineFragmentFormat(
+    private val beforeFileLock: (Path) -> Unit = {},
+    private val afterProcessLockRegistered: () -> Unit = {},
+) {
 
     fun read(directory: Path): DefaultBaseline {
         require(directory.isDirectory()) { "Baseline fragment path must be a directory: $directory" }
@@ -114,27 +117,29 @@ internal class BaselineFragmentFormat {
     }
 
     private fun <T> withDirectoryLock(directory: Path, action: () -> T): T {
-        val lockIdentity = runCatching { directory.toRealPath() }
-            .getOrElse { directory.toAbsolutePath().normalize() }
-        val processLock = processLocks.computeIfAbsent(lockIdentity) { ReentrantLock() }
-        processLock.lock()
+        val lockIdentity = directory.baselineFragmentLockIdentity()
+        val processLock = processLocks.compute(lockIdentity) { _, existing ->
+            (existing ?: ProcessLock()).also { it.users++ }
+        } ?: error("Could not register baseline fragment lock.")
+        afterProcessLockRegistered()
+        processLock.lock.lock()
         try {
-            val lockFile = lockFileFor(lockIdentity)
+            val lockFile = baselineFragmentLockFileForIdentity(lockIdentity)
             return FileChannel.open(lockFile, CREATE, WRITE).use { channel ->
+                beforeFileLock(lockFile)
                 channel.lock().use { action() }
             }
         } finally {
-            processLock.unlock()
+            processLock.lock.unlock()
+            processLocks.compute(lockIdentity) { _, current ->
+                if (current === processLock) {
+                    processLock.users--
+                    processLock.takeUnless { it.users == 0 }
+                } else {
+                    current
+                }
+            }
         }
-    }
-
-    private fun lockFileFor(lockIdentity: Path): Path {
-        // A user-scoped directory keeps coordination files outside checkouts without exposing a shared tmp namespace.
-        val lockDirectory = Path.of(System.getProperty("user.home"), ".detekt", LOCK_DIRECTORY_NAME).createDirectories()
-        val digest = MessageDigest.getInstance("SHA-256")
-            .digest(lockIdentity.toString().toByteArray(UTF_8))
-            .joinToString("") { byte -> "%02x".format(Locale.ROOT, byte) }
-        return lockDirectory.resolve("$digest.lock")
     }
 
     private fun deleteEmptyShardDirectories(directory: Path) {
@@ -181,13 +186,39 @@ internal class BaselineFragmentFormat {
         }
     }
 
-    private companion object {
-        val processLocks = ConcurrentHashMap<Path, ReentrantLock>()
+    private class ProcessLock(val lock: ReentrantLock = ReentrantLock(), var users: Int = 0)
+
+    internal companion object {
+        private val processLocks = ConcurrentHashMap<Path, ProcessLock>()
         const val XML_EXTENSION = "xml"
         const val LOCK_DIRECTORY_NAME = "detekt-baseline-locks"
+        const val LOCK_DIRECTORY_PROPERTY = "dev.detekt.baseline.lock.directory"
         const val TEMPORARY_SUFFIX = ".tmp"
+
+        internal fun processLockUsers(lockIdentity: Path): Int = processLocks[lockIdentity]?.users ?: 0
     }
 }
+
+internal fun baselineFragmentLockFile(directory: Path): Path =
+    baselineFragmentLockFileForIdentity(directory.baselineFragmentLockIdentity())
+
+internal fun baselineFragmentProcessLockUsers(directory: Path): Int =
+    BaselineFragmentFormat.processLockUsers(directory.baselineFragmentLockIdentity())
+
+private fun baselineFragmentLockFileForIdentity(lockIdentity: Path): Path {
+    // A user-scoped directory keeps coordination files outside checkouts without exposing a shared tmp namespace.
+    val configuredLockDirectory = System.getProperty(BaselineFragmentFormat.LOCK_DIRECTORY_PROPERTY)
+    val lockDirectory = configuredLockDirectory?.let(Path::of)
+        ?: Path.of(System.getProperty("user.home"), ".detekt", BaselineFragmentFormat.LOCK_DIRECTORY_NAME)
+    lockDirectory.createDirectories()
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest(lockIdentity.toString().toByteArray(UTF_8))
+        .joinToString("") { byte -> "%02x".format(Locale.ROOT, byte) }
+    return lockDirectory.resolve("$digest.lock")
+}
+
+private fun Path.baselineFragmentLockIdentity(): Path =
+    runCatching { toRealPath() }.getOrElse { toAbsolutePath().normalize() }
 
 private fun canonicalElement(id: String): String = "<ID>${id.escapeXml()}</ID>"
 
@@ -199,6 +230,7 @@ private fun String.escapeXml(): String =
                     '&' -> "&amp;"
                     '<' -> "&lt;"
                     '>' -> "&gt;"
+                    '\r' -> "&#13;"
                     else -> character
                 }
             )

--- a/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineFragmentFormat.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineFragmentFormat.kt
@@ -1,0 +1,224 @@
+package dev.detekt.core.baseline
+
+import org.xml.sax.Attributes
+import org.xml.sax.SAXException
+import org.xml.sax.helpers.DefaultHandler
+import java.nio.channels.FileChannel
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.WRITE
+import java.security.MessageDigest
+import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+import javax.xml.XMLConstants
+import javax.xml.parsers.SAXParserFactory
+import kotlin.io.path.createDirectories
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.extension
+import kotlin.io.path.inputStream
+import kotlin.io.path.isDirectory
+import kotlin.io.path.name
+import kotlin.io.path.outputStream
+import kotlin.io.path.relativeTo
+import kotlin.io.path.walk
+
+internal class BaselineFragmentFormat {
+
+    fun read(directory: Path): DefaultBaseline {
+        require(directory.isDirectory()) { "Baseline fragment path must be a directory: $directory" }
+        return withDirectoryLock(directory) {
+            val currentIssues = directory.fragmentFiles()
+                .map { path ->
+                    val id = readFragment(path)
+                    require(path.relativeTo(directory) == relativePath(id)) {
+                        "Baseline fragment path does not match its content hash: $path"
+                    }
+                    id
+                }
+                .toList()
+            require(currentIssues.size == currentIssues.toSet().size) {
+                "Baseline fragment directory contains duplicate IDs: $directory"
+            }
+            DefaultBaseline(emptySet(), currentIssues.toSet())
+        }
+    }
+
+    fun write(directory: Path, baseline: DefaultBaseline) {
+        val fragments = baseline.currentIssues
+            .associateByCollisionChecked(::relativePath)
+            .mapKeys { (path, _) -> directory.resolve(path) }
+
+        directory.createDirectories()
+        withDirectoryLock(directory) {
+            deleteTemporaryFiles(directory)
+            fragments.forEach { (target, id) -> writeAtomically(target, canonicalElement(id) + "\n") }
+            directory.fragmentFiles()
+                .filterNot(fragments::containsKey)
+                .forEach(Path::deleteIfExists)
+            deleteTemporaryFiles(directory)
+            deleteEmptyShardDirectories(directory)
+        }
+    }
+
+    private fun readFragment(path: Path): String =
+        try {
+            path.inputStream().use { input ->
+                val handler = FragmentHandler()
+                secureSaxParser().parse(input, handler)
+                handler.id()
+            }
+        } catch (error: SAXException) {
+            throw IllegalStateException("Baseline fragment '$path' must contain exactly one valid ID element.", error)
+        }
+
+    private fun secureSaxParser() =
+        SAXParserFactory.newInstance()
+            .apply {
+                setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true)
+                setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+                setFeature("http://xml.org/sax/features/external-general-entities", false)
+                setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+                setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+            }
+            .newSAXParser()
+
+    private fun Path.fragmentFiles(): Sequence<Path> =
+        walk().filter { path ->
+            Files.isRegularFile(path, NOFOLLOW_LINKS) && path.extension == XML_EXTENSION
+        }
+
+    private fun writeAtomically(target: Path, content: String) {
+        requireNotNull(target.parent).createDirectories()
+        val temporary = Files.createTempFile(target.parent, ".${target.name}.", TEMPORARY_SUFFIX)
+        temporary.outputStream().bufferedWriter(UTF_8).use { it.write(content) }
+        try {
+            Files.move(temporary, target, ATOMIC_MOVE, REPLACE_EXISTING)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(temporary, target, REPLACE_EXISTING)
+        } finally {
+            temporary.deleteIfExists()
+        }
+    }
+
+    private fun deleteTemporaryFiles(directory: Path) {
+        directory.walk()
+            .filter { path -> Files.isRegularFile(path, NOFOLLOW_LINKS) && path.name.endsWith(TEMPORARY_SUFFIX) }
+            .forEach(Path::deleteIfExists)
+    }
+
+    private fun <T> withDirectoryLock(directory: Path, action: () -> T): T {
+        val lockIdentity = runCatching { directory.toRealPath() }
+            .getOrElse { directory.toAbsolutePath().normalize() }
+        val processLock = processLocks.computeIfAbsent(lockIdentity) { ReentrantLock() }
+        processLock.lock()
+        try {
+            val lockFile = lockFileFor(lockIdentity)
+            return FileChannel.open(lockFile, CREATE, WRITE).use { channel ->
+                channel.lock().use { action() }
+            }
+        } finally {
+            processLock.unlock()
+        }
+    }
+
+    private fun lockFileFor(lockIdentity: Path): Path {
+        // A user-scoped directory keeps coordination files outside checkouts without exposing a shared tmp namespace.
+        val lockDirectory = Path.of(System.getProperty("user.home"), ".detekt", LOCK_DIRECTORY_NAME).createDirectories()
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(lockIdentity.toString().toByteArray(UTF_8))
+            .joinToString("") { byte -> "%02x".format(Locale.ROOT, byte) }
+        return lockDirectory.resolve("$digest.lock")
+    }
+
+    private fun deleteEmptyShardDirectories(directory: Path) {
+        directory.walk()
+            .filter { it != directory && it.isDirectory() }
+            .sortedByDescending { it.nameCount }
+            .forEach { path ->
+                if (!path.walk().drop(1).iterator().hasNext()) path.deleteIfExists()
+            }
+    }
+
+    private class FragmentHandler : DefaultHandler() {
+        private var depth = 0
+        private var idCount = 0
+        private val content = StringBuilder()
+
+        override fun startElement(uri: String, localName: String, qName: String, attributes: Attributes) {
+            depth++
+            if (attributes.length != 0) {
+                throw SAXException("A baseline fragment ID element must not have attributes.")
+            }
+            if (depth != 1 || qName != ID || idCount != 0) {
+                throw SAXException("A baseline fragment must contain exactly one ID element.")
+            }
+            idCount++
+        }
+
+        override fun characters(ch: CharArray, start: Int, length: Int) {
+            if (depth == 1) content.append(ch, start, length)
+        }
+
+        override fun endElement(uri: String, localName: String, qName: String) {
+            if (depth != 1 || qName != ID) {
+                throw SAXException("A baseline fragment must contain exactly one ID element.")
+            }
+            depth--
+        }
+
+        fun id(): String {
+            if (idCount != 1 || depth != 0 || content.isBlank()) {
+                throw SAXException("A baseline fragment must contain exactly one non-empty ID element.")
+            }
+            return content.toString()
+        }
+    }
+
+    private companion object {
+        val processLocks = ConcurrentHashMap<Path, ReentrantLock>()
+        const val XML_EXTENSION = "xml"
+        const val LOCK_DIRECTORY_NAME = "detekt-baseline-locks"
+        const val TEMPORARY_SUFFIX = ".tmp"
+    }
+}
+
+private fun canonicalElement(id: String): String = "<ID>${id.escapeXml()}</ID>"
+
+private fun String.escapeXml(): String =
+    buildString(length) {
+        this@escapeXml.forEach { character ->
+            append(
+                when (character) {
+                    '&' -> "&amp;"
+                    '<' -> "&lt;"
+                    '>' -> "&gt;"
+                    else -> character
+                }
+            )
+        }
+    }
+
+private fun relativePath(id: String): Path {
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest(canonicalElement(id).toByteArray(UTF_8))
+        .joinToString("") { byte -> "%02x".format(Locale.ROOT, byte) }
+    return Path.of(digest.take(SHARD_LENGTH), "$digest.xml")
+}
+
+private fun Set<String>.associateByCollisionChecked(path: (String) -> Path): Map<Path, String> =
+    buildMap {
+        this@associateByCollisionChecked.forEach { id ->
+            val target = path(id)
+            val previous = put(target, id)
+            check(previous == null || previous == id) { "Baseline fragment SHA-256 collision: $target" }
+        }
+    }
+
+private const val SHARD_LENGTH = 2

--- a/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineResultMapping.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/baseline/BaselineResultMapping.kt
@@ -12,22 +12,30 @@ import kotlin.io.path.isRegularFile
 class BaselineResultMapping : ReportingExtension {
 
     private var baselineFile: Path? = null
+    private var fragmentDirectory: Path? = null
     private var createBaseline: Boolean = false
 
     override val id: String = "BaselineResultMapping"
 
     override fun init(context: SetupContext) {
         baselineFile = context.getOrNull(DETEKT_BASELINE_PATH_KEY)
+        fragmentDirectory = context.getOrNull(DETEKT_BASELINE_FRAGMENTS_PATH_KEY)
         createBaseline = context.getOrNull(DETEKT_BASELINE_CREATION_KEY) ?: false
     }
 
     override fun transformIssues(issues: List<Issue>): List<Issue> {
         val baselineFile = baselineFile
-        require(!createBaseline || (createBaseline && baselineFile != null)) {
+        val fragmentDirectory = fragmentDirectory
+        require(baselineFile == null || fragmentDirectory == null) { "Invalid baseline options invariant." }
+        require(!createBaseline || baselineFile != null || fragmentDirectory != null) {
             "Invalid baseline options invariant."
         }
 
-        return baselineFile?.let { issues.transformWithBaseline(it) } ?: issues
+        return when {
+            baselineFile != null -> issues.transformWithBaseline(baselineFile)
+            fragmentDirectory != null -> issues.transformWithFragments(fragmentDirectory)
+            else -> issues
+        }
     }
 
     private fun List<Issue>.transformWithBaseline(baselinePath: Path): List<Issue> {
@@ -36,6 +44,16 @@ class BaselineResultMapping : ReportingExtension {
         }
 
         return filterByBaseline(baselinePath, this)
+    }
+
+    private fun List<Issue>.transformWithFragments(directory: Path): List<Issue> {
+        val format = BaselineFragmentFormat()
+        if (createBaseline) {
+            val ids = map { it.baselineId }.toSortedSet()
+            format.write(directory, DefaultBaseline(emptySet(), ids))
+        }
+        val baseline = format.read(directory)
+        return filterNot { baseline.contains(it.baselineId) }
     }
 
     fun filterByBaseline(baselineFile: Path, issues: List<Issue>): List<Issue> =

--- a/detekt-core/src/main/kotlin/dev/detekt/core/baseline/DefaultBaseline.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/baseline/DefaultBaseline.kt
@@ -27,6 +27,7 @@ internal data class DefaultBaseline(
 }
 
 const val DETEKT_BASELINE_PATH_KEY = "detekt.baseline.path.key"
+const val DETEKT_BASELINE_FRAGMENTS_PATH_KEY = "detekt.baseline.fragments.path.key"
 const val DETEKT_BASELINE_CREATION_KEY = "detekt.baseline.creation.key"
 
 internal const val SMELL_BASELINE = "SmellBaseline"

--- a/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/tooling/ProcessingSpecSettingsBridge.kt
@@ -3,6 +3,7 @@ package dev.detekt.core.tooling
 import dev.detekt.api.Config
 import dev.detekt.core.ProcessingSettings
 import dev.detekt.core.baseline.DETEKT_BASELINE_CREATION_KEY
+import dev.detekt.core.baseline.DETEKT_BASELINE_FRAGMENTS_PATH_KEY
 import dev.detekt.core.baseline.DETEKT_BASELINE_PATH_KEY
 import dev.detekt.core.config.AllRulesConfig
 import dev.detekt.core.config.CompositeConfig
@@ -28,6 +29,7 @@ internal fun <R> ProcessingSpec.withSettings(execute: ProcessingSettings.() -> R
     val settings = monitor.measure(Phase.CreateSettings) {
         ProcessingSettings(this, configuration, monitor).apply {
             baselineSpec.path?.let { register(DETEKT_BASELINE_PATH_KEY, it) }
+            baselineSpec.fragmentDirectory?.let { register(DETEKT_BASELINE_FRAGMENTS_PATH_KEY, it) }
             register(DETEKT_BASELINE_CREATION_KEY, baselineSpec.shouldCreateDuringAnalysis)
         }
     }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
@@ -94,6 +94,16 @@ class BaselineFragmentFormatSpec {
     }
 
     @Test
+    fun `rejects a whitespace-only ID`() {
+        fragmentsDirectory.createDirectories()
+        fragmentsDirectory.resolve("invalid.xml").writeText("<ID>   </ID>\n")
+
+        assertThatIllegalStateException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+            .withMessageContaining("exactly one")
+    }
+
+    @Test
     fun `escapes IDs and verifies the hash from their decoded value`() {
         val id = "one & <two>"
         val format = BaselineFragmentFormat()
@@ -302,5 +312,19 @@ class BaselineFragmentFormatSpec {
         )
 
         assertThat(fragmentsDirectory.walk().filter { it.name.endsWith(".tmp") }.toList()).isEmpty()
+    }
+
+    @Test
+    fun `removes stale temporary files when writing fragments`() {
+        val staleTemporaryFile = fragmentsDirectory.resolve("nested/orphan.tmp")
+        staleTemporaryFile.parent.createDirectories()
+        staleTemporaryFile.writeText("stale")
+
+        BaselineFragmentFormat().write(
+            fragmentsDirectory,
+            DefaultBaseline(emptySet(), setOf("one")),
+        )
+
+        assertThat(staleTemporaryFile).doesNotExist()
     }
 }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
@@ -1,0 +1,177 @@
+package dev.detekt.core.baseline
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
+import org.assertj.core.api.Assertions.assertThatIllegalStateException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.createDirectories
+import kotlin.io.path.createFile
+import kotlin.io.path.listDirectoryEntries
+import kotlin.io.path.name
+import kotlin.io.path.walk
+import kotlin.io.path.writeText
+
+class BaselineFragmentFormatSpec {
+
+    private val oneHash = "eaf9bfb60bc3201b682726631958d1ad05bfcc3382d08a3963823f00aa56eeb1"
+
+    @TempDir
+    lateinit var tempDir: Path
+
+    private val fragmentsDirectory
+        get() = tempDir.resolve("baseline.d")
+
+    @Test
+    fun `writes one deterministic hash-addressed file for each unique ID`() {
+        val baseline = DefaultBaseline(emptySet(), setOf("one", "one"))
+
+        BaselineFragmentFormat().write(fragmentsDirectory, baseline)
+
+        val expected = fragmentsDirectory.resolve("${oneHash.substring(0, 2)}/$oneHash.xml")
+        assertThat(expected).hasContent("<ID>one</ID>\n")
+        assertThat(fragmentsDirectory.resolve(oneHash.substring(0, 2)).listDirectoryEntries()).containsExactly(expected)
+    }
+
+    @Test
+    fun `rejects a fragment whose path does not match its content hash`() {
+        fragmentsDirectory.resolve("aa").createDirectories()
+        fragmentsDirectory.resolve("aa/incorrect.xml").writeText("<ID>one</ID>\n")
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+            .withMessageContaining("does not match")
+    }
+
+    @Test
+    fun `removes stale fragments during explicit creation`() {
+        fragmentsDirectory.resolve("stale").createDirectories()
+        fragmentsDirectory.resolve("stale/old.xml").writeText("<ID>old</ID>\n")
+
+        BaselineFragmentFormat().write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf("one")))
+
+        assertThat(fragmentsDirectory.resolve("stale/old.xml")).doesNotExist()
+        assertThat(BaselineFragmentFormat().read(fragmentsDirectory).currentIssues).containsExactly("one")
+    }
+
+    @Test
+    fun `rejects fragments with more than one ID`() {
+        fragmentsDirectory.createDirectories()
+        val fragment = fragmentsDirectory.resolve("invalid.xml")
+        fragment.writeText("<ID>one</ID><ID>two</ID>\n")
+
+        assertThatIllegalStateException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+            .withMessageContaining("exactly one")
+    }
+
+    @Test
+    fun `rejects attributes on an ID element`() {
+        fragmentsDirectory.createDirectories()
+        fragmentsDirectory.resolve("invalid.xml").writeText("<ID source=\"manual\">one</ID>\n")
+
+        assertThatIllegalStateException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+            .withMessageContaining("exactly one")
+    }
+
+    @Test
+    fun `rejects nested elements in an ID element`() {
+        fragmentsDirectory.createDirectories()
+        fragmentsDirectory.resolve("invalid.xml").writeText("<ID>one<nested/>two</ID>\n")
+
+        assertThatIllegalStateException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+            .withMessageContaining("exactly one")
+    }
+
+    @Test
+    fun `escapes IDs and verifies the hash from their decoded value`() {
+        val id = "one & <two>"
+        val format = BaselineFragmentFormat()
+
+        format.write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf(id)))
+
+        val fragment = fragmentsDirectory.walk().single { it.toString().endsWith(".xml") }
+        assertThat(fragment).hasContent("<ID>one &amp; &lt;two&gt;</ID>\n")
+        assertThat(format.read(fragmentsDirectory).currentIssues).containsExactly(id)
+    }
+
+    @Test
+    fun `rejects document type declarations`() {
+        fragmentsDirectory.createDirectories()
+        val fragment = fragmentsDirectory.resolve("invalid.xml")
+        fragment.writeText("<!DOCTYPE ID [<!ENTITY xxe SYSTEM \"file:///etc/passwd\">]><ID>&xxe;</ID>\n")
+
+        assertThatIllegalStateException()
+            .isThrownBy { BaselineFragmentFormat().read(fragmentsDirectory) }
+    }
+
+    @Test
+    fun `writes an empty directory for an empty baseline`() {
+        fragmentsDirectory.createDirectories()
+        fragmentsDirectory.resolve("old.xml").createFile()
+
+        BaselineFragmentFormat().write(fragmentsDirectory, DefaultBaseline(emptySet(), emptySet()))
+
+        assertThat(fragmentsDirectory.toFile().walkTopDown().filter { it.extension == "xml" }.toList()).isEmpty()
+    }
+
+    @Test
+    fun `reading fragments does not change the managed directory`() {
+        val format = BaselineFragmentFormat()
+        format.write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf("one")))
+        val entriesBeforeRead = fragmentsDirectory.walk().map { it.toString() }.toList()
+        val parentEntriesBeforeRead = tempDir.listDirectoryEntries()
+
+        format.read(fragmentsDirectory)
+
+        assertThat(
+            fragmentsDirectory.walk().map { it.toString() }.toList()
+        ).containsExactlyElementsOf(entriesBeforeRead)
+        assertThat(tempDir.listDirectoryEntries()).containsExactlyElementsOf(parentEntriesBeforeRead)
+    }
+
+    @Test
+    fun `concurrent readers observe a complete writer snapshot`() {
+        val format = BaselineFragmentFormat()
+        val oldIds = (1..50).mapTo(mutableSetOf()) { "old-$it" }
+        val newIds = (1..50).mapTo(mutableSetOf()) { "new-$it" }
+        format.write(fragmentsDirectory, DefaultBaseline(emptySet(), oldIds))
+        val start = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val writer = executor.submit {
+                start.await()
+                format.write(fragmentsDirectory, DefaultBaseline(emptySet(), newIds))
+            }
+            val reader = executor.submit<List<Set<String>>> {
+                start.await()
+                List(20) { format.read(fragmentsDirectory).currentIssues }
+            }
+            start.countDown()
+
+            writer.get(10, TimeUnit.SECONDS)
+            assertThat(reader.get(10, TimeUnit.SECONDS)).allSatisfy { snapshot ->
+                assertThat(snapshot == oldIds || snapshot == newIds).isTrue()
+            }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `does not leave temporary files after writing fragments`() {
+        BaselineFragmentFormat().write(
+            fragmentsDirectory,
+            DefaultBaseline(emptySet(), setOf("one", "two")),
+        )
+
+        assertThat(fragmentsDirectory.walk().filter { it.name.endsWith(".tmp") }.toList()).isEmpty()
+    }
+}

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineFragmentFormatSpec.kt
@@ -5,7 +5,10 @@ import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.ResourceLock
+import org.junit.jupiter.api.parallel.Resources
 import java.nio.file.Path
+import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -16,6 +19,7 @@ import kotlin.io.path.name
 import kotlin.io.path.walk
 import kotlin.io.path.writeText
 
+@ResourceLock(Resources.SYSTEM_PROPERTIES)
 class BaselineFragmentFormatSpec {
 
     private val oneHash = "eaf9bfb60bc3201b682726631958d1ad05bfcc3382d08a3963823f00aa56eeb1"
@@ -102,6 +106,19 @@ class BaselineFragmentFormatSpec {
     }
 
     @Test
+    fun `preserves carriage returns in canonical XML and its hash path`() {
+        val id = "one\rtwo"
+        val hash = "db8eed34a90a4e3edbb620b45c73f2047983dc901e746fa343ca66440be27544"
+        val format = BaselineFragmentFormat()
+
+        format.write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf(id)))
+
+        val fragment = fragmentsDirectory.resolve("${hash.take(2)}/$hash.xml")
+        assertThat(fragment).hasContent("<ID>one&#13;two</ID>\n")
+        assertThat(format.read(fragmentsDirectory).currentIssues).containsExactly(id)
+    }
+
+    @Test
     fun `rejects document type declarations`() {
         fragmentsDirectory.createDirectories()
         val fragment = fragmentsDirectory.resolve("invalid.xml")
@@ -162,6 +179,118 @@ class BaselineFragmentFormatSpec {
             }
         } finally {
             executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `reader waits for a lock held by another process`() {
+        val expected = setOf("one", "two")
+        BaselineFragmentFormat().write(fragmentsDirectory, DefaultBaseline(emptySet(), expected))
+        val lockFile = baselineFragmentLockFile(fragmentsDirectory)
+        val lockHolderSource = tempDir.resolve("LockHolder.java")
+        lockHolderSource.writeText(
+            """
+                import java.nio.channels.FileChannel;
+                import java.nio.file.Path;
+                import static java.nio.file.StandardOpenOption.CREATE;
+                import static java.nio.file.StandardOpenOption.WRITE;
+
+                class LockHolder {
+                    public static void main(String[] args) throws Exception {
+                        try (var channel = FileChannel.open(Path.of(args[0]), CREATE, WRITE);
+                             var ignored = channel.lock()) {
+                            System.out.println("LOCKED");
+                            System.out.flush();
+                            System.in.read();
+                        }
+                    }
+                }
+            """.trimIndent()
+        )
+        val process = ProcessBuilder(
+            Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+            lockHolderSource.toString(),
+            lockFile.toString(),
+        ).redirectErrorStream(true).start()
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val childReady = executor.submit(Callable { process.inputStream.bufferedReader().readLine() })
+            assertThat(childReady.get(10, TimeUnit.SECONDS)).isEqualTo("LOCKED")
+            val beforeFileLock = CountDownLatch(1)
+            val reader = executor.submit<Set<String>> {
+                BaselineFragmentFormat(beforeFileLock = { beforeFileLock.countDown() })
+                    .read(fragmentsDirectory)
+                    .currentIssues
+            }
+            assertThat(beforeFileLock.await(10, TimeUnit.SECONDS)).isTrue()
+            assertThat(reader).isNotDone()
+
+            process.outputStream.write(1)
+            process.outputStream.close()
+
+            assertThat(reader.get(10, TimeUnit.SECONDS)).isEqualTo(expected)
+            assertThat(process.waitFor(10, TimeUnit.SECONDS)).isTrue()
+            assertThat(process.exitValue()).isZero()
+        } finally {
+            process.destroyForcibly()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `retains a process lock for a waiting user and releases it after both finish`() {
+        val firstRegistered = CountDownLatch(1)
+        val releaseFirst = CountDownLatch(1)
+        val secondRegistered = CountDownLatch(1)
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val first = executor.submit {
+                BaselineFragmentFormat(
+                    afterProcessLockRegistered = {
+                        firstRegistered.countDown()
+                        releaseFirst.await()
+                    }
+                ).write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf("one")))
+            }
+            assertThat(firstRegistered.await(10, TimeUnit.SECONDS)).isTrue()
+            val second = executor.submit {
+                BaselineFragmentFormat(afterProcessLockRegistered = { secondRegistered.countDown() })
+                    .write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf("two")))
+            }
+            assertThat(secondRegistered.await(10, TimeUnit.SECONDS)).isTrue()
+            assertThat(baselineFragmentProcessLockUsers(fragmentsDirectory)).isEqualTo(2)
+
+            releaseFirst.countDown()
+            first.get(10, TimeUnit.SECONDS)
+            second.get(10, TimeUnit.SECONDS)
+
+            assertThat(baselineFragmentProcessLockUsers(fragmentsDirectory)).isZero()
+        } finally {
+            releaseFirst.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `uses a configured lock directory`() {
+        val configuredLockDirectory = tempDir.resolve("locks")
+        val previous = System.setProperty(
+            BaselineFragmentFormat.LOCK_DIRECTORY_PROPERTY,
+            configuredLockDirectory.toString(),
+        )
+
+        try {
+            BaselineFragmentFormat().write(fragmentsDirectory, DefaultBaseline(emptySet(), setOf("one")))
+
+            assertThat(configuredLockDirectory.listDirectoryEntries("*.lock")).hasSize(1)
+        } finally {
+            if (previous == null) {
+                System.clearProperty(BaselineFragmentFormat.LOCK_DIRECTORY_PROPERTY)
+            } else {
+                System.setProperty(BaselineFragmentFormat.LOCK_DIRECTORY_PROPERTY, previous)
+            }
         }
     }
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -107,6 +107,41 @@ class BaselineResultMappingSpec {
     }
 
     @Test
+    fun `filters issues found in a baseline fragment directory`() {
+        val fragmentDirectory = dir.resolve("baseline.d")
+        val suppressed = issues.first()
+        BaselineFragmentFormat().write(
+            fragmentDirectory,
+            DefaultBaseline(emptySet(), setOf(suppressed.baselineId)),
+        )
+        val mapping = resultMapping(
+            baselineFile = null,
+            createBaseline = false,
+            fragmentDirectory = fragmentDirectory,
+        )
+
+        val filtered = mapping.transformIssues(issues)
+
+        assertThat(filtered).containsExactlyElementsOf(issues.drop(1))
+    }
+
+    @Test
+    fun `creates one fragment per unique issue and filters all created issues`() {
+        val fragmentDirectory = dir.resolve("baseline.d")
+        val mapping = resultMapping(
+            baselineFile = null,
+            createBaseline = true,
+            fragmentDirectory = fragmentDirectory,
+        )
+
+        val filtered = mapping.transformIssues(issues + issues.first())
+
+        assertThat(filtered).isEmpty()
+        assertThat(BaselineFragmentFormat().read(fragmentDirectory).currentIssues)
+            .containsExactlyInAnyOrderElementsOf(issues.map { it.baselineId })
+    }
+
+    @Test
     fun `should update an existing baseline file if a file is configured`() {
         existingBaselineFile.copyTo(baselineFile)
         val existing = DefaultBaseline.load(baselineFile)
@@ -210,12 +245,13 @@ class BaselineResultMappingSpec {
     }
 }
 
-private fun resultMapping(baselineFile: Path?, createBaseline: Boolean?) =
+private fun resultMapping(baselineFile: Path?, createBaseline: Boolean?, fragmentDirectory: Path? = null) =
     BaselineResultMapping().apply {
         init(
             TestSetupContext(
                 properties = mapOf(
                     DETEKT_BASELINE_PATH_KEY to baselineFile,
+                    DETEKT_BASELINE_FRAGMENTS_PATH_KEY to fragmentDirectory,
                     DETEKT_BASELINE_CREATION_KEY to createBaseline,
                 )
             )

--- a/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/baseline/BaselineResultMappingSpec.kt
@@ -6,6 +6,7 @@ import dev.detekt.api.testfixtures.createIssueEntity
 import dev.detekt.api.testfixtures.createRuleInstance
 import dev.detekt.test.utils.resourceAsPath
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
@@ -139,6 +140,31 @@ class BaselineResultMappingSpec {
         assertThat(filtered).isEmpty()
         assertThat(BaselineFragmentFormat().read(fragmentDirectory).currentIssues)
             .containsExactlyInAnyOrderElementsOf(issues.map { it.baselineId })
+    }
+
+    @Test
+    fun `rejects baseline file and fragment directory configured together`() {
+        val mapping = resultMapping(
+            baselineFile = baselineFile,
+            createBaseline = false,
+            fragmentDirectory = dir.resolve("baseline.d"),
+        )
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { mapping.transformIssues(issues) }
+            .withMessage("Invalid baseline options invariant.")
+    }
+
+    @Test
+    fun `rejects baseline creation without a storage path`() {
+        val mapping = resultMapping(
+            baselineFile = null,
+            createBaseline = true,
+        )
+
+        assertThatIllegalArgumentException()
+            .isThrownBy { mapping.transformIssues(issues) }
+            .withMessage("Invalid baseline options invariant.")
     }
 
     @Test

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -6,6 +6,7 @@ public abstract class dev/detekt/gradle/Detekt : org/gradle/api/tasks/SourceTask
 	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBaselineFragments ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -37,6 +38,7 @@ public abstract class dev/detekt/gradle/DetektCreateBaselineTask : org/gradle/ap
 	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBasePath ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBaselineFragments ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getClasspath ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
@@ -85,6 +87,7 @@ public abstract interface class dev/detekt/gradle/extensions/DetektExtension {
 	public abstract fun getAutoCorrect ()Lorg/gradle/api/provider/Property;
 	public abstract fun getBasePath ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public abstract fun getBaselineFragments ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public abstract fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;
 	public abstract fun getDebug ()Lorg/gradle/api/provider/Property;

--- a/detekt-gradle-plugin/api/detekt-gradle-plugin.api
+++ b/detekt-gradle-plugin/api/detekt-gradle-plugin.api
@@ -151,6 +151,7 @@ public class dev/detekt/gradle/extensions/KotlinCompileTaskDetektExtension {
 	public fun <init> (Lorg/gradle/api/Project;)V
 	public final fun getAllRules ()Lorg/gradle/api/provider/Property;
 	public final fun getBaseline ()Lorg/gradle/api/file/RegularFileProperty;
+	public final fun getBaselineFragments ()Lorg/gradle/api/file/DirectoryProperty;
 	public final fun getBuildUponDefaultConfig ()Lorg/gradle/api/provider/Property;
 	public final fun getCheckstyle ()Ldev/detekt/gradle/extensions/DetektCompilerPluginReport;
 	public final fun getConfig ()Lorg/gradle/api/file/ConfigurableFileCollection;

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -147,6 +147,8 @@ dependencies {
 
     implementation(libs.sarif4k)
 
+    testImplementation(libs.kotlin.gradlePluginApi)
+
     testKitRuntimeOnly(libs.kotlin.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.plugin)
     testKitRuntimeOnly(libs.android.gradle.builtInKotlin.plugin)

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CreateBaselineTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/CreateBaselineTaskDslSpec.kt
@@ -56,6 +56,86 @@ class CreateBaselineTaskDslSpec {
             assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).exists()
         }
     }
+
+    @Test
+    fun `detektBaseline task creates hash-addressed baseline fragments`() {
+        val directoryName = "detekt-baseline.d"
+        val detektConfig = """
+            detekt {
+                baselineFragments.set(layout.projectDirectory.dir("$directoryName"))
+            }
+        """.trimIndent()
+        val gradleRunner = DslTestBuilder.kotlin()
+            .withProjectLayout(
+                ProjectLayout(
+                    numberOfSourceFilesInRootPerSourceDir = 1,
+                    numberOfFindingsInRootPerSourceDir = 1,
+                )
+            )
+            .withDetektConfig(detektConfig)
+            .withConfigFile("config/detekt/detekt.yml")
+            .build()
+
+        gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
+            assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(projectFile(DEFAULT_BASELINE_FILENAME)).doesNotExist()
+            assertThat(projectFile(directoryName).walkTopDown().filter { it.extension == "xml" }.toList()).isNotEmpty()
+        }
+
+        gradleRunner.runTasksAndCheckResult("detekt") { result ->
+            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        }
+
+        gradleRunner.projectFile(DEFAULT_BASELINE_FILENAME).writeText("unused baseline artifact")
+
+        gradleRunner.runTasksAndCheckResult("detekt") { result ->
+            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+        }
+    }
+
+    @Test
+    fun `detekt task ignores a missing baseline fragments directory`() {
+        val detektConfig = """
+            detekt {
+                baselineFragments.set(layout.projectDirectory.dir("missing-baseline.d"))
+            }
+        """.trimIndent()
+        val gradleRunner = DslTestBuilder.kotlin()
+            .withDetektConfig(detektConfig)
+            .build()
+
+        gradleRunner.runTasksAndCheckResult("detekt") { result ->
+            assertThat(result.task(":detekt")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+        }
+    }
+
+    @Test
+    fun `detektBaseline task gives fragments precedence over an explicitly configured baseline`() {
+        val baselineFilename = "unused-baseline.xml"
+        val directoryName = "detekt-baseline.d"
+        val detektConfig = """
+            detekt {
+                baseline = file("$baselineFilename")
+                baselineFragments.set(layout.projectDirectory.dir("$directoryName"))
+            }
+        """.trimIndent()
+        val gradleRunner = DslTestBuilder.kotlin()
+            .withDetektConfig(detektConfig)
+            .withProjectLayout(
+                ProjectLayout(
+                    numberOfSourceFilesInRootPerSourceDir = 1,
+                    numberOfFindingsInRootPerSourceDir = 1,
+                )
+            )
+            .withConfigFile("config/detekt/detekt.yml")
+            .build()
+
+        gradleRunner.runTasksAndCheckResult("detektBaseline") { result ->
+            assertThat(result.task(":detektBaseline")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+            assertThat(projectFile(baselineFilename)).doesNotExist()
+            assertThat(projectFile(directoryName).walkTopDown().filter { it.extension == "xml" }.toList()).isNotEmpty()
+        }
+    }
 }
 
 private const val DEFAULT_BASELINE_FILENAME = "detekt-baseline.xml"

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektMultiplatformSpec.kt
@@ -131,6 +131,42 @@ class DetektMultiplatformSpec {
                 assertDetektWithClasspath(it)
             }
         }
+
+        @Test
+        fun `uses target-qualified fragment directory for a KMP JVM target`() {
+            val fragmentsRunner = setupProject {
+                addSubmodule(
+                    "shared",
+                    1,
+                    1,
+                    buildFileContent = joinGradleBlocks(
+                        KMM_PLUGIN_BLOCK,
+                        """
+                            kotlin {
+                                jvm("desktop")
+                            }
+                            file("detekt-baseline-mainDesktop.d").mkdirs()
+                        """.trimIndent(),
+                        DETEKT_BLOCK,
+                        """
+                            detekt {
+                                baselineFragments.set(layout.projectDirectory.dir("detekt-baseline.d"))
+                            }
+                        """.trimIndent(),
+                    ),
+                    srcDirs = listOf(
+                        "src/commonMain/kotlin",
+                        "src/desktopMain/kotlin",
+                    ),
+                )
+            }
+
+            fragmentsRunner.runTasksAndCheckResult(":shared:detektMainDesktop") {
+                assertThat(it.output).containsPattern(
+                    """--baseline-fragments \S*[/\\]detekt-baseline-mainDesktop.d"""
+                )
+            }
+        }
     }
 
     @Nested

--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/DetektTaskDslSpec.kt
@@ -126,6 +126,54 @@ class DetektTaskDslSpec {
     }
 
     @Nested
+    inner class `with baseline fragments directory` {
+        private val directoryName = "detekt-baseline.d"
+        private val config = """
+            file("$directoryName").mkdirs()
+            detekt {
+                baselineFragments.set(layout.projectDirectory.dir("$directoryName"))
+            }
+        """.trimIndent()
+        private val gradleRunner = kotlin()
+            .dryRun()
+            .withDetektConfig(config)
+            .build()
+        private val result = gradleRunner.runDetektTask()
+
+        @Test
+        fun `passes only the baseline fragments directory to detekt cli`() {
+            val fragmentsDirectory = gradleRunner.projectFile(directoryName)
+
+            assertThat(result.output).contains("--baseline-fragments $fragmentsDirectory")
+            assertThat(result.output).doesNotContain("--baseline ")
+        }
+    }
+
+    @Nested
+    inner class `with baseline fragments directory that does not exist` {
+        private val directoryName = "missing-baseline.d"
+        private val baselineFilename = "existing-baseline.xml"
+        private val config = """
+            detekt {
+                baseline = file("$baselineFilename")
+                baselineFragments.set(layout.projectDirectory.dir("$directoryName"))
+            }
+        """.trimIndent()
+        private val gradleRunner = kotlin()
+            .dryRun()
+            .withDetektConfig(config)
+            .withBaseline(baselineFilename)
+            .build()
+        private val result = gradleRunner.runDetektTask()
+
+        @Test
+        fun `does not pass the missing directory to detekt cli`() {
+            assertThat(result.output).doesNotContain("--baseline-fragments")
+            assertThat(result.output).doesNotContain("--baseline ")
+        }
+    }
+
+    @Nested
     inner class `with custom input directories` {
         val customSrc1 = "gensrc/kotlin"
         val customSrc2 = "src/main/kotlin"

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/Detekt.kt
@@ -9,6 +9,7 @@ import dev.detekt.gradle.invoke.ApiVersionArgument
 import dev.detekt.gradle.invoke.AutoCorrectArgument
 import dev.detekt.gradle.invoke.BasePathArgument
 import dev.detekt.gradle.invoke.BaselineArgumentOrEmpty
+import dev.detekt.gradle.invoke.BaselineFragmentsArgument
 import dev.detekt.gradle.invoke.BuildUponDefaultConfigArgument
 import dev.detekt.gradle.invoke.ClasspathArgument
 import dev.detekt.gradle.invoke.CliArgument
@@ -59,6 +60,7 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.language.base.plugins.LifecycleBasePlugin
 import org.gradle.workers.WorkerExecutor
+import java.io.File
 import javax.inject.Inject
 
 @CacheableTask
@@ -74,10 +76,24 @@ abstract class Detekt @Inject constructor(
     @get:Classpath
     abstract val pluginClasspath: ConfigurableFileCollection
 
+    @get:Internal
+    abstract val baseline: RegularFileProperty
+
+    @get:Internal
+    abstract val baselineFragments: DirectoryProperty
+
     @get:InputFiles // Why not InputFile? See https://github.com/gradle/gradle/issues/2016
     @get:Optional
     @get:PathSensitive(PathSensitivity.NONE)
-    abstract val baseline: RegularFileProperty
+    internal val baselineInputs: List<File>
+        get() = if (baselineFragments.isPresent) {
+            listOfNotNull(existingBaselineFragments)
+        } else {
+            listOfNotNull(baseline.orNull?.asFile?.takeIf(File::exists))
+        }
+
+    private val existingBaselineFragments: File?
+        get() = baselineFragments.orNull?.asFile?.takeIf(File::isDirectory)
 
     @get:InputFiles
     @get:Optional
@@ -179,7 +195,8 @@ abstract class Detekt @Inject constructor(
             JvmTargetArgument(jvmTarget.orNull),
             JdkHomeArgument(jdkHome),
             ConfigArgument(config),
-            BaselineArgumentOrEmpty(baseline.orNull),
+            BaselineArgumentOrEmpty(baseline.orNull.takeIf { !baselineFragments.isPresent }),
+            BaselineFragmentsArgument(baselineFragments.orNull.takeIf { existingBaselineFragments != null }),
             DefaultReportArgument(reports.checkstyle),
             DefaultReportArgument(reports.html),
             DefaultReportArgument(reports.sarif),

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/DetektCreateBaselineTask.kt
@@ -5,6 +5,7 @@ import dev.detekt.gradle.invoke.ApiVersionArgument
 import dev.detekt.gradle.invoke.AutoCorrectArgument
 import dev.detekt.gradle.invoke.BasePathArgument
 import dev.detekt.gradle.invoke.BaselineArgument
+import dev.detekt.gradle.invoke.BaselineFragmentsArgument
 import dev.detekt.gradle.invoke.BuildUponDefaultConfigArgument
 import dev.detekt.gradle.invoke.ClasspathArgument
 import dev.detekt.gradle.invoke.CliArgument
@@ -42,6 +43,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
@@ -63,8 +65,21 @@ abstract class DetektCreateBaselineTask @Inject constructor(
         group = LifecycleBasePlugin.VERIFICATION_GROUP
     }
 
-    @get:OutputFile
+    @get:Internal
     abstract val baseline: RegularFileProperty
+
+    @get:Internal
+    abstract val baselineFragments: DirectoryProperty
+
+    @get:OutputFile
+    @get:Optional
+    internal val baselineOutput: java.io.File?
+        get() = baseline.orNull?.asFile?.takeIf { !baselineFragments.isPresent }
+
+    @get:OutputDirectory
+    @get:Optional
+    internal val baselineFragmentsOutput: java.io.File?
+        get() = baselineFragments.orNull?.asFile
 
     @get:InputFiles
     @get:Optional
@@ -158,7 +173,8 @@ abstract class DetektCreateBaselineTask @Inject constructor(
             LanguageVersionArgument(languageVersion.orNull),
             JvmTargetArgument(jvmTarget.orNull),
             JdkHomeArgument(jdkHome),
-            BaselineArgument(baseline.get()),
+            BaselineArgument(baseline.orNull.takeIf { !baselineFragments.isPresent }),
+            BaselineFragmentsArgument(baselineFragments.orNull),
             InputArgument(source),
             ConfigArgument(config),
             DebugArgument(debug.get()),

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/DetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/DetektExtension.kt
@@ -21,6 +21,8 @@ interface DetektExtension {
 
     val baseline: RegularFileProperty
 
+    val baselineFragments: DirectoryProperty
+
     val basePath: DirectoryProperty
 
     val enableCompilerPlugin: Property<Boolean>

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/extensions/KotlinCompileTaskDetektExtension.kt
@@ -3,6 +3,7 @@ package dev.detekt.gradle.extensions
 import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
@@ -28,6 +29,7 @@ open class KotlinCompileTaskDetektExtension(project: Project) {
     val parallel: Property<Boolean> = objects.property(Boolean::class.java)
 
     val baseline: RegularFileProperty = objects.fileProperty()
+    val baselineFragments: DirectoryProperty = objects.directoryProperty()
     val config: ConfigurableFileCollection = objects.fileCollection()
     val excludes: SetProperty<String> = objects.setProperty(String::class.java)
 

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/internal/SharedTasks.kt
@@ -35,6 +35,7 @@ internal fun Project.setDetektTaskDefaults(extension: DetektExtension) {
         it.ignoreFailures.convention(extension.ignoreFailures)
         it.failOnSeverity.convention(extension.failOnSeverity)
         it.config.conventionCompat(provider { extension.config })
+        it.baselineFragments.convention(extension.baselineFragments)
         it.basePath.convention(extension.basePath.map { basePath -> basePath.asFile.absolutePath })
         it.allRules.convention(extension.allRules)
         it.noJdk.convention(false)
@@ -60,6 +61,7 @@ internal fun Project.setCreateBaselineTaskDefaults(extension: DetektExtension) {
         }
 
         it.config.conventionCompat(project.provider { extension.config })
+        it.baselineFragments.convention(extension.baselineFragments)
         it.debug.convention(extension.debug)
         it.parallel.convention(extension.parallel)
         it.disableDefaultRuleSets.convention(extension.disableDefaultRuleSets)

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -2,6 +2,7 @@ package dev.detekt.gradle.invoke
 
 import dev.detekt.gradle.extensions.DetektReport
 import dev.detekt.gradle.extensions.FailOnSeverity
+import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.RegularFile
@@ -12,6 +13,7 @@ private const val INPUT_PARAMETER = "--input"
 private const val ANALYSIS_MODE = "--analysis-mode"
 private const val CONFIG_PARAMETER = "--config"
 private const val BASELINE_PARAMETER = "--baseline"
+private const val BASELINE_FRAGMENTS_PARAMETER = "--baseline-fragments"
 private const val PARALLEL_PARAMETER = "--parallel"
 private const val DISABLE_DEFAULT_RULESETS_PARAMETER = "--disable-default-rulesets"
 private const val BUILD_UPON_DEFAULT_CONFIG_PARAMETER = "--build-upon-default-config"
@@ -95,6 +97,11 @@ internal data class BaselineArgumentOrEmpty(val baseline: RegularFile?) : CliArg
         } else {
             emptyList()
         }
+}
+
+internal data class BaselineFragmentsArgument(val directory: Directory?) : CliArgument {
+    override fun toArgument() =
+        directory?.let { listOf(BASELINE_FRAGMENTS_PARAMETER, it.asFile.absolutePath) }.orEmpty()
 }
 
 internal data class DefaultReportArgument(val report: DetektReport) : CliArgument {

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektBasePlugin.kt
@@ -93,6 +93,11 @@ class DetektBasePlugin : Plugin<Project> {
                                 }
                             )
                         )
+                        detektTask.setBaselineFragmentsConvention(
+                            project,
+                            extension,
+                            "${sourceSet.name}SourceSet",
+                        )
                         if (sourceSet.name == "main") {
                             detektTask.explicitApi.convention(mapExplicitArgMode())
                         }
@@ -111,6 +116,11 @@ class DetektBasePlugin : Plugin<Project> {
                                     providers.provider { it.asFile.addVariantName("${sourceSet.name}SourceSet") }
                                 }
                             )
+                        )
+                        createBaselineTask.setBaselineFragmentsConvention(
+                            project,
+                            extension,
+                            "${sourceSet.name}SourceSet",
                         )
 
                         if (sourceSet.name == "main") {
@@ -146,6 +156,26 @@ class DetektBasePlugin : Plugin<Project> {
         // This flag is ignored unless the compiler plugin is applied to the project
         private const val DEFAULT_COMPILER_PLUGIN_ENABLED = true
     }
+}
+
+private fun Detekt.setBaselineFragmentsConvention(project: Project, extension: DetektExtension, variant: String) {
+    baselineFragments.convention(
+        project.layout.dir(
+            extension.baselineFragments.flatMap {
+                project.providers.provider { it.asFile.existingVariantOrBaseFile(variant) }
+            }
+        )
+    )
+}
+
+private fun DetektCreateBaselineTask.setBaselineFragmentsConvention(
+    project: Project,
+    extension: DetektExtension,
+    variant: String,
+) {
+    baselineFragments.convention(
+        project.layout.dir(extension.baselineFragments.map { it.asFile.addVariantName(variant) })
+    )
 }
 
 internal const val CONFIGURATION_DETEKT_PLUGINS = "detektPlugins"

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektKotlinCompilerPlugin.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/DetektKotlinCompilerPlugin.kt
@@ -3,10 +3,14 @@ package dev.detekt.gradle.plugin
 import dev.detekt.detekt_gradle_plugin.BuildConfig
 import dev.detekt.gradle.extensions.DetektExtension
 import dev.detekt.gradle.extensions.KotlinCompileTaskDetektExtension
+import dev.detekt.gradle.internal.addVariantName
+import dev.detekt.gradle.internal.existingVariantOrBaseFile
 import dev.detekt.gradle.plugin.DetektBasePlugin.Companion.DETEKT_EXTENSION
+import dev.detekt.gradle.plugin.internal.baselineFragmentVariant
 import org.gradle.api.Project
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.PathSensitivity
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
 import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
@@ -30,6 +34,7 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
             task.extensions.create(DETEKT_EXTENSION, KotlinCompileTaskDetektExtension::class.java, target).apply {
                 isEnabled.convention(extension.enableCompilerPlugin)
                 baseline.convention(extension.baseline)
+                baselineFragments.convention(extension.baselineFragments)
                 debug.convention(extension.debug)
                 buildUponDefaultConfig.convention(extension.buildUponDefaultConfig)
                 allRules.convention(extension.allRules)
@@ -81,7 +86,26 @@ class DetektKotlinCompilerPlugin : KotlinCompilerPluginSupportPlugin {
             }
         }
 
-        taskExtension.get().baseline.getOrNull()?.let { options.add(SubpluginOption("baseline", it.toString())) }
+        val fragments = taskExtension.get().baselineFragments
+        if (fragments.isPresent) {
+            val target = kotlinCompilation.target.takeIf {
+                project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
+            }
+            val variant = kotlinCompilation.baselineFragmentVariant(target)
+            val baseDirectory = fragments.get().asFile
+            val variantDirectory = baseDirectory.addVariantName(variant)
+            kotlinCompilation.compileTaskProvider.configure { task ->
+                task.inputs.files(baseDirectory, variantDirectory)
+                    .withPropertyName("detektBaselineFragments")
+                    .withPathSensitivity(PathSensitivity.RELATIVE)
+                    .optional()
+            }
+            baseDirectory.existingVariantOrBaseFile(variant)?.let {
+                options.add(SubpluginOption("baselineFragments", it.absolutePath))
+            }
+        } else {
+            taskExtension.get().baseline.getOrNull()?.let { options.add(SubpluginOption("baseline", it.toString())) }
+        }
         taskExtension.get().config.forEach {
             options.add(SubpluginOption("config", it.absolutePath))
         }

--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/plugin/internal/SharedTasks.kt
@@ -21,8 +21,7 @@ internal fun Project.registerJvmCompilationDetektTask(
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
-    val taskSuffix =
-        if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
+    val taskSuffix = compilation.baselineFragmentVariant(target)
     tasks.register(
         DetektPlugin.DETEKT_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
         Detekt::class.java
@@ -64,6 +63,13 @@ internal fun Project.registerJvmCompilationDetektTask(
                 }
             )
         )
+        detektTask.baselineFragments.convention(
+            project.layout.dir(
+                extension.baselineFragments.flatMap {
+                    providers.provider { it.asFile.existingVariantOrBaseFile(taskSuffix) }
+                }
+            )
+        )
         detektTask.description = if (target != null) {
             "Run detekt analysis for compilation ${compilation.name} on target " +
                 "${compilation.target.name} with type resolution"
@@ -79,8 +85,7 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
     target: KotlinTarget? = null,
     source: ConfigurableFileCollection = sourceProvider(compilation),
 ) {
-    val taskSuffix =
-        if (target != null) compilation.name + target.name.replaceFirstChar { it.uppercase() } else compilation.name
+    val taskSuffix = compilation.baselineFragmentVariant(target)
     tasks.register(
         DetektPlugin.BASELINE_TASK_NAME + taskSuffix.replaceFirstChar { it.uppercase() },
         DetektCreateBaselineTask::class.java,
@@ -122,6 +127,11 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
                 }
             )
         )
+        createBaselineTask.baselineFragments.convention(
+            project.layout.dir(
+                extension.baselineFragments.map { it.asFile.addVariantName(taskSuffix) }
+            )
+        )
         createBaselineTask.description = if (target != null) {
             "Creates detekt baseline for compilation ${compilation.name} on target " +
                 "${compilation.target.name} with type resolution"
@@ -130,6 +140,9 @@ internal fun Project.registerJvmCompilationCreateBaselineTask(
         }
     }
 }
+
+internal fun KotlinCompilation<*>.baselineFragmentVariant(target: KotlinTarget?): String =
+    if (target == null) name else name + target.name.replaceFirstChar { it.uppercase() }
 
 internal fun Project.mapExplicitArgMode(): Provider<String> =
     provider {

--- a/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/DetektJvmSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/DetektJvmSpec.kt
@@ -1,11 +1,15 @@
 package dev.detekt.gradle
 
+import dev.detekt.gradle.extensions.DetektExtension
+import dev.detekt.gradle.plugin.DetektKotlinCompilerPlugin
 import dev.detekt.gradle.plugin.DetektPlugin
 import dev.detekt.gradle.testkit.DslGradleRunner
 import dev.detekt.gradle.testkit.ProjectLayout
 import org.assertj.core.api.Assertions.assertThat
 import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.repositories
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapper
 import org.junit.jupiter.api.Test
 
@@ -69,5 +73,60 @@ class DetektJvmSpec {
         assertThat(argumentString).contains("--api-version 1.5")
         assertThat(argumentString).contains("--language-version 1.6")
         assertThat(argumentString).contains("--fail-on-severity error")
+    }
+
+    @Test
+    fun `uses separate fragment directories for main and test baseline tasks`() {
+        val project = gradleRunner.buildProject()
+        val baseDirectory = project.layout.projectDirectory.dir("detekt-baseline.d")
+        project.extensions.getByType<DetektExtension>().baselineFragments.set(baseDirectory)
+
+        val main = project.tasks.getByPath("detektBaselineMain") as DetektCreateBaselineTask
+        val test = project.tasks.getByPath("detektBaselineTest") as DetektCreateBaselineTask
+
+        assertThat(main.baselineFragments.get().asFile.name).isEqualTo("detekt-baseline-main.d")
+        assertThat(test.baselineFragments.get().asFile.name).isEqualTo("detekt-baseline-test.d")
+        assertThat(main.baselineFragments.get().asFile).isNotEqualTo(test.baselineFragments.get().asFile)
+    }
+
+    @Test
+    fun `analysis fragment directory prefers variant and falls back to base`() {
+        val project = gradleRunner.buildProject()
+        val baseDirectory = project.layout.projectDirectory.dir("detekt-baseline.d")
+        baseDirectory.asFile.mkdirs()
+        project.layout.projectDirectory.dir("detekt-baseline-main.d").asFile.mkdirs()
+        project.extensions.getByType<DetektExtension>().baselineFragments.set(baseDirectory)
+
+        val main = project.tasks.getByPath("detektMain") as Detekt
+        val test = project.tasks.getByPath("detektTest") as Detekt
+
+        assertThat(main.baselineFragments.get().asFile.name).isEqualTo("detekt-baseline-main.d")
+        assertThat(test.baselineFragments.get().asFile.name).isEqualTo("detekt-baseline.d")
+    }
+
+    @Test
+    fun `compiler task tracks base and variant fragment directories as inputs`() {
+        val compilerRunner = DslGradleRunner(
+            projectLayout = ProjectLayout(numberOfSourceFilesInRootPerSourceDir = 1),
+            buildFileName = "build.gradle.kts",
+            projectScript = {
+                apply<KotlinPluginWrapper>()
+                apply<DetektKotlinCompilerPlugin>()
+                repositories {
+                    mavenCentral()
+                }
+                extensions.getByType<DetektExtension>().baselineFragments.set(
+                    layout.projectDirectory.dir("detekt-baseline.d")
+                )
+            },
+        ).also(DslGradleRunner::setupProject)
+        val project = compilerRunner.buildProject()
+        val compilerPlugin = project.plugins.getPlugin(DetektKotlinCompilerPlugin::class.java)
+        val mainCompilation = project.extensions.getByType<KotlinJvmExtension>().target.compilations.getByName("main")
+        compilerPlugin.applyToCompilation(mainCompilation).get()
+        val compileKotlin = project.tasks.getByPath("compileKotlin")
+
+        assertThat(compileKotlin.inputs.files.files.map { it.name })
+            .contains("detekt-baseline.d", "detekt-baseline-main.d")
     }
 }

--- a/detekt-tooling/api/detekt-tooling.api
+++ b/detekt-tooling/api/detekt-tooling.api
@@ -96,6 +96,7 @@ public final class dev/detekt/tooling/api/VersionProvider$Companion {
 }
 
 public abstract interface class dev/detekt/tooling/api/spec/BaselineSpec {
+	public fun getFragmentDirectory ()Ljava/nio/file/Path;
 	public abstract fun getPath ()Ljava/nio/file/Path;
 	public abstract fun getShouldCreateDuringAnalysis ()Z
 }
@@ -225,8 +226,10 @@ public final class dev/detekt/tooling/dsl/BaselineSpecBuilder : dev/detekt/tooli
 	public fun <init> ()V
 	public fun build ()Ldev/detekt/tooling/api/spec/BaselineSpec;
 	public synthetic fun build ()Ljava/lang/Object;
+	public final fun getFragmentDirectory ()Ljava/nio/file/Path;
 	public final fun getPath ()Ljava/nio/file/Path;
 	public final fun getShouldCreateDuringAnalysis ()Z
+	public final fun setFragmentDirectory (Ljava/nio/file/Path;)V
 	public final fun setPath (Ljava/nio/file/Path;)V
 	public final fun setShouldCreateDuringAnalysis (Z)V
 }

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/BaselineSpec.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/api/spec/BaselineSpec.kt
@@ -12,6 +12,12 @@ interface BaselineSpec {
     val path: Path?
 
     /**
+     * Path to a directory containing one hash-addressed baseline ID fragment per XML file.
+     */
+    val fragmentDirectory: Path?
+        get() = null
+
+    /**
      * Should this analysis write all findings to a new baseline.
      */
     val shouldCreateDuringAnalysis: Boolean

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/BaselineSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/BaselineSpecBuilder.kt
@@ -7,10 +7,14 @@ import java.nio.file.Path
 class BaselineSpecBuilder : Builder<BaselineSpec> {
 
     var path: Path? = null
+    var fragmentDirectory: Path? = null
     var shouldCreateDuringAnalysis: Boolean = false
 
-    override fun build(): BaselineSpec = BaselineModel(path, shouldCreateDuringAnalysis)
+    override fun build(): BaselineSpec = BaselineModel(path, fragmentDirectory, shouldCreateDuringAnalysis)
 }
 
-private data class BaselineModel(override val path: Path?, override val shouldCreateDuringAnalysis: Boolean) :
-    BaselineSpec
+private data class BaselineModel(
+    override val path: Path?,
+    override val fragmentDirectory: Path?,
+    override val shouldCreateDuringAnalysis: Boolean,
+) : BaselineSpec

--- a/detekt-tooling/src/test/kotlin/dev/detekt/tooling/api/spec/BaselineSpecSpec.kt
+++ b/detekt-tooling/src/test/kotlin/dev/detekt/tooling/api/spec/BaselineSpecSpec.kt
@@ -1,0 +1,18 @@
+package dev.detekt.tooling.api.spec
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.nio.file.Path
+
+class BaselineSpecSpec {
+
+    @Test
+    fun `defaults fragment directory to null for existing implementations`() {
+        val baselineSpec = object : BaselineSpec {
+            override val path: Path? = null
+            override val shouldCreateDuringAnalysis: Boolean = false
+        }
+
+        assertThat(baselineSpec.fragmentDirectory).isNull()
+    }
+}

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -213,6 +213,10 @@ detekt {
     
     // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     baseline = file("path/to/baseline.xml")
+
+    // Alternatively, store every unique baseline ID in a hash-addressed file.
+    // When set, this option takes precedence over `baseline`.
+    baselineFragments = file("path/to/baseline.d")
     
     // Disables all default detekt rulesets and will only run detekt with custom rules
     // defined in plugins passed in with `detektPlugins` configuration. `false` by default.
@@ -274,6 +278,10 @@ detekt {
     
     // Specifying a baseline file. All findings stored in this file in subsequent runs of detekt.
     baseline = file("path/to/baseline.xml")
+
+    // Alternatively, store every unique baseline ID in a hash-addressed file.
+    // When set, this option takes precedence over `baseline`.
+    baselineFragments.set(layout.projectDirectory.dir("path/to/baseline.d"))
     
     // Disables all default detekt rulesets and will only run detekt with custom rules
     // defined in plugins passed in with `detektPlugins` configuration. `false` by default.

--- a/website/docs/introduction/baseline.md
+++ b/website/docs/introduction/baseline.md
@@ -46,6 +46,10 @@ Each file contains exactly one `<ID>...</ID>` element and is stored at
 the file ends with a newline that is not part of the hash. Duplicate IDs are stored once. Fragment baselines represent `CurrentIssues`; use the
 single baseline format when `ManuallySuppressedIssues` are required.
 
+Readers and writers coordinate through lock files in `~/.detekt/detekt-baseline-locks`, outside the managed baseline
+directory. Environments where the user home is read-only can set the `dev.detekt.baseline.lock.directory` system
+property to a writable directory. Lock files are coordination state and are not removed after each analysis.
+
 #### CLI
 To generate yourself a `baseline.xml` you need to provide the same config as the the rules you are going to scan your project.
 
@@ -65,8 +69,8 @@ This will create one baseline file per Gradle module.
 As this might not be the desired behavior for a multi module project, think about implementing
 a custom meta baseline task:
 
-To create and consume baseline fragments instead, configure a directory. Running `detektBaseline` then replaces the
-managed directory with the current set of findings.
+To create and consume baseline fragments instead, configure a directory. Running `detektBaseline` then reconciles the
+managed fragment XML files with the current set of findings.
 
 ```kotlin
 detekt {

--- a/website/docs/introduction/baseline.md
+++ b/website/docs/introduction/baseline.md
@@ -8,6 +8,11 @@ sidebar_position: 7
 With the cli option `--baseline` or the detekt-gradle-plugin closure-property `baseline` you can specify a file which is used to generate a `baseline.xml`.
 It is a file where ignored findings are defined.
 
+Alternatively, `--baseline-fragments` and the Gradle `baselineFragments` property store every unique current issue in
+an individual file. This layout avoids merge conflicts when independent changes remove different baseline entries.
+The CLI options are mutually exclusive. In the Gradle DSL, `baselineFragments` takes precedence over `baseline`,
+including its conventional default value.
+
 The intention of `CurrentIssues` is that only new findings are printed on further analysis.
 The `ManuallySuppressedIssues` can be used to write down false positive detections (instead of suppressing them and pollute your code base).
 
@@ -27,6 +32,20 @@ When adding a custom issue to the xml file, make sure the `RuleID` should be sel
 </SmellBaseline>
 ```
 
+To create a conflict-free fragment baseline, pass a directory instead of a baseline file:
+
+```shell
+java -jar detekt-cli-all.jar \
+  --config path/to/config/detekt/detekt.yml \
+  --baseline-fragments path/to/config/detekt/baseline.d \
+  --create-baseline
+```
+
+Each file contains exactly one `<ID>...</ID>` element and is stored at
+`<first-two-sha256-characters>/<sha256>.xml`. The hash is calculated from the UTF-8 encoded, XML-escaped element;
+the file ends with a newline that is not part of the hash. Duplicate IDs are stored once. Fragment baselines represent `CurrentIssues`; use the
+single baseline format when `ManuallySuppressedIssues` are required.
+
 #### CLI
 To generate yourself a `baseline.xml` you need to provide the same config as the the rules you are going to scan your project.
 
@@ -45,6 +64,15 @@ If you are using the gradle-plugin run the `detektBaseline` task to generate you
 This will create one baseline file per Gradle module.
 As this might not be the desired behavior for a multi module project, think about implementing
 a custom meta baseline task:
+
+To create and consume baseline fragments instead, configure a directory. Running `detektBaseline` then replaces the
+managed directory with the current set of findings.
+
+```kotlin
+detekt {
+    baselineFragments.set(layout.projectDirectory.dir("config/detekt/baseline.d"))
+}
+```
 
 ###### Groovy DSL
 ```groovy


### PR DESCRIPTION
Proposes an implementation for #9496.

## Summary

This draft adds an opt-in baseline storage format that keeps each unique baseline ID from `CurrentIssues` in a separate, hash-addressed XML fragment.

The existing single-file baseline format remains unchanged and continues to be the default.

## Motivation

Our team uses small, independent pull requests for incremental refactoring. With a single baseline XML file, unrelated refactoring pull requests in our repository regularly modify different entries in the same file and produce merge conflicts.

We have been using one deterministic file per baseline ID to reduce those conflicts. This draft contributes that workflow as an opt-in detekt feature and provides a concrete design for discussion.

## Usage

CLI:

```bash
detekt \
  --baseline-fragments config/detekt/baseline.d \
  --create-baseline
```

Gradle Kotlin DSL:

```kotlin
detekt {
    baselineFragments.set(
        layout.projectDirectory.dir("config/detekt/baseline.d")
    )
}
```

Gradle Groovy DSL:

```groovy
detekt {
    baselineFragments = layout.projectDirectory.dir(
        "config/detekt/baseline.d"
    )
}
```

## Format

Each unique baseline ID from `CurrentIssues` is stored in one XML file:

```xml
<ID>LongMethod:Example.kt$Example$execute()</ID>
```

The relative path is derived from the SHA-256 hash of the canonical, XML-escaped `<ID>...</ID>` element:

```text
<first two hash characters>/<full hash>.xml
```

The reader verifies that each file's content matches its hash-derived path and rejects duplicate or malformed fragments.

## Behavior

- The feature is opt-in.
- Existing `--baseline` behavior is unchanged.
- `--baseline` and `--baseline-fragments` are mutually exclusive in the CLI.
- In the Gradle DSL, `baselineFragments` takes precedence over the conventional `baseline` property.
- Gradle baseline-generation tasks use compilation- or source-set-specific sibling fragment directories.
- Kotlin Multiplatform fragment directories use target-qualified compilation identities so compilations with shared names do not reconcile the same directory.
- Analysis prefers an existing variant-specific fragment directory and otherwise falls back to the configured base directory.
- The Kotlin compiler plugin forwards the selected fragment directory to the tooling processing specification.
- The configured base and variant fragment directories are registered as Kotlin compile-task inputs so fragment changes invalidate the relevant task.
- Duplicate IDs are stored only once.
- When a baseline is regenerated, managed fragment XML files whose hash-derived paths are absent from the new ID set are removed, and empty shard directories are cleaned up.
- Fragment mode represents `CurrentIssues`; it does not represent `ManuallySuppressedIssues`.
- No automatic migration or round-trip conversion with the existing single-file format is provided.

The trade-offs are a larger repository file count, additional filesystem traversal, and persistent lock files, stored in a user-scoped location by default, used for cross-process coordination.

## Implementation

Serialization, hashing, validation, reconciliation, and concurrency logic live in `detekt-core`. The CLI, tooling API, Gradle tasks, and Kotlin compiler plugin expose and forward the new storage option.

Each ID is serialized as a canonical, XML-escaped `<ID>...</ID>` element before hashing. Carriage returns are represented as `&#13;` so XML parsing does not change the ID or its hash-derived path.

Concurrent readers and writers are coordinated with a process-local lock and a deterministic file lock. The default lock directory is `~/.detekt/detekt-baseline-locks`, outside the managed fragment directory. Environments with a read-only user home can override it through the `dev.detekt.baseline.lock.directory` system property. Lock files may remain after execution, while unused process-local lock entries are released.

Generation writes each fragment through a temporary file in its target shard before moving it into place. It then reconciles the managed fragment XML files with the newly generated hash paths and removes empty shard directories.

Gradle baseline-generation tasks derive sibling fragment directories from their compilation or source-set identity. Kotlin Multiplatform identities include the target name when required to avoid collisions between compilations that share the same name. Analysis uses an existing variant-specific directory when available and otherwise falls back to the configured base directory.

The Kotlin compiler integration explicitly registers both the configured base directory and the target-specific sibling directory as optional task inputs. The selected existing directory is forwarded to the compiler as the fragment baseline path.

The option name, API, storage format, shard structure, lock strategy, and supported baseline sections can be adjusted based on maintainer feedback. This PR is a draft design artifact rather than a request to merge the current shape unchanged.

## Testing

Core tests cover deterministic hash-derived paths, canonical XML round trips including carriage returns, malformed XML and XXE rejection, content/path integrity, stale reconciliation, temporary cleanup, process-local lock lifecycle, configurable lock storage, and blocking on a lock held by a separate JVM process.

CLI tests cover option validation, fragment creation, and reuse.

Gradle tests cover Kotlin and Groovy DSL wiring, actual baseline creation and consumption, missing directories, precedence, up-to-date behavior, compilation- and source-set-specific sibling directories, base-directory fallback, KMP target-qualified identities, and compiler-task input registration.

Compiler-plugin tests cover option registration and mapping the fragment directory into the tooling processing specification.

The tooling and Gradle public API dumps were updated and checked.

The targeted core, CLI, tooling, compiler-plugin, and Gradle tests pass locally. The full non-Android build also passes. The complete Android functional-test matrix was not run locally because an Android SDK was unavailable and is expected to be covered by CI.
