### PR TITLE
ci: pin loader-utils to v2 in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -52,6 +52,11 @@
       "matchPackageNames": ["org.assertj:assertj-core"],
       "matchCurrentValue": "3.27.4",
       "enabled": false
+    },
+    {
+      "description": "loader-utils v3 removed the getOptions() API that file-loader, url-loader and html-webpack-plugin still rely on, so the website build breaks. Keep it pinned to v2 until those loaders migrate.",
+      "matchPackageNames": ["loader-utils"],
+      "allowedVersions": "<3"
     }
   ]
 }


### PR DESCRIPTION
## Problem

Renovate PR #9404 (bump `loader-utils` `^2.0.3` → `^3.0.0`) fails the website build (`build-detekt-docs` / Cloudflare Pages) with:

```
[ERROR] Client bundle compiled with errors therefore further build is impossible.
TypeError: (0 , _loaderUtils.getOptions) is not a function
```

`loader-utils` is only present as a Yarn `resolutions` override in `website/package.json` (added in #9395 to force a security-patched 2.0.4). loader-utils **v3 removed the `getOptions` export**, but the webpack loaders Docusaurus depends on still call the v2 API:

- `file-loader/dist/index.js` → `(0, _loaderUtils.getOptions)(this)`
- `url-loader/dist/index.js` → `(0, _loaderUtils.getOptions)(this)`
- `html-webpack-plugin/lib/loader.js`

All declare `loader-utils "^2.0.0"`, so forcing v3 breaks them at build time. There is no version that satisfies both v3 and these unmaintained loaders.

## Fix

Add a Renovate `packageRule` restricting `loader-utils` to `<3` so it stops re-proposing the v3 bump until those transitive loaders migrate off the v2 API. The existing 2.0.4 pin already carries the security fix from #9395, so staying on v2 introduces no known vulnerability.

Once merged, #9404 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)