### PR TITLE
Configure Renovate to run lock file maintenance weekly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
   ],
   "extends": [
     "config:recommended",
+    ":maintainLockFilesWeekly",
     "helpers:pinGitHubActionDigests"
   ],
   "packageRules": [


### PR DESCRIPTION
There's signficant drift in the yarn lockfile for the detekt website. Renovate can maintain this for us, opening a new PR once a week.

It will happen "early Monday mornings (before 4 AM)" according to Renovate docs but it doesn't say which timezone is used as the reference.

https://docs.renovatebot.com/presets-default/#maintainlockfilesweekly