### PR TITLE
Report unused constructor properties whose only usages are property initializers

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
@@ -181,14 +181,46 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
 
             references
                 .filter { it.isPrivateProperty() || it.isConstructorParameter() }
-                .forEach {
-                    val psi = it.psi ?: return@forEach
-                    when {
-                        psi is KtProperty && psi.isTopLevel -> usedTopLevelProperties.add(psi)
-                        psi is KtProperty || (psi is KtParameter && psi.hasValOrVar()) -> usedClassProperties.add(psi)
-                        else -> usedConstructorParameters.add(psi)
-                    }
-                }
+                .forEach { registerUsage(expression, it.psi ?: return@forEach) }
+        }
+    }
+
+    private fun registerUsage(expression: KtReferenceExpression, psi: PsiElement) {
+        when {
+            psi is KtProperty && psi.isTopLevel -> usedTopLevelProperties.add(psi)
+
+            // A usage of a constructor property from a property initializer of
+            // the same class reads the constructor parameter, not the backing
+            // field, so it justifies the PARAMETER and not the property (#9467).
+            psi is KtParameter && psi.hasValOrVar() &&
+                expression.isInSameClassPropertyInitializer(psi) ->
+                usedConstructorParameters.add(psi)
+
+            psi is KtProperty || (psi is KtParameter && psi.hasValOrVar()) -> usedClassProperties.add(psi)
+
+            else -> usedConstructorParameters.add(psi)
+        }
+    }
+
+    // A reference to a constructor property from a property initializer of the
+    // SAME class reads the constructor parameter, not the backing field — the
+    // initializer runs during construction, where a plain (non-val) parameter
+    // would serve identically. Such a usage therefore justifies the constructor
+    // PARAMETER, never the property; crediting it to the property hid
+    // constructor properties whose only usages are initializers (#9467).
+    // Usages anywhere else (member bodies, accessors, init blocks, super-call
+    // arguments, other classes) keep crediting the property. A local property's
+    // initializer is NOT construction scope, so the walk stops crediting the
+    // parameter at the first non-matching property boundary.
+    private fun KtReferenceExpression.isInSameClassPropertyInitializer(parameter: KtParameter): Boolean {
+        val parameterClass = parameter.containingClassOrObject ?: return false
+        var node: PsiElement = this
+        while (true) {
+            val parent = node.parent ?: return false
+            if (parent is KtProperty && parent.initializer === node) {
+                return !parent.isLocal && parent.containingClassOrObject === parameterClass
+            }
+            node = parent
         }
     }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -714,6 +714,17 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
         }
 
         @Test
+        fun `should report when the parameter is used but not the property`() {
+            val code = """
+                class Foo(private val text: String) {
+                    val count2: Int = text.length
+                }
+            """.trimIndent()
+            val findings = subject.lintWithContext(env, code)
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
         fun `does not report private property used in function`() {
             val code = """
                 class Test(private val used: Any) {


### PR DESCRIPTION
Closes #9467

## Problem

`UnusedPrivateProperty` does not report `text` in:

```kotlin
class Foo(private val text: String) {
    val count2: Int = text.length
}
```

The property initializer reads the **constructor parameter**, not the backing field — a plain `text: String` parameter would serve identically — so the `private val` keeps an unused field alive. Reproduced with the exact test from the issue: `Expected size: 1 but was: 0`.

## Root cause

In `UnusedPrivatePropertyVisitor`, every resolved usage whose PSI is a `val`/`var` constructor parameter is credited to the *property* bucket (`usedClassProperties`), regardless of where the usage occurs. Construction-time usages in property initializers therefore mark the property as used, hiding the finding.

## Fix

Usage classification now checks *where* the reference sits: a reference located inside a **property initializer of the same class** as the constructor property credits the constructor *parameter* (`usedConstructorParameters`) instead of the property. Everything else — member bodies, accessors, `init` blocks, super-call arguments, other classes, local-property initializers — keeps crediting the property, preserving all pinned behaviour.

A note on an approach that was tried and rejected: classifying by *resolved symbol* (crediting any `KaValueParameterSymbol`-resolved usage to the parameter) does not work — the initializer reference resolves to the property symbol, and re-routing parameter-resolved usages breaks the pinned `vararg val` super-call cases (`class Child(private vararg val used: Any) : Parent(used)`), which intentionally credit the property. The position-based check targets exactly the reported gap without touching those semantics.

## Testing

- Added the reproduction test from #9467 (`should report when the parameter is used but not the property`).
- `:detekt-rules-style:test --tests "*UnusedPrivatePropertySpec*"` → 58/58 passing (all existing pins intact, including `does not report private property used in init block` and both vararg cases).
- `:detekt-rules-style:detektMain :detekt-rules-style:detektTest` → clean (the first version of the change tripped `CyclomaticComplexMethod` and `BlankLineBetweenWhenConditions` on detekt's own analysis; the classification was extracted into a `registerUsage` helper to satisfy both).

## AI involvement disclosure

Per the [AI contribution policy](https://github.com/detekt/detekt/blob/main/AGENTS.md): this change was developed with AI assistance (Claude, credited as commit co-author). The workflow was human-directed — reproduce the issue first, validate every step against the full spec, and run detekt's self-analysis — and all code was reviewed by the submitting human. Happy to answer review feedback personally.
