### PR TITLE
docs: fix admonition titles using unsupported legacy syntax

### DIFF
--- a/website/docs/introduction/extensions.mdx
+++ b/website/docs/introduction/extensions.mdx
@@ -12,7 +12,7 @@ The associated **code samples** to this guide can be found in the package [detek
 
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of the `RuleSetProvider` interface, making it possible to define rules/rule sets and enhance _detekt_ with your own flavor.
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file containing the fully qualified name of
 your `RuleSetProvider`. For example: 

--- a/website/docs/introduction/migrationguide.mdx
+++ b/website/docs/introduction/migrationguide.mdx
@@ -15,7 +15,7 @@ This page is a migration guide from **detekt 1.x to detekt 2.x**. It is split in
 If you find a missing or unclear step while migrating, please open an issue or — even better — a
 pull request to improve this page.
 
-:::tip Why so many changes?
+:::tip[Why so many changes?]
 
 detekt 1.0 shipped in 2019 and we kept backwards compatibility for the entire 1.x line. The 2.x
 line is our opportunity to clean up the API, drop the K1 (legacy) Kotlin compiler in favour of the

--- a/website/docs/introduction/reporting.mdx
+++ b/website/docs/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-1.21.0/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.21.0/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.22.0/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.22.0/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.0/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.0/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.1/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.1/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.3/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.3/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.4/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.4/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.5/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.5/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.6/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.6/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.7/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.7/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.8/introduction/extensions.mdx
+++ b/website/versioned_docs/version-1.23.8/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/io.gitlab.arturbosch.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `io.gitlab.arturbosch.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-1.23.8/introduction/reporting.mdx
+++ b/website/versioned_docs/version-1.23.8/introduction/reporting.mdx
@@ -55,7 +55,7 @@ namely XML and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.0/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.0/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `dev.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-2.0.0-alpha.0/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.0/introduction/reporting.mdx
@@ -55,7 +55,7 @@ namely XML and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.1/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.1/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `dev.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-2.0.0-alpha.1/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.1/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.2/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.2/introduction/extensions.mdx
@@ -13,7 +13,7 @@ The associated **code samples** to this guide can be found in the package [detek
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of `RuleSetProvider` interfaces. 
 So it is possible to define rules/rule sets and enhance _detekt_ with your own flavor. 
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file which 
 has as content the fully qualified name of your `RuleSetProvider` e.g. `dev.detekt.sample.extensions.SampleProvider`.

--- a/website/versioned_docs/version-2.0.0-alpha.2/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.2/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.3/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.3/introduction/extensions.mdx
@@ -12,7 +12,7 @@ The associated **code samples** to this guide can be found in the package [detek
 
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of the `RuleSetProvider` interface, making it possible to define rules/rule sets and enhance _detekt_ with your own flavor.
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file containing the fully qualified name of
 your `RuleSetProvider`. For example: 

--- a/website/versioned_docs/version-2.0.0-alpha.3/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.3/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.4/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.4/introduction/extensions.mdx
@@ -12,7 +12,7 @@ The associated **code samples** to this guide can be found in the package [detek
 
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of the `RuleSetProvider` interface, making it possible to define rules/rule sets and enhance _detekt_ with your own flavor.
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file containing the fully qualified name of
 your `RuleSetProvider`. For example: 

--- a/website/versioned_docs/version-2.0.0-alpha.4/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.4/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.

--- a/website/versioned_docs/version-2.0.0-alpha.5/introduction/extensions.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/introduction/extensions.mdx
@@ -12,7 +12,7 @@ The associated **code samples** to this guide can be found in the package [detek
 
 _detekt_ uses the `ServiceLoader` pattern to collect all instances of the `RuleSetProvider` interface, making it possible to define rules/rule sets and enhance _detekt_ with your own flavor.
 
-:::caution Attention
+:::caution[Attention]
 
 You need a `resources/META-INF/services/dev.detekt.api.RuleSetProvider` file containing the fully qualified name of
 your `RuleSetProvider`. For example: 

--- a/website/versioned_docs/version-2.0.0-alpha.5/introduction/migrationguide.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/introduction/migrationguide.mdx
@@ -15,7 +15,7 @@ This page is a migration guide from **detekt 1.x to detekt 2.x**. It is split in
 If you find a missing or unclear step while migrating, please open an issue or — even better — a
 pull request to improve this page.
 
-:::tip Why so many changes?
+:::tip[Why so many changes?]
 
 detekt 1.0 shipped in 2019 and we kept backwards compatibility for the entire 1.x line. The 2.x
 line is our opportunity to clean up the API, drop the K1 (legacy) Kotlin compiler in favour of the

--- a/website/versioned_docs/version-2.0.0-alpha.5/introduction/reporting.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/introduction/reporting.mdx
@@ -54,7 +54,7 @@ namely Checkstyle and SARIF.
 
 ## Merging reports
 
-:::caution Attention
+:::caution[Attention]
 
 **Gradle 7.4 or higher is required**. Earlier Gradle prevent tasks running if they depend on a failing task, so merge
 tasks will not run if detekt finds issues.


### PR DESCRIPTION
Admonitions on the website are rendering as literal text instead of styled callouts. For example, on [the 2.x migration guide](https://detekt.dev/docs/introduction/migration/) the "Why so many changes?" tip shows up as a plain paragraph reading `:::tip Why so many changes?`, followed by the body text, followed by another paragraph containing `:::`.

The cause is the title syntax. These blocks were written as `:::tip Title`, which the markdown pipeline Docusaurus ships with no longer recognises — the space-separated label form was dropped in favour of `:::tip[Title]`. Without a valid directive to match, the opening and closing fences are left alone and end up in the output verbatim. Admonitions without a title were never affected, which is why this went unnoticed.

This switches every affected block to the bracketed form. It touches the current docs and all versioned snapshots, since each published version renders the same broken markup today.

Verified by running every file under `website/docs` and `website/versioned_docs` (513 files) through the Docusaurus MDX processor: 27 files emitted literal `:::` before the change and none do afterwards, with the admonition components now carrying their titles.