### PR TITLE
Link Java class references in rule KDoc to the Java SE API docs

### DIFF
--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/RulePrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/RulePrinter.kt
@@ -13,6 +13,8 @@ import dev.detekt.utils.paragraph
 
 internal object RulePrinter : DocumentationPrinter<Rule> {
 
+    private val javaAutolinkRegex = Regex("""\[((?:java|javax)\.[\w.]+)](?!\()""")
+
     override fun print(item: Rule): String =
         markdown {
             if (item.isDeprecated()) {
@@ -23,7 +25,7 @@ internal object RulePrinter : DocumentationPrinter<Rule> {
             }
 
             if (item.description.isNotEmpty()) {
-                paragraph { item.description }
+                paragraph { item.description.withJavadocLinks() }
             } else {
                 paragraph { "TODO: Specify description" }
             }
@@ -48,6 +50,41 @@ internal object RulePrinter : DocumentationPrinter<Rule> {
             markdown { ConfigurationsPrinter.print(item.configurations) }
 
             printRuleCodeExamples(item)
+        }
+
+    // KDoc autolinks to Java types (e.g. `[java.util.Locale]`) resolve nowhere in
+    // the rendered markdown — without a target they reach the website as literal
+    // bracketed text (#9533). Rewrite them as links to the Java SE API docs, using
+    // the module-less javase/8 URL scheme the docs already use elsewhere. Segment
+    // heuristic: lowercase segments are packages; the first capitalized segment
+    // starts the class chain; following CamelCase segments are nested classes;
+    // anything after that (ALL_CAPS constants, lowercase members) becomes the
+    // anchor. A pure package reference has nothing stable to link to and is left
+    // untouched, as are regular `[text](url)` markdown links (lookahead).
+    private fun String.withJavadocLinks(): String =
+        javaAutolinkRegex.replace(this) { match ->
+            val reference = match.groupValues[1]
+            val segments = reference.split('.')
+            val classIndex = segments.indexOfFirst { it.first().isUpperCase() }
+            if (classIndex == -1) {
+                match.value
+            } else {
+                val packagePath = segments.take(classIndex).joinToString("/")
+                val classChain = mutableListOf(segments[classIndex])
+                var next = classIndex + 1
+                while (next < segments.size &&
+                    segments[next].first().isUpperCase() &&
+                    segments[next] != segments[next].uppercase()
+                ) {
+                    classChain += segments[next]
+                    next++
+                }
+                val anchor = segments.drop(next).joinToString(".")
+                    .let { if (it.isEmpty()) "" else "#$it" }
+                val url = "https://docs.oracle.com/javase/8/docs/api/" +
+                    "$packagePath/${classChain.joinToString(".")}.html$anchor"
+                "[`$reference`]($url)"
+            }
         }
 
     private fun MarkdownContent.printRuleCodeExamples(rule: Rule) {

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/RulePrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/RulePrinterTest.kt
@@ -49,6 +49,41 @@ internal class RulePrinterTest {
             val actual = RulePrinter.print(rule)
             assertThat(actual).contains("The return type is `Array<String>`")
         }
+
+        @Test
+        fun `renders a KDoc autolink to a Java class as a Javadoc link`() {
+            val rule = ruleTemplate.copy(description = "Prefer passing [java.util.Locale] explicitly.")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains(
+                "Prefer passing [`java.util.Locale`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) explicitly."
+            )
+        }
+
+        @Test
+        fun `renders a KDoc autolink to a Java class member with an anchor`() {
+            val rule = ruleTemplate.copy(description = "[java.util.Locale.US] is recommended.")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains(
+                "[`java.util.Locale.US`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#US) is recommended."
+            )
+        }
+
+        @Test
+        fun `renders a KDoc autolink to a nested Java class`() {
+            val rule = ruleTemplate.copy(description = "See [java.util.Map.Entry] for details.")
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains(
+                "See [`java.util.Map.Entry`](https://docs.oracle.com/javase/8/docs/api/java/util/Map.Entry.html) for details."
+            )
+        }
+
+        @Test
+        fun `keeps regular markdown links and non-Java autolinks untouched`() {
+            val description = "See [the docs](https://example.org) and [kotlin.String] and [java.util]."
+            val rule = ruleTemplate.copy(description = description)
+            val actual = RulePrinter.print(rule)
+            assertThat(actual).contains(description)
+        }
     }
 
     @Nested

--- a/website/scripts/generate-docs.mjs
+++ b/website/scripts/generate-docs.mjs
@@ -710,6 +710,38 @@ function crossOut(text) { return `~~${text}~~`; }
 function code(text) { return `\`\`${text}\`\``; }
 function codeBlock(content) { return `\`\`\`kotlin\n${content}\n\`\`\``; }
 
+// KDoc autolinks to Java types (e.g. `[java.util.Locale]`) resolve nowhere in
+// the rendered markdown — without a target they reach the website as literal
+// bracketed text (#9533). Rewrite them as links to the Java SE API docs, using
+// the module-less javase/8 URL scheme the docs already use elsewhere. Mirrors
+// RulePrinter.kt's withJavadocLinks exactly, so both website generators stay
+// byte-identical (verify-generators-parity CI job).
+const JAVA_AUTOLINK_REGEX = /\[((?:java|javax)\.[\w.]+)\](?!\()/g;
+
+function withJavadocLinks(text) {
+  return text.replace(JAVA_AUTOLINK_REGEX, (match, reference) => {
+    const segments = reference.split('.');
+    const classIndex = segments.findIndex(s => /[A-Z]/.test(s[0]));
+    if (classIndex === -1) return match;
+
+    const packagePath = segments.slice(0, classIndex).join('/');
+    const classChain = [segments[classIndex]];
+    let next = classIndex + 1;
+    while (
+      next < segments.length &&
+      /[A-Z]/.test(segments[next][0]) &&
+      segments[next] !== segments[next].toUpperCase()
+    ) {
+      classChain.push(segments[next]);
+      next++;
+    }
+    const anchorSegments = segments.slice(next).join('.');
+    const anchor = anchorSegments ? `#${anchorSegments}` : '';
+    const url = `https://docs.oracle.com/javase/8/docs/api/${packagePath}/${classChain.join('.')}.html${anchor}`;
+    return `[\`${reference}\`](${url})`;
+  });
+}
+
 function printConfigurations(configs) {
   if (!configs.length) return '';
   const md = new MarkdownBuilder();
@@ -748,7 +780,7 @@ function printRule(rule) {
   }
 
   if (rule.description) {
-    md.paragraph(rule.description);
+    md.paragraph(withJavadocLinks(rule.description));
   } else {
     md.paragraph('TODO: Specify description');
   }


### PR DESCRIPTION
Closes #9533

## Problem

KDoc autolinks to Java types in rule documentation — e.g. `[java.util.Locale]` in `ImplicitDefaultLocale` — are copied verbatim into the generated rule pages, so they reach the website as literal bracketed text with no link (see the [reproduction from the issue](https://detekt.dev/docs/2.0.0-alpha.5/rules/potential-bugs/#implicitdefaultlocale)).

## Root cause

`DocumentationCollector` extracts the KDoc as-is and `RulePrinter` prints the description untouched, so a KDoc autolink — which has no meaning in plain markdown — lands in the `.mdx` unchanged.

## Fix

`RulePrinter` now rewrites `java.`/`javax.` autolinks in rule descriptions as markdown links to the Java SE API docs, using the module-less `docs.oracle.com/javase/8/docs/api/` URL scheme the generated docs already use elsewhere (e.g. the `Iterator.next()` reference in `IteratorNotThrowingNoSuchElementException`). Segment heuristic, documented in the code: lowercase segments are packages; the first capitalized segment starts the class chain; following CamelCase segments are nested classes (`java.util.Map.Entry` → `Map.Entry.html`); anything after that becomes the anchor (`java.util.Locale.US` → `Locale.html#US`). Regular `[text](url)` links, non-Java autolinks, and package-only references are left untouched.

Generated output for the issue's reproduction case, before → after:

```
Prefer passing [java.util.Locale] explicitly …
[java.util.Locale.US] is recommended …
```

```
Prefer passing [`java.util.Locale`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html) explicitly …
[`java.util.Locale.US`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#US) is recommended …
```

## Testing

- Four new `RulePrinterTest` cases: plain class, class member (anchor), nested class, and the untouched set (regular markdown links, `[kotlin.String]`, package-only `[java.util]`).
- `:detekt-generator:test` + `:detekt-generator:detektMain`/`:detektTest` → green (self-analysis first caught a `ClassOrdering` violation in my initial version — fixed).
- Verified end-to-end by running `:detekt-generator:generateDocumentation` and inspecting the regenerated `website/docs/rules/potential-bugs.mdx` (gitignored output, hence not part of this PR) — the two lines above render as real links.

## Observation for maintainers (out of scope here)

While verifying, I noticed `generateDocumentation` declares only the rule modules' sources as `inputs`, not the generator's own classes — so a generator-code change does not invalidate the task and a build-cache-restored output can mask it (I had to use `--rerun` to see the effect). Happy to file a separate issue/PR for that if useful.

## AI involvement disclosure

Per the [AI contribution policy](https://github.com/detekt/detekt/blob/main/AGENTS.md): this change was developed with AI assistance (Claude, credited as commit co-author), with a human directing the work and reviewing the result. Review feedback will be answered personally.
