### PR TITLE
Add IgnoredJavaDefaultMethod rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -459,6 +459,8 @@ potential-bugs:
     active: true
   HasPlatformType:
     active: true
+  IgnoredJavaDefaultMethod:
+    active: false
   IgnoredReturnValue:
     active: true
     restrictToConfig: true

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethod.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethod.kt
@@ -1,0 +1,140 @@
+package dev.detekt.rules.potentialbugs
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.KaSession
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassKind
+import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
+import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.analysis.api.types.KaType
+import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
+
+/**
+ * Reports classes that implement a Java interface by delegation when that interface has default
+ * methods that the class does not forward.
+ *
+ * Kotlin does not generate delegating members for the default methods of a Java interface. The
+ * class inherits the default implementation instead of forwarding the call, so whatever the
+ * delegate does for those methods is ignored. Override them and forward to the delegate. See
+ * [KT-15226](https://youtrack.jetbrains.com/issue/KT-15226).
+ *
+ * Kotlin collection types such as `List` are excluded. Their mapped `java.util` defaults are not
+ * forwarded either, but those defaults read members that delegation does forward, so a delegate
+ * that does not override them itself still supplies the result.
+ *
+ * <noncompliant>
+ * // `JavaInterface` is written in Java and declares a default method `optional()`.
+ * class Wrapper(private val delegate: JavaInterface) : JavaInterface by delegate
+ * </noncompliant>
+ *
+ * <compliant>
+ * // `JavaInterface` is written in Java and declares a default method `optional()`.
+ * class Wrapper(private val delegate: JavaInterface) : JavaInterface by delegate {
+ *     override fun optional() {
+ *         delegate.optional()
+ *     }
+ * }
+ * </compliant>
+ */
+class IgnoredJavaDefaultMethod(config: Config) :
+    Rule(
+        config,
+        "Delegated Java interface has default methods that are not forwarded.",
+    ),
+    RequiresAnalysisApi {
+
+    override fun visitClassOrObject(classOrObject: KtClassOrObject) {
+        super.visitClassOrObject(classOrObject)
+
+        val delegatedEntries = classOrObject.superTypeListEntries
+            .filterIsInstance<KtDelegatedSuperTypeEntry>()
+        if (delegatedEntries.isEmpty()) return
+
+        analyze(classOrObject) {
+            val javaInterfaces = delegatedEntries.mapNotNull { entry ->
+                val type = entry.typeReference?.type ?: return@mapNotNull null
+                val symbol = type.symbol as? KaClassSymbol ?: return@mapNotNull null
+                if (symbol.classKind != KaClassKind.INTERFACE) return@mapNotNull null
+                if (!hasJavaDeclaredAncestor(type)) return@mapNotNull null
+                entry to symbol
+            }
+            if (javaInterfaces.isEmpty()) return@analyze
+
+            val classSymbol = classOrObject.symbol as? KaClassSymbol ?: return@analyze
+            // The methods the class ends up with that still come straight from Java. Keyed by the
+            // original declaration so an overload of the same name cannot stand in for another.
+            val ignoredOriginals = classSymbol.memberScope
+                .callables
+                .filterIsInstance<KaNamedFunctionSymbol>()
+                .filter { isIgnoredJavaDefault(it) }
+                .map { it.fakeOverrideOriginal }
+                .toSet()
+            if (ignoredOriginals.isEmpty()) return@analyze
+
+            javaInterfaces.forEach { (entry, symbol) ->
+                reportIgnoredDefaultMethods(entry, symbol, ignoredOriginals)
+            }
+        }
+    }
+
+    private fun KaSession.reportIgnoredDefaultMethods(
+        entry: KtDelegatedSuperTypeEntry,
+        interfaceSymbol: KaClassSymbol,
+        ignoredOriginals: Set<KaCallableSymbol>,
+    ) {
+        val ignored = interfaceSymbol.memberScope
+            .callables
+            .filterIsInstance<KaNamedFunctionSymbol>()
+            .filter { isIgnoredJavaDefault(it) }
+            .filter { it.fakeOverrideOriginal in ignoredOriginals }
+            .map { it.name.asString() }
+            .distinct()
+            .sorted()
+            .toList()
+
+        if (ignored.isEmpty()) return
+
+        val single = ignored.size == 1
+        report(
+            Finding(
+                Entity.from(entry),
+                "Delegating to `${interfaceSymbol.name?.asString()}` ignores what the delegate " +
+                    "does for the default ${if (single) "method" else "methods"} " +
+                    "${ignored.joinToString { "`$it`" }}. " +
+                    "Override ${if (single) "it" else "them"} to delegate explicitly.",
+            )
+        )
+    }
+
+    // Kotlin maps its own collection types onto java.util ones without a Java type in the
+    // hierarchy, so requiring a Java-declared interface here keeps them out.
+    private fun KaSession.hasJavaDeclaredAncestor(type: KaType): Boolean =
+        (sequenceOf(type) + type.allSupertypes).any { supertype ->
+            (supertype.symbol as? KaClassSymbol)
+                ?.let { it.classKind == KaClassKind.INTERFACE && it.isDeclaredInJava() } == true
+        }
+
+    // The origin comes off the original because generic substitution hides the Java one.
+    // The original turns Kotlin as soon as anything in Kotlin overrides the method, and a
+    // generated delegating member drops out on its own DELEGATED origin.
+    // Public and not abstract leaves out the Java 9 private interface methods.
+    private fun KaSession.isIgnoredJavaDefault(symbol: KaNamedFunctionSymbol): Boolean =
+        symbol.fakeOverrideOriginal.isDeclaredInJava() &&
+            symbol.origin != KaSymbolOrigin.DELEGATED &&
+            symbol.modality != KaSymbolModality.ABSTRACT &&
+            symbol.visibility == KaSymbolVisibility.PUBLIC
+
+    private fun KaSymbol.isDeclaredInJava(): Boolean =
+        origin == KaSymbolOrigin.JAVA_SOURCE || origin == KaSymbolOrigin.JAVA_LIBRARY
+}

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethod.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethod.kt
@@ -5,8 +5,11 @@ import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.KaExperimentalApi
 import org.jetbrains.kotlin.analysis.api.KaSession
 import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.renderer.base.annotations.KaRendererAnnotationsFilter
+import org.jetbrains.kotlin.analysis.api.renderer.declarations.impl.KaDeclarationRendererForSource
 import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassKind
 import org.jetbrains.kotlin.analysis.api.symbols.KaClassSymbol
@@ -15,6 +18,7 @@ import org.jetbrains.kotlin.analysis.api.symbols.KaSymbol
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolModality
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolOrigin
 import org.jetbrains.kotlin.analysis.api.symbols.KaSymbolVisibility
+import org.jetbrains.kotlin.analysis.api.types.KaClassType
 import org.jetbrains.kotlin.analysis.api.types.KaType
 import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.psi.KtClassOrObject
@@ -27,7 +31,8 @@ import org.jetbrains.kotlin.psi.KtDelegatedSuperTypeEntry
  * Kotlin does not generate delegating members for the default methods of a Java interface. The
  * class inherits the default implementation instead of forwarding the call, so whatever the
  * delegate does for those methods is ignored. Override them and forward to the delegate. See
- * [KT-15226](https://youtrack.jetbrains.com/issue/KT-15226).
+ * [KT-15226](https://youtrack.jetbrains.com/issue/KT-15226) and
+ * [KT-18324](https://youtrack.jetbrains.com/issue/KT-18324).
  *
  * Kotlin collection types such as `List` are excluded. Their mapped `java.util` defaults are not
  * forwarded either, but those defaults read members that delegation does forward, so a delegate
@@ -93,17 +98,25 @@ class IgnoredJavaDefaultMethod(config: Config) :
         interfaceSymbol: KaClassSymbol,
         ignoredOriginals: Set<KaCallableSymbol>,
     ) {
-        val ignored = interfaceSymbol.memberScope
+        // Dedup on the declaration, not on the rendered text: two overloads can render alike and
+        // dropping one would hide a method the delegate still owns.
+        val symbols = interfaceSymbol.memberScope
             .callables
             .filterIsInstance<KaNamedFunctionSymbol>()
             .filter { isIgnoredJavaDefault(it) }
             .filter { it.fakeOverrideOriginal in ignoredOriginals }
-            .map { it.name.asString() }
-            .distinct()
-            .sorted()
+            .distinctBy { it.fakeOverrideOriginal }
             .toList()
 
-        if (ignored.isEmpty()) return
+        if (symbols.isEmpty()) return
+
+        // `f(int)` and `f(Integer)` both read as `f(Int)`, so the ones that collide fall back to
+        // the whole declaration.
+        val short = symbols.map { signatureOf(it) }
+        val colliding = short.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+        val ignored = symbols.mapIndexed { index, symbol ->
+            if (short[index] in colliding) declarationOf(symbol) else short[index]
+        }.sorted()
 
         val single = ignored.size == 1
         report(
@@ -115,6 +128,42 @@ class IgnoredJavaDefaultMethod(config: Config) :
                     "Override ${if (single) "it" else "them"} to delegate explicitly.",
             )
         )
+    }
+
+    // Overloads share a name, so the parameter types go in to tell them apart.
+    private fun KaSession.signatureOf(symbol: KaNamedFunctionSymbol): String =
+        symbol.valueParameters.joinToString(
+            prefix = "${symbol.name.asString()}(",
+            postfix = ")",
+        ) { parameter ->
+            val rendered = typeName(parameter.returnType)
+            if (parameter.isVararg) "vararg $rendered" else rendered
+        }
+
+    // Overloads that differ only in nullability or in a type parameter bound still share a
+    // signature. The whole declaration spells both out. Annotations are left out: they render on
+    // their own line, and a message has to stay on one.
+    @OptIn(KaExperimentalApi::class)
+    private fun KaSession.declarationOf(symbol: KaNamedFunctionSymbol): String =
+        symbol.render(
+            KaDeclarationRendererForSource.WITH_QUALIFIED_NAMES.with {
+                annotationRenderer = annotationRenderer.with { annotationFilter = KaRendererAnnotationsFilter.NONE }
+            }
+        )
+
+    // A Java parameter is a flexible type, which has no symbol of its own; the bound does.
+    // Type arguments are rendered too, so `Array<String>` and `Array<Int>` stay distinct.
+    private fun KaSession.typeName(type: KaType): String {
+        val bounded = type.lowerBoundIfFlexible()
+        val name = bounded.symbol?.name?.asString() ?: return bounded.toString()
+        val arguments = (bounded as? KaClassType)?.typeArguments.orEmpty()
+        return if (arguments.isEmpty()) {
+            name
+        } else {
+            arguments.joinToString(prefix = "$name<", postfix = ">") { argument ->
+                argument.type?.let { typeName(it) } ?: "*"
+            }
+        }
     }
 
     // Kotlin maps its own collection types onto java.util ones without a Java type in the

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/PotentialBugProvider.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/PotentialBugProvider.kt
@@ -56,6 +56,7 @@ class PotentialBugProvider : DefaultRuleSetProvider {
                 ::PropertyUsedBeforeDeclaration,
                 ::CharArrayToStringCall,
                 ::MissingSuperCall,
+                ::IgnoredJavaDefaultMethod,
             )
         )
 }

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethodSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethodSpec.kt
@@ -1,0 +1,271 @@
+package dev.detekt.rules.potentialbugs
+
+import dev.detekt.api.Config
+import dev.detekt.test.assertj.assertThat
+import dev.detekt.test.junit.KotlinCoreEnvironmentTest
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.utils.KotlinEnvironmentContainer
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest(additionalJavaSourcePaths = ["java"])
+class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) {
+    private val subject = IgnoredJavaDefaultMethod(Config.empty)
+
+    @Test
+    fun `reports delegation to a Java interface with a default method`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            class Wrapper(private val delegate: JavaInterfaceWithDefaults) :
+                JavaInterfaceWithDefaults by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `reports a default method inherited from a Java super-interface`() {
+        val code = """
+            import com.example.delegation.JavaSubInterface
+
+            class Wrapper(private val delegate: JavaSubInterface) : JavaSubInterface by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report when the class overrides the default method`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            class Wrapper(private val delegate: JavaInterfaceWithDefaults) :
+                JavaInterfaceWithDefaults by delegate {
+                override fun optional() {
+                    delegate.optional()
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a Java interface without default methods`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithoutDefaults
+
+            class Wrapper(private val delegate: JavaInterfaceWithoutDefaults) :
+                JavaInterfaceWithoutDefaults by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a static method on a Java interface`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithStatics
+
+            class Wrapper(private val delegate: JavaInterfaceWithStatics) :
+                JavaInterfaceWithStatics by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a Kotlin interface with a default method`() {
+        val code = """
+            interface KotlinInterface {
+                fun required()
+                fun optional() {}
+            }
+
+            class Wrapper(private val delegate: KotlinInterface) : KotlinInterface by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report delegation to a Kotlin collection mapped onto a Java interface`() {
+        val code = """
+            class MyList(private val list: List<String>) : List<String> by list
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report delegation to a mutable Kotlin collection`() {
+        val code = """
+            class MyList(private val list: MutableList<String>) : MutableList<String> by list
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a class implementing the Java interface without delegation`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            class Wrapper : JavaInterfaceWithDefaults {
+                override fun required() {}
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report when a superclass overrides the default method`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            abstract class Base : JavaInterfaceWithDefaults {
+                override fun optional() {}
+            }
+
+            class Wrapper(private val delegate: JavaInterfaceWithDefaults) :
+                Base(), JavaInterfaceWithDefaults by delegate {
+                override fun required() {}
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports a default method reached through a Kotlin interface extending a Java one`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            interface KotlinSub : JavaInterfaceWithDefaults
+
+            class Wrapper(private val delegate: KotlinSub) : KotlinSub by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `KotlinSub` ignores what the delegate does for the default " +
+                    "method `optional`. Override it to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `does not report when a Kotlin interface in the chain overrides the default method`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+
+            interface KotlinSub : JavaInterfaceWithDefaults {
+                override fun optional() {}
+            }
+
+            class Wrapper(private val delegate: KotlinSub) : KotlinSub by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `does not report a private method of a Java interface`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithPrivate
+
+            class Wrapper(private val delegate: JavaInterfaceWithPrivate) :
+                JavaInterfaceWithPrivate by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaInterfaceWithPrivate` ignores what the delegate does for the " +
+                    "default method `run`. Override it to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports a default method of a generic Java interface`() {
+        val code = """
+            import com.example.delegation.JavaGenericInterface
+
+            class Wrapper(private val delegate: JavaGenericInterface<String>) :
+                JavaGenericInterface<String> by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaGenericInterface` ignores what the delegate does for the " +
+                    "default methods `substituted`, `unsubstituted`. Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `does not report a generic Java interface whose defaults a superclass overrides`() {
+        val code = """
+            import com.example.delegation.JavaGenericInterface
+
+            abstract class Base : JavaGenericInterface<String> {
+                override fun substituted(input: String): String = input
+                override fun unsubstituted(): String = ""
+            }
+
+            class Wrapper(private val delegate: JavaGenericInterface<String>) :
+                Base(), JavaGenericInterface<String> by delegate {
+                override fun required(): String = ""
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports a default method of a Java interface from the standard library`() {
+        val code = """
+            class Wrapper(private val delegate: Comparator<String>) : Comparator<String> by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(1)
+    }
+
+    @Test
+    fun `does not report an overload of the same name that the class overrides`() {
+        val code = """
+            import com.example.delegation.JavaOverloadA
+            import com.example.delegation.JavaOverloadB
+
+            class Wrapper(
+                private val first: JavaOverloadA,
+                private val second: JavaOverloadB,
+            ) : JavaOverloadA by first, JavaOverloadB by second {
+                override fun foo(s: String) {
+                    second.foo(s)
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaOverloadA` ignores what the delegate does for the default " +
+                    "method `foo`. Override it to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `does not report a same-named default of an interface implemented without delegation`() {
+        val code = """
+            import com.example.delegation.JavaOverloadA
+            import com.example.delegation.JavaOverloadB
+
+            class Wrapper(private val second: JavaOverloadB) : JavaOverloadA, JavaOverloadB by second {
+                override fun requiredA() {}
+                override fun foo(s: String) {
+                    second.foo(s)
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `reports each delegated Java interface separately`() {
+        val code = """
+            import com.example.delegation.JavaInterfaceWithDefaults
+            import com.example.delegation.JavaOtherInterface
+
+            class Wrapper(
+                private val first: JavaInterfaceWithDefaults,
+                private val second: JavaOtherInterface,
+            ) : JavaInterfaceWithDefaults by first, JavaOtherInterface by second
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).hasSize(2)
+    }
+}

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethodSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/IgnoredJavaDefaultMethodSpec.kt
@@ -140,7 +140,7 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
             .singleElement()
             .hasMessage(
                 "Delegating to `KotlinSub` ignores what the delegate does for the default " +
-                    "method `optional`. Override it to delegate explicitly."
+                    "method `optional()`. Override it to delegate explicitly."
             )
     }
 
@@ -159,7 +159,7 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
     }
 
     @Test
-    fun `does not report a private method of a Java interface`() {
+    fun `reports the default method but not the private method of a Java interface`() {
         val code = """
             import com.example.delegation.JavaInterfaceWithPrivate
 
@@ -170,12 +170,12 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
             .singleElement()
             .hasMessage(
                 "Delegating to `JavaInterfaceWithPrivate` ignores what the delegate does for the " +
-                    "default method `run`. Override it to delegate explicitly."
+                    "default method `run()`. Override it to delegate explicitly."
             )
     }
 
     @Test
-    fun `reports a default method of a generic Java interface`() {
+    fun `reports the default methods of a generic Java interface`() {
         val code = """
             import com.example.delegation.JavaGenericInterface
 
@@ -186,7 +186,7 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
             .singleElement()
             .hasMessage(
                 "Delegating to `JavaGenericInterface` ignores what the delegate does for the " +
-                    "default methods `substituted`, `unsubstituted`. Override them to delegate explicitly."
+                    "default methods `substituted(T)`, `unsubstituted()`. Override them to delegate explicitly."
             )
     }
 
@@ -217,7 +217,45 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
     }
 
     @Test
-    fun `does not report an overload of the same name that the class overrides`() {
+    fun `reports both overloads with their parameter types`() {
+        val code = """
+            import com.example.delegation.JavaOverloadedDefaults
+
+            class Wrapper(
+                private val delegate: JavaOverloadedDefaults,
+            ) : JavaOverloadedDefaults by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaOverloadedDefaults` ignores what the delegate does for the " +
+                    "default methods `write(Int)`, `write(String)`. Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports only the overload the class leaves unforwarded`() {
+        val code = """
+            import com.example.delegation.JavaOverloadedDefaults
+
+            class Wrapper(
+                private val delegate: JavaOverloadedDefaults,
+            ) : JavaOverloadedDefaults by delegate {
+                override fun write(text: String) {
+                    delegate.write(text)
+                }
+            }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaOverloadedDefaults` ignores what the delegate does for the " +
+                    "default method `write(Int)`. Override it to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports only the same-named overload the class leaves unforwarded`() {
         val code = """
             import com.example.delegation.JavaOverloadA
             import com.example.delegation.JavaOverloadB
@@ -235,7 +273,7 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
             .singleElement()
             .hasMessage(
                 "Delegating to `JavaOverloadA` ignores what the delegate does for the default " +
-                    "method `foo`. Override it to delegate explicitly."
+                    "method `foo()`. Override it to delegate explicitly."
             )
     }
 
@@ -267,5 +305,102 @@ class IgnoredJavaDefaultMethodSpec(private val env: KotlinEnvironmentContainer) 
             ) : JavaInterfaceWithDefaults by first, JavaOtherInterface by second
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).hasSize(2)
+    }
+
+    @Test
+    fun `reports a vararg parameter as a vararg`() {
+        val code = """
+            import com.example.delegation.JavaVarargDefault
+
+            class Wrapper(private val delegate: JavaVarargDefault) : JavaVarargDefault by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaVarargDefault` ignores what the delegate does for the default " +
+                    "method `log(vararg String)`. Override it to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports both overloads that differ only by array element type`() {
+        val code = """
+            import com.example.delegation.JavaArrayOverloads
+
+            class Wrapper(private val delegate: JavaArrayOverloads) : JavaArrayOverloads by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaArrayOverloads` ignores what the delegate does for the default " +
+                    "methods `put(Array<Int>)`, `put(Array<String>)`. Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports the whole declaration when two overloads render the same`() {
+        val code = """
+            import com.example.delegation.JavaBoxedOverloads
+
+            class Wrapper(private val delegate: JavaBoxedOverloads) : JavaBoxedOverloads by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaBoxedOverloads` ignores what the delegate does for the default " +
+                    "methods `fun write(number: kotlin.Int)`, `fun write(number: kotlin.Int?)`. " +
+                    "Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports the whole declaration when parameter types share a simple name`() {
+        val code = """
+            import com.example.delegation.JavaCrossPackageOverloads
+
+            class Wrapper(private val delegate: JavaCrossPackageOverloads) :
+                JavaCrossPackageOverloads by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaCrossPackageOverloads` ignores what the delegate does for the " +
+                    "default methods `fun handle(stamp: com.example.delegation.Stamp?)`, " +
+                    "`fun handle(stamp: com.example.other.Stamp?)`. Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports the whole declaration when two overloads differ only by type parameter bound`() {
+        val code = """
+            import com.example.delegation.JavaGenericBoundOverloads
+
+            class Wrapper(private val delegate: JavaGenericBoundOverloads) :
+                JavaGenericBoundOverloads by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaGenericBoundOverloads` ignores what the delegate does for the " +
+                    "default methods `fun <T : kotlin.CharSequence?> accept(value: T?)`, " +
+                    "`fun <T : kotlin.Number?> accept(value: T?)`. Override them to delegate explicitly."
+            )
+    }
+
+    @Test
+    fun `reports a deprecated overload on one line`() {
+        val code = """
+            import com.example.delegation.JavaDeprecatedOverloads
+
+            class Wrapper(private val delegate: JavaDeprecatedOverloads) :
+                JavaDeprecatedOverloads by delegate
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code))
+            .singleElement()
+            .hasMessage(
+                "Delegating to `JavaDeprecatedOverloads` ignores what the delegate does for the " +
+                    "default methods `fun write(number: kotlin.Int)`, " +
+                    "`fun write(number: kotlin.Int?)`. Override them to delegate explicitly."
+            )
     }
 }

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaArrayOverloads.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaArrayOverloads.java
@@ -1,0 +1,9 @@
+package com.example.delegation;
+
+public interface JavaArrayOverloads {
+    void required();
+
+    default void put(String[] values) {}
+
+    default void put(Integer[] values) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaBoxedOverloads.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaBoxedOverloads.java
@@ -1,0 +1,9 @@
+package com.example.delegation;
+
+public interface JavaBoxedOverloads {
+    void required();
+
+    default void write(int number) {}
+
+    default void write(Integer number) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaCrossPackageOverloads.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaCrossPackageOverloads.java
@@ -1,0 +1,9 @@
+package com.example.delegation;
+
+public interface JavaCrossPackageOverloads {
+    void required();
+
+    default void handle(Stamp stamp) {}
+
+    default void handle(com.example.other.Stamp stamp) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaDeprecatedOverloads.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaDeprecatedOverloads.java
@@ -1,0 +1,10 @@
+package com.example.delegation;
+
+public interface JavaDeprecatedOverloads {
+    void required();
+
+    default void write(int number) {}
+
+    @Deprecated
+    default void write(Integer number) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaGenericBoundOverloads.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaGenericBoundOverloads.java
@@ -1,0 +1,9 @@
+package com.example.delegation;
+
+public interface JavaGenericBoundOverloads {
+    void required();
+
+    default <T extends Number> void accept(T value) {}
+
+    default <T extends CharSequence> void accept(T value) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaGenericInterface.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaGenericInterface.java
@@ -1,0 +1,11 @@
+package com.example.delegation;
+
+public interface JavaGenericInterface<T> {
+    T required();
+
+    /** Default whose signature mentions T, so it gets substituted. */
+    default T substituted(T input) { return input; }
+
+    /** Default whose signature does not mention T. */
+    default String unsubstituted() { return "JAVA_DEFAULT"; }
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithDefaults.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithDefaults.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaInterfaceWithDefaults {
+    void required();
+
+    default void optional() {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithPrivate.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithPrivate.java
@@ -1,0 +1,11 @@
+package com.example.delegation;
+
+public interface JavaInterfaceWithPrivate {
+    void required();
+
+    private void helper() {}
+
+    default void run() {
+        helper();
+    }
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithStatics.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithStatics.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaInterfaceWithStatics {
+    void required();
+
+    static void helper() {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithoutDefaults.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaInterfaceWithoutDefaults.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaInterfaceWithoutDefaults {
+    void required();
+
+    void alsoRequired();
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOtherInterface.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOtherInterface.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaOtherInterface {
+    void alsoRequired();
+
+    default void alsoOptional() {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadA.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadA.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaOverloadA {
+    void requiredA();
+
+    default void foo() {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadB.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadB.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaOverloadB {
+    void requiredB();
+
+    default void foo(String s) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadedDefaults.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaOverloadedDefaults.java
@@ -1,0 +1,9 @@
+package com.example.delegation;
+
+public interface JavaOverloadedDefaults {
+    void required();
+
+    default void write(String text) {}
+
+    default void write(int number) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaSubInterface.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaSubInterface.java
@@ -1,0 +1,5 @@
+package com.example.delegation;
+
+public interface JavaSubInterface extends JavaInterfaceWithDefaults {
+    void extra();
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaVarargDefault.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/JavaVarargDefault.java
@@ -1,0 +1,7 @@
+package com.example.delegation;
+
+public interface JavaVarargDefault {
+    void required();
+
+    default void log(String... args) {}
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/Stamp.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/delegation/Stamp.java
@@ -1,0 +1,4 @@
+package com.example.delegation;
+
+public class Stamp {
+}

--- a/detekt-rules-potential-bugs/src/test/resources/java/com/example/other/Stamp.java
+++ b/detekt-rules-potential-bugs/src/test/resources/java/com/example/other/Stamp.java
@@ -1,0 +1,4 @@
+package com.example.other;
+
+public class Stamp {
+}


### PR DESCRIPTION
Closes #8905.

Kotlin does not generate delegating members for the default methods of a Java interface, so a class that implements one by delegation inherits the interface default instead of forwarding to the delegate (KT-15226). Whatever the delegate does for those methods is silently dropped. That is how the bug in open-telemetry/opentelemetry-android#1464 reached a release.

The new `IgnoredJavaDefaultMethod` rule reports a delegated Java interface whose default methods the class does not forward. A method is left alone once the class, a superclass, or a Kotlin interface up the hierarchy overrides it, and Kotlin's mapped collection types such as `List` are skipped. It is not active by default.

Tests cover the generic, super-interface, superclass-override and multi-interface cases. I also ran the rule against the pre-fix and post-fix opentelemetry-android wrapper to confirm it fires on the bug and stays quiet on the fix.

AI-assisted (Claude), reviewed and tested locally.
