### PR TITLE
Don't override picomatch version

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -68,7 +68,6 @@
     "nanoid": "^5.0.0",
     "node-forge": "^1.3.2",
     "on-headers": "^1.1.0",
-    "picomatch": "^4.0.0",
     "postcss": "^8.5.10",
     "prismjs": "^1.30.0",
     "react-router/path-to-regexp": "8.4.2",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -8258,7 +8258,12 @@ picocolors@^1.1.0, picocolors@^1.1.1:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1, picomatch@^4.0.0, picomatch@^4.0.4:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
+
+picomatch@^4.0.4:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
   integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==


### PR DESCRIPTION
This causes detekt website builds to fail on Windows with messages like:

`Module not found: Error: Can't resolve '@site/.docusaurus/docusaurus-plugin-content-docs/default/site-versioned-docs-version-1-23-5-gettingstarted-cli-generator-options-md-d91.json' in 'C:\Users\user\IdeaProjects\detekt\website\versioned_docs\version-1.23.5\gettingstarted'`