### PR TITLE
Migrate to the OSS Community Develocity Instance

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -312,22 +312,22 @@ Check the [README.md inside website/](https://github.com/detekt/detekt/blob/main
 
 ## Develocity Access
 
-We do have access to a managed [Develocity instance][6] that is publishing
+We do have access to the [OSS Community Develocity Instance][6] that is publishing
 build scans for all the builds executed on CI (not from forks).
 
 This is extremely helpful to debug build failures and have access to remote build cache.
 Build scans are public so everyone can get insights on our build status.
 
-If you're a **maintainer** of a project under github.com/detekt/, you can request an access token
+If you're a **maintainer** of a project under github.com/detekt/, you can provision an access key
 to connect your local machine to the Develocity instance, so you will also be publishing scans.
 
 You must follow the steps below:
 
-1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainers.
-2. An account on https://ge.detekt.dev/ will be created for you, which you need to configure upon login (e.g. reset your password).
-3. Run the `./gradlew provisionGradleEnterpriseAccessKey` task from the detekt root folder
+1. Email us at [info@detekt.dev][7] or get in touch with one of the existing maintainers to be granted access to the `detekt` project on the instance.
+2. Sign in at https://community.develocity.cloud/.
+3. Run the `./gradlew provisionDevelocityAccessKey` task from the detekt root folder
 4. Complete the access key provisioning process (you will have to go through a browser).
-5. Verify that the access key is correctly stored inside `~/.gradle/enterprise/keys.properties`
+5. Verify that the access key is correctly stored inside `~/.gradle/develocity/keys.properties`
 6. Do a test run (say with `./gradlew tasks`) to verify that a scan is correctly published.
 
 More information on this process could be found on the [official Develocity documentation][8].
@@ -337,6 +337,6 @@ More information on this process could be found on the [official Develocity docu
 [3]: https://kotlinlang.org/docs/kotlin-doc.html
 [4]: https://daringfireball.net/projects/markdown/syntax
 [5]: https://kotlinlang.org/docs/functions.html#named-arguments
-[6]: https://ge.detekt.dev/
+[6]: https://community.develocity.cloud/
 [7]: mailto:info@detekt.dev
 [8]: https://docs.gradle.com/develocity/gradle-plugin/current/#automated_access_key_provisioning

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Visit the website at detekt.dev/](https://img.shields.io/badge/visit-website-red.svg?logo=firefox)](https://detekt.dev/)
 [![Maven Central](https://img.shields.io/maven-central/v/io.gitlab.arturbosch.detekt/detekt-cli?label=MavenCentral&logo=apache-maven)](https://search.maven.org/artifact/io.gitlab.arturbosch.detekt/detekt-cli)
 [![Gradle Plugin](https://img.shields.io/maven-central/v/io.gitlab.arturbosch.detekt/detekt-gradle-plugin?label=Gradle&logo=gradle)](https://plugins.gradle.org/plugin/io.gitlab.arturbosch.detekt)
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.detekt.dev/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=detekt)
 [![License](https://img.shields.io/github/license/detekt/detekt.svg)](LICENSE)
 
 ![Pre Merge Checks](https://github.com/detekt/detekt/workflows/Pre%20Merge%20Checks/badge.svg?branch=main)

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -26,7 +26,7 @@ buildCache {
         isEnabled = !isCiBuild
     }
     remote(develocity.buildCache) {
-        server = "https://ge.detekt.dev"
+        server = "https://community.develocity.cloud"
         isEnabled = true
         isPush = isCiBuild
     }

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -51,7 +51,7 @@ buildCache {
         isEnabled = !isCiBuild
     }
     remote(develocity.buildCache) {
-        server = "https://ge.detekt.dev"
+        server = "https://community.develocity.cloud"
         isEnabled = true
         isPush = isCiBuild
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -67,7 +67,8 @@ develocity {
     buildScan {
         // Publish to scans.gradle.com when `--scan` is used explicitly
         if (!gradle.startParameter.isBuildScan) {
-            server = "https://ge.detekt.dev"
+            server = "https://community.develocity.cloud"
+            projectId = "detekt"
             publishing.onlyIf { it.isAuthenticated }
         }
 
@@ -81,7 +82,7 @@ buildCache {
         isEnabled = !isCiBuild
     }
     remote(develocity.buildCache) {
-        server = "https://ge.detekt.dev"
+        server = "https://community.develocity.cloud"
         isEnabled = true
         isPush = isCiBuild
     }


### PR DESCRIPTION
# Onboard to the OSS Community Develocity Instance

This PR migrates [Develocity](https://gradle.com/develocity) Build Scan® and Build Cache support
for this project from the `ge.detekt.dev` instance to the **OSS Community Develocity
Instance** at <https://community.develocity.cloud>, under project ID `detekt`.

The OSS Community Develocity Instance is a managed instance provided by Gradle for open-source
projects.

## Step 1 — Get an access key for `community.develocity.cloud`

Build Scan publishing **and** remote Build Cache writes from CI need a Develocity access key that
is authorised for the `detekt` project on the community instance.

1. Visit <https://community.develocity.cloud>.
2. Sign in as the CI account that has been provided for detekt.
3. From the user menu in the top-right, open **My settings** → **Access keys**.
4. Click **Generate access key**, give it a description (e.g. `GitHub Actions`), and copy the
   generated key. Keep this tab open until you complete Step 2 — the key is only shown once.

## Step 2 — Update the GitHub Actions secret on this repository

The six workflows that publish Build Scans already read the secret
`GRADLE_ENTERPRISE_ACCESS_KEY` and expose it to Gradle as the `DEVELOCITY_ACCESS_KEY` environment
variable. That secret currently holds a key for `ge.detekt.dev`, so its **value** must be replaced.

1. Open this repository on GitHub.
2. Click **Settings**.
3. In the left sidebar, click **Secrets and variables** → **Actions**.
4. Find the existing `GRADLE_ENTERPRISE_ACCESS_KEY` secret and click **Update**.
5. Set the value to the following, replacing `PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE` with the key
   you copied in Step 1:

   ```
   community.develocity.cloud=PASTE_THE_ACCESS_KEY_FROM_STEP_1_HERE
   ```

   The `community.develocity.cloud=` prefix is **required** — without the host name, the access key
   is silently ignored. This is the most common point of failure when onboarding, so please
   double-check the format.
6. Click **Update secret**.

Optionally, you may want to rename this secret to `DEVELOCITY_ACCESS_KEY` to match the current
product naming.

## Step 3 — Provision an access key for your local builds

Developers building this project locally should provision an access key for
`community.develocity.cloud` so their Build Scans publish. The Develocity Gradle plugin's `provisionDevelocityAccessKey` task does this in a single
command — it opens the browser, asks the developer to confirm, and writes the key to
`~/.gradle/develocity/keys.properties` automatically.

**Before running this command**, sign out of `community.develocity.cloud` in your browser (or use a
private/incognito window) so the access key gets associated with **your personal account**, not the
CI service account from Step 1.

```
./gradlew provisionDevelocityAccessKey
```

## Note on the CI run on this PR

This PR was prepared from a fork. Forks can't read this repository's secrets, so the workflow run on
this PR cannot publish to `community.develocity.cloud` even after you complete Step 2 — the same
constraint that applies to detekt's existing fork builds today.

If you want CI verification before merging, push the branch
`dv/onboard-oss-community-develocity-instance` to a temporary branch on **this** repo (not the fork)
and re-run the workflow there — it will pick up the secret and publish a Build Scan.

After merging, every CI run **on this repository** will publish a Build Scan to
<https://community.develocity.cloud>. CI runs from forks of this repository will not, and that's
expected.