### PR TITLE
Recognize params swallowed by KDoc lexer in OutdatedDocumentation

### DIFF
--- a/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
+++ b/detekt-rules-comments/src/main/kotlin/dev/detekt/rules/comments/OutdatedDocumentation.kt
@@ -168,13 +168,40 @@ class OutdatedDocumentation(config: Config) :
 
     @Suppress("ElseCaseInsteadOfExhaustiveWhen")
     private fun processDocTag(docTag: KDocTag): List<Declaration> {
-        val knownTag = docTag.knownTag
-        val subjectName = docTag.getSubjectName() ?: return emptyList()
-        return when (knownTag) {
-            KDocKnownTag.PARAM -> listOf(Declaration(subjectName, DeclarationType.PARAM))
-            KDocKnownTag.PROPERTY -> listOf(Declaration(subjectName, DeclarationType.PROPERTY))
-            else -> emptyList()
+        val declaration = docTag.getSubjectName()?.let { subjectName ->
+            when (docTag.knownTag) {
+                KDocKnownTag.PARAM -> Declaration(subjectName, DeclarationType.PARAM)
+                KDocKnownTag.PROPERTY -> Declaration(subjectName, DeclarationType.PROPERTY)
+                else -> null
+            }
         }
+        return listOfNotNull(declaration) + findSwallowedDeclarations(docTag)
+    }
+
+    /**
+     * The KDoc lexer treats a tag description consisting only of an inline code span (e.g. ``@param x `[0, 1]` ``)
+     * as a code span that continues on the following lines, so subsequent tags are merged into the current
+     * [KDocTag] as raw text instead of being parsed as separate tags. Recover them from the tag text.
+     */
+    private fun findSwallowedDeclarations(docTag: KDocTag): List<Declaration> {
+        var inFencedCodeBlock = false
+        return docTag.text
+            .lineSequence()
+            .drop(1)
+            .map { it.trimStart().removePrefix("*").trim() }
+            .mapNotNull { line ->
+                if (line.startsWith("```")) {
+                    inFencedCodeBlock = !inFencedCodeBlock
+                    return@mapNotNull null
+                }
+                if (inFencedCodeBlock) return@mapNotNull null
+                swallowedTagRegex.find(line)?.let { match ->
+                    val (tagName, subjectName) = match.destructured
+                    val type = if (tagName == "param") DeclarationType.PARAM else DeclarationType.PROPERTY
+                    Declaration(subjectName, type)
+                }
+            }
+            .toList()
     }
 
     private fun findDocumentationMismatch(
@@ -254,3 +281,5 @@ class OutdatedDocumentation(config: Config) :
         ANY,
     }
 }
+
+private val swallowedTagRegex = Regex("""^@(param|property)\s+\[?([^\s\[\]]+)]?""")

--- a/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
+++ b/detekt-rules-comments/src/test/kotlin/dev/detekt/rules/comments/OutdatedDocumentationSpec.kt
@@ -462,6 +462,107 @@ class OutdatedDocumentationSpec {
     }
 
     @Nested
