### PR TITLE
Measure code coverage for Gradle plugin

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,6 +14,3 @@ coverage:
         target: 80%
         # Only post a patch status to pull requests
         only_pulls: true
-
-ignore:
-  - "detekt-gradle-plugin/"

--- a/.github/workflows/codecoverage.yaml
+++ b/.github/workflows/codecoverage.yaml
@@ -31,7 +31,7 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Generate Coverage Report
-        run: ./gradlew jacocoMergedReport
+        run: ./gradlew jacocoMergedTestReport jacocoMergedFunctionalTestReport
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
 
@@ -39,6 +39,8 @@ jobs:
         if: success()
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          files: ./code-coverage-report/build/reports/jacoco/jacocoMergedReport/jacocoMergedReport.xml
+          files: >-
+            ./code-coverage-report/build/reports/jacoco/jacocoMergedTestReport/jacocoMergedTestReport.xml,
+            ./code-coverage-report/build/reports/jacoco/jacocoMergedFunctionalTestReport/jacocoMergedFunctionalTestReport.xml,
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -22,6 +22,7 @@ reporting {
 jacoco.toolVersion = libs.versions.jacoco.get()
 
 dependencies {
+    jacocoAggregation("dev.detekt:detekt-gradle-plugin")
     jacocoAggregation(projects.detektApi)
     jacocoAggregation(projects.detektCli)
     jacocoAggregation(projects.detektCompilerPlugin)

--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -4,8 +4,14 @@ plugins {
 
 reporting {
     reports {
-        create("jacocoMergedReport", JacocoCoverageReport::class) {
+        create<JacocoCoverageReport>("jacocoMergedTestReport") {
             testSuiteName = "test"
+            reportTask {
+                dependsOn(":detekt-generator:generateDocumentation")
+            }
+        }
+        create<JacocoCoverageReport>("jacocoMergedFunctionalTestReport") {
+            testSuiteName = "functionalTest"
             reportTask {
                 dependsOn(":detekt-generator:generateDocumentation")
             }

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -122,6 +122,8 @@ kotlin {
 val testKitRuntimeOnly = configurations.register("testKitRuntimeOnly")
 val testKitGradleMinVersionRuntimeOnly = configurations.register("testKitGradleMinVersionRuntimeOnly")
 
+val jacocoAgentRuntime = configurations.register("jacocoAgentRuntime")
+
 dependencies {
     compileOnly(libs.android.gradleApi)
     compileOnly(libs.kotlin.gradlePluginApi)
@@ -156,6 +158,7 @@ dependencies {
             attribute(GradlePluginApiVersion.GRADLE_PLUGIN_API_VERSION_ATTRIBUTE, named("7.6.3"))
         }
     }
+    jacocoAgentRuntime("org.jacoco:org.jacoco.agent:${libs.versions.jacoco.get()}:runtime")
 
     // We use this published version of the detekt-rules-ktlint-wrapper to self analyse this project.
     detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:2.0.0-alpha.6")
@@ -253,6 +256,26 @@ tasks {
                     maxFailures = 20
                 }
             }
+        }
+    }
+
+    // JaCoCo does not instrument the Gradle JVMs that TestKit spawns to run the build under test, so
+    // functional tests would otherwise contribute no coverage of the plugin. Expose the agent jar and
+    // a destination directory to the test JVM; DslGradleRunner reads these system properties and
+    // injects the agent into the spawned JVMs via -Dorg.gradle.jvmargs.
+    //
+    // Only the functionalTest suite is instrumented. functionalTestMinSupportedGradle runs against
+    // Gradle 7.6.3, which does not support a Java agent in a TestKit build that uses the configuration
+    // cache (the build under test enables isolated projects); its coverage is redundant with
+    // functionalTest anyway.
+    named<Test>("functionalTest") {
+        inputs.files(jacocoAgentRuntime)
+        val agentJarPath = jacocoAgentRuntime.map { it.singleFile.absolutePath }
+        val outputFile = layout.buildDirectory.file("jacoco/functionalTest.exec").map { it.asFile.absolutePath }
+
+        doFirst {
+            systemProperty("jacoco.agent.jar", agentJarPath.get())
+            systemProperty("jacoco.agent.destfile", outputFile.get())
         }
     }
 

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -148,6 +148,7 @@ constructor(
             if (failOnGradleWarnings) {
                 add("--warning-mode=fail")
             }
+            add("-Pkotlin.internal.collectFUSMetrics=false") // https://github.com/gradle/gradle/issues/31278
             addAll(gradleProperties.toList().map { (key, value) -> "-P$key=$value" })
             addAll(tasks)
         }

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -138,7 +138,7 @@ constructor(
             add("--stacktrace")
             add("--info")
             add("--build-cache")
-            add("-Dorg.gradle.jvmargs=$jvmArgs")
+            add("-Dorg.gradle.jvmargs=${listOfNotNull(jvmArgs, jacocoAgentArg()).joinToString(" ")}")
             if (dryRun) {
                 add("-Pdetekt-dry-run=true")
             }
@@ -162,6 +162,19 @@ constructor(
             withArguments(args)
             gradleVersionOrNone?.let(::withGradleVersion)
         }
+    }
+
+    /**
+     * When the functional test task injects the JaCoCo agent (via the `jacoco.agent.jar` and
+     * `jacoco.agent.destfile` system properties), return a `-javaagent` argument so the
+     * TestKit-spawned Gradle JVMs are instrumented. JaCoCo does not instrument these spawned JVMs
+     * out of the box, so without this functional tests contribute no coverage of the plugin.
+     */
+    private fun jacocoAgentArg(): String? {
+        val agentJar = System.getProperty("jacoco.agent.jar")
+        val destFile = System.getProperty("jacoco.agent.destfile")
+        if (agentJar == null || destFile == null) return null
+        return "-javaagent:$agentJar=destfile=$destFile"
     }
 
     fun runTasksAndCheckResult(vararg tasks: String, doAssert: DslGradleRunner.(BuildResult) -> Unit) {


### PR DESCRIPTION
AI-assisted, but I made a few changes to make the implementation simpler, and added support to the code-coverage project so it maintains responsibility for aggregating code coverage reports for upload to Codecov.

Resolves #1294. Requires Gradle 9.7 so it's possible to attach a Java agent and keep Configuration Cache enabled in TestKit tests: https://docs.gradle.org/9.7.0/release-notes.html#third-party-java-agents-work-with-the-configuration-cache-in-testkit