### PR TITLE
Add a Danger check for legacy admonition title syntax

### DIFF
--- a/bots/dangerfile.js
+++ b/bots/dangerfile.js
@@ -1,4 +1,4 @@
-import { danger, fail, markdown, warn, message } from "danger";
+import { danger, fail, markdown, warn, message, schedule } from "danger";
 
 // API reference: https://danger.systems/js/reference.html
 const pr = danger.github.pr;
@@ -21,6 +21,9 @@ const websiteUnversionedChanges = danger.git.fileMatch(
 const websiteVersionedChanges = danger.git.fileMatch(
     "website/versioned_docs/**/*.md",
     "website/versioned_docs/**/*.mdx");
+const websiteMarkdownChanges = danger.git.fileMatch(
+    "website/**/*.md",
+    "website/**/*.mdx");
 const milestone = danger.github.pr.milestone;
 const prReviews = danger.github.reviews;
 
@@ -93,3 +96,42 @@ if (websiteUnversionedChanges.edited && !websiteVersionedChanges.edited) {
       "Most of the time you want to update also the docs inside `website/docs/` as well, so this change will reflect also for documentation on **future versions** of detekt."
   );
 }
+
+// Docusaurus 3 only understands the `:::keyword[Title]` form of admonition titles.
+// The Docusaurus 2 form, `:::keyword Title`, is no longer parsed as an admonition:
+// it silently renders as a literal `:::` paragraph and the website still builds fine,
+// so nothing but a human reading the published page will catch it.
+const legacyAdmonitionTitle = /^[ \t]*:{3,}[a-z]+[ \t]+\S/;
+
+schedule(async () => {
+  const offenders = [];
+
+  for (const file of websiteMarkdownChanges.getKeyedPaths().edited) {
+    const diff = await danger.git.structuredDiffForFile(file);
+    if (!diff) {
+      continue;
+    }
+    for (const chunk of diff.chunks) {
+      for (const change of chunk.changes) {
+        if (change.type !== "add") {
+          continue;
+        }
+        // `content` keeps the leading `+` from the diff, so drop it before matching.
+        const line = change.content.slice(1);
+        if (legacyAdmonitionTitle.test(line)) {
+          offenders.push(`- \`${file}:${change.ln}\` — \`${line.trim()}\``);
+        }
+      }
+    }
+  }
+
+  if (offenders.length > 0) {
+    fail(
+      "This PR adds admonitions written with the Docusaurus 2 title syntax `:::keyword Title`. " +
+        "Docusaurus 3 only recognises `:::keyword[Title]`, so these blocks won't render as admonitions — " +
+        "they'll appear as literal `:::` text on the website, and the build won't fail. " +
+        "Please move the titles into square brackets:\n\n" +
+        offenders.join("\n")
+    );
+  }
+});


### PR DESCRIPTION
Follow-up to #9551, which fixed 27 admonitions that had stopped rendering on the website. This adds a guard so it doesn't happen again.

Docusaurus 3 dropped the Docusaurus 2 syntax for admonition titles. `:::tip Why so many changes?` used to work; now only `:::tip[Why so many changes?]` does. The problem is how it fails: the legacy form simply isn't parsed as a container directive, so it falls through as an ordinary paragraph and readers see a literal `:::tip Why so many changes?` on the page. The admonitions remark plugin only ever visits `containerDirective` nodes, so there's no node left for it to warn about — `yarn build` exits 0 and CI stays green.

That's how the original 27 slipped by. Most date back to #5055 in July 2022 and were perfectly correct then; the Docusaurus 3 upgrade in #6754 broke them silently a year and a half later. What convinced me a guard was worth adding is that it has already happened again since: `:::tip Why so many changes?` was written in #9414 on 2026-06-18, as part of a rewrite that took `migrationguide.md` from 110 lines to 506. That string appears in no commit on any ref before that one, so it was invalid the day it was authored — and it was still written, reviewed, merged and deployed with nothing flagging it. It's currently rendering as literal `:::` text on the live 2.0.0-alpha.5 docs. Since the build can't help here, the check has to live outside it.

Danger already hosts our website-authoring rules (the versioned/unversioned pairing warning), runs on every PR, and sees exactly the added lines, so it seemed like the natural place. The check scans added lines in `website/**/*.{md,mdx}` for `:::keyword` followed by a bare title and reports the file, line and offending text. It ignores the bracketed form, bare `:::tip`, and closing fences, and handles `::::` nesting.

I used `fail` rather than `warn` because the rendering is objectively broken rather than a matter of taste, and the fix is two characters. Happy to downgrade it to a warning if you'd rather keep the dangerfile advisory-only.

One thing worth knowing about the scope: a `docusaurus docs:version` snapshot shows up as an entirely new file, so every line reads as added and copied admonitions get flagged alongside hand-written ones. In practice that can only fire if `website/docs/` is already broken — which is the thing this check prevents on the way in — so after #9551 lands it shouldn't produce noise on release PRs.

### Testing

Run against #9414:

```
$ yarn danger pr https://github.com/detekt/detekt/pull/9414

- `website/docs/introduction/migrationguide.md:18` — `:::tip Why so many changes?`
- `website/versioned_docs/version-2.0.0-alpha.5/introduction/extensions.md:15` — `:::caution Attention`
- `website/versioned_docs/version-2.0.0-alpha.5/introduction/migrationguide.md:18` — `:::tip Why so many changes?`
- `website/versioned_docs/version-2.0.0-alpha.5/introduction/reporting.md:57` — `:::caution Attention`
```

The first line is the newly authored one; the other three are the alpha.5 snapshot picking up the same content, which is the copied-lines behaviour described above.

Run against #9551, which converts those same lines to the bracketed form, it stays quiet. Applied to the whole corpus the same pattern finds all 27 occurrences on `main` and none after #9551, with no false positives across 516 files — matching what the Docusaurus MDX processor reports.