+    inner class `inline code descriptions` {
+
+        @Test
+        fun `should not report when aligned params are documented with backtick-only descriptions`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param hue        `[0, 1]`
+                 * @param saturation `[0, 1]`
+                 * @param brightness `[0, 1]`
+                 * @param alpha      `[0, 1]`
+                 */
+                fun fromHsb(hue: Float, saturation: Float, brightness: Float, alpha: Float) = Unit
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when unaligned params are documented with backtick-only descriptions`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param hue `[0, 1]`
+                 * @param saturation `[0, 1]`
+                 */
+                fun fromHsb(hue: Float, saturation: Float) = Unit
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).isEmpty()
+        }
+
+        @Test
+        fun `should not report when class params and properties are documented with backtick-only descriptions`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param someParam `[0, 1]`
+                 * @property someProp `[0, 1]`
+                 */
+                class MyClass(someParam: String, val someProp: String)
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).isEmpty()
+        }
+
+        @Test
+        fun `should report when a param documented with backtick-only description is not present in the declaration`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param hue `[0, 1]`
+                 * @param saturation `[0, 1]`
+                 */
+                fun fromHsb(hue: Float) = Unit
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).singleElement()
+                .hasMessage(
+                    "Documentation of fromHsb is outdated: documented parameters 'saturation' are not present in the declaration"
+                )
+        }
+
+        @Test
+        fun `should report when params documented with backtick-only descriptions have mismatching order`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param saturation `[0, 1]`
+                 * @param hue `[0, 1]`
+                 */
+                fun fromHsb(hue: Float, saturation: Float) = Unit
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).singleElement()
+                .hasMessage(
+                    "Documentation of fromHsb is outdated: order of documented parameters does not match the declaration order"
+                )
+        }
+
+        @Test
+        fun `should report when not all params are documented with backtick-only descriptions`() {
+            val backtickOnlyDescriptions = """
+                /**
+                 * @param hue `[0, 1]`
+                 * @param saturation `[0, 1]`
+                 */
+                fun fromHsb(hue: Float, saturation: Float, brightness: Float) = Unit
+            """.trimIndent()
+            assertThat(subject.lint(backtickOnlyDescriptions)).singleElement()
+                .hasMessage(
+                    "Documentation of fromHsb is outdated: parameters 'brightness' are not documented"
+                )
+        }
+
+        @Test
+        fun `should not report param tags inside fenced code blocks as documentation`() {
+            val fencedCodeBlock = """
+                /**
+                 * @param someParam usage:
+                 * ```
+                 * @param fake
+                 * ```
+                 */
+                fun myFun(someParam: String) {}
+            """.trimIndent()
+            assertThat(subject.lint(fencedCodeBlock)).isEmpty()
+        }
+    }
+
+    @Nested
     inner class `function with type params` {
 
         @Test


### PR DESCRIPTION
Fixes #9527

This is AI generated 👇

## Problem

`OutdatedDocumentation` reported parameters as undocumented when their descriptions consisted only of an inline code span:

```kotlin
/**
 * @param hue        `[0, 1]`
 * @param saturation `[0, 1]`
 * @param brightness `[0, 1]`
 * @param alpha      `[0, 1]`
 */
fun fromHsb(hue: Float, saturation: Float, brightness: Float, alpha: Float) = Unit
```

reported `parameters 'saturation', 'brightness', 'alpha' are not documented`.

## Root cause

This is not about alignment. The KDoc lexer in the bundled Kotlin compiler mis-handles a tag description that consists *only* of an inline code span: the code span is treated as continuing across the newline, so all subsequent `@param` lines are lexed as `KDOC_CODE_SPAN_TEXT` and merged into the first `KDocTag` as raw text instead of being parsed as separate tags. The rule walks the PSI tags, so it only saw the first parameter. Adding prose before the backtick avoids the lexer state that triggers this, which is why the workaround mentioned in the issue works. Detekt 1.23.8 embedded an older compiler without this lexer behavior, hence the regression in 2.0.

## Fix

Since the parser quirk is upstream, the rule now recovers the swallowed tags: `processDocTag` additionally scans the tag's raw text (lines after the first, leading `*` stripped) for `@param`/`@property` lines and turns them into declarations, preserving textual order so `matchDeclarationsOrder` and the "not present in declaration" checks keep working in this style. Lines inside fenced code blocks are skipped so code examples containing `@param`-like text can't produce false findings. On a correctly parsed tag the scan finds nothing, leaving normal behavior untouched.

## Tests

Added an `inline code descriptions` group to `OutdatedDocumentationSpec` covering: the issue's exact repro (aligned and unaligned), class `@param`/`@property`, genuinely outdated docs in this style (extra param, missing param, wrong order) still being reported, and the fenced-code-block guard.

---

This PR was authored with AI assistance (Claude) under human review, per the repository's AI contribution policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)