### PR TITLE
Add detekt-baseline-fragments to the Marketplace

### DIFF
--- a/website/src/data/marketplace.js
+++ b/website/src/data/marketplace.js
@@ -113,6 +113,14 @@ export const extensions = [
     tags: ["ruleset"],
   },
   {
+    title: "detekt-baseline-fragments",
+    description:
+      "Conflict-resistant, hash-addressed baseline fragments for detekt.",
+    repo: "https://github.com/JunggiKim/detekt-baseline-fragments",
+    docs: "https://github.com/JunggiKim/detekt-baseline-fragments#readme",
+    tags: ["plugin"],
+  },
+  {
     title: "Compiler",
     description:
       "A ruleset that wraps the warnings and info messages of the Kotlin compiler as detekt findings..",


### PR DESCRIPTION
## Summary

Adds detekt-baseline-fragments, a third-party ReportingExtension that stores
detekt baseline IDs as deterministic hash-addressed XML fragments to reduce
merge conflicts in shared baseline files.

## Installation

Published on Maven Central as
`io.github.junggikim:detekt-baseline-fragments:0.1.0`.

## Related

Related to #9496