### PR TITLE
Recommend to use Locale.ROOT instead of Locale.US

### DIFF
--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ImplicitDefaultLocale.kt
@@ -24,18 +24,16 @@ import org.jetbrains.kotlin.resolve.calls.util.getCalleeExpressionIfAny
  * The default locale is almost always inappropriate for machine-readable text like HTTP headers.
  * For example, if locale with tag `ar-SA-u-nu-arab` is a current default then `%d` placeholders
  * will be evaluated to a number consisting of Eastern-Arabic (non-ASCII) digits.
- * [java.util.Locale.US] is recommended for machine-readable output.
+ * [java.util.Locale.ROOT] is recommended for machine-readable output.
  *
  * <noncompliant>
  * String.format("Timestamp: %d", System.currentTimeMillis())
  * "Timestamp: %d".format(System.currentTimeMillis())
- *
  * </noncompliant>
  *
  * <compliant>
- * String.format(Locale.US, "Timestamp: %d", System.currentTimeMillis())
- * "Timestamp: %d".format(Locale.US, System.currentTimeMillis())
- *
+ * String.format(Locale.ROOT, "Timestamp: %d", System.currentTimeMillis())
+ * "Timestamp: %d".format(Locale.ROOT, System.currentTimeMillis())
  * </compliant>
  */
 @ActiveByDefault(since = "1.16.0")


### PR DESCRIPTION
[From the javadoc](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#ROOT)

> The root locale is the locale whose language, country, and variant are empty ("") strings. This is regarded as the base locale of all locales, and is used as the language/country neutral locale for the locale sensitive operations.

So it is better to use `Root` than `US`. Different reasons but I think that the main one is that the code is more clear with their intentions.