### PR TITLE
Publish detekt-api test-fixtures runtime JAR

### DIFF
--- a/detekt-api/build.gradle.kts
+++ b/detekt-api/build.gradle.kts
@@ -39,15 +39,6 @@ tasks {
     }
 }
 
-val javaComponent = components["java"] as AdhocComponentWithVariants
-listOf(configurations.testFixturesApiElements, configurations.testFixturesRuntimeElements).forEach { config ->
-    config.configure {
-        javaComponent.withVariantsFromConfiguration(this) {
-            skip()
-        }
-    }
-}
-
 kotlin {
     @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
     abiValidation {


### PR DESCRIPTION
This is AI generated. Fix is quite trivial 👇

## Problem

Since `2.0.0-alpha.3`, depending on `testFixtures("dev.detekt:detekt-api")` fails with a `No matching variant` error, and the test-fixtures runtime JAR returns HTTP 404 on Maven Central. This blocks resolving the test classpath for projects that rely on detekt-api's test fixtures.

## Root cause

The `skip()` block in `detekt-api/build.gradle.kts` skipped the `testFixturesApiElements` and `testFixturesRuntimeElements` variants (the actual runtime JAR), but **not** the `testFixturesSourcesElements` (sources/documentation) variant. That sources variant started leaking into the published Gradle module metadata around alpha.3 due to a Gradle/plugin behavior change (which is why `2.0.0-alpha.2` worked and `alpha.3`+ broke).

The result: the module advertised the `detekt-api-test-fixtures` capability through a documentation-only variant with no consumable runtime JAR, so consumers requesting the test fixtures got `No matching variant`.

## Fix

Remove the skip block so the api and runtime test-fixtures variants are published alongside the sources variant, making the capability resolvable.

## Verification

- Regenerated Gradle module metadata now includes `testFixturesApiElements`, `testFixturesRuntimeElements`, and `testFixturesSourcesElements`, all carrying the `detekt-api-test-fixtures` capability.
- `publishToMavenLocal` now produces `detekt-api-<version>-test-fixtures.jar` (the previously-missing runtime JAR) with a consistent `.module` and `.pom`.

## Note

`detekt-gradle-plugin` has the same skip pattern (`build.gradle.kts:269-270`). It is left untouched here since its fixtures are internal-only and out of scope for this issue, but it may warrant a follow-up.

Fixes #9543

Co-authored-by: Claude <claude@anthropic.com>