### PR TITLE
docs: drop stale Android compile classpath warning note

### DIFF
--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.0/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.0/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.1/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.1/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.2/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.2/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.3/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.3/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.4/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.4/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 

--- a/website/versioned_docs/version-2.0.0-alpha.5/gettingstarted/gradle.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/gettingstarted/gradle.mdx
@@ -48,11 +48,6 @@ the name of the build variant in their name, unless otherwise configured, such a
 If both, a `detekt-main.xml` and a `detekt.xml` baseline file exists in place, the more specific one - `detekt-main.xml` -
 takes precedence when the `detektMain` task is executed, likewise for Android variant-specific baseline files.
 
-_NOTE:_ When analyzing Android projects that make use of specific code generators, such as Data Binding, Kotlin synthetic
-view accessors or else, you might see warnings output while detekt runs. This is due to the inability to gather the
-complete compile classpath from the Android Gradle Plugin ([upstream ticket](https://issuetracker.google.com/issues/158777988))
-and can safely be ignored.
-
 Use the Groovy or Kotlin DSL of Gradle to apply the Detekt Gradle Plugin. You can further configure the Plugin
 using the detekt closure as described [here](#options-for-detekt-configuration-closure).
 


### PR DESCRIPTION
The Gradle setup page tells Android users that they may see warnings from code generators like Data Binding or Kotlin synthetic view accessors, and that these come from detekt not being able to gather the complete compile classpath from AGP. It points at [b/158777988](https://issuetracker.google.com/issues/158777988) as the upstream cause.

That hasn't been true since #7016. The Android integration no longer calls `BaseVariant.getCompileClasspath(null)` — `DetektAndroidCompilations` hooks `AndroidComponentsExtension.onVariants`, matches the corresponding `KotlinCompilation`, and `SharedTasks` builds the classpath from `compilation.output.classesDirs` plus the Kotlin compile task's own `libraries`. Because that is exactly the classpath kotlinc uses, generated sources such as R classes and Data Binding output are already there.

Both concrete examples in the note are also gone independently: the upstream ticket was fixed in February 2022, and Kotlin synthetic view accessors were removed in Kotlin 1.8. Leaving the note in place mostly trains Android users to ignore warnings that would now be real signal.

I checked this against a real project — running the type-resolved variant tasks (`detektMain`, `detektFullDebug`, `detektMinimalDebug`) on the Home Assistant Android app with 2.0.0-alpha.5 produces findings with no classpath warnings.

`git tag --contains 92269e66b0` gives `v2.0.0-alpha.0` through `v2.0.0-alpha.5`, so the note is stale on every published 2.x release too, not just on `next`. It's removed from `website/docs/` and from all six `version-2.0.0-alpha.*` copies. The 1.x snapshots keep it — 1.23.x still registers the Android tasks via `BaseVariant` and genuinely hits the gap the note describes.