### PR TITLE
fix(doc): remove mention of fixed issue

### DIFF
--- a/website/docs/gettingstarted/compilerplugin.mdx
+++ b/website/docs/gettingstarted/compilerplugin.mdx
@@ -139,7 +139,3 @@ rootPath=<path> # Root path used to relativize paths when using exclude patterns
 excludes=<base64-encoded globs> # A base64-encoded list of the globs used to exclude paths from scanning.
 report=<report-id:path> # Generates a report for given 'report-id' and stores it on given 'path'. Available 'report-id' values: 'checkstyle', 'html'.
 ```
-
-## Known Issues
-
-1. The rule `InvalidPackageDeclaration` is known to not be working well with the Compiler Plugin [#5747](https://github.com/detekt/detekt/issues/5747).

--- a/website/versioned_docs/version-2.0.0-alpha.5/gettingstarted/compilerplugin.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/gettingstarted/compilerplugin.mdx
@@ -139,7 +139,3 @@ rootPath=<path> # Root path used to relativize paths when using exclude patterns
 excludes=<base64-encoded globs> # A base64-encoded list of the globs used to exclude paths from scanning.
 report=<report-id:path> # Generates a report for given 'report-id' and stores it on given 'path'. Available 'report-id' values: 'checkstyle', 'html'.
 ```
-
-## Known Issues
-
-1. The rule `InvalidPackageDeclaration` is known to not be working well with the Compiler Plugin [#5747](https://github.com/detekt/detekt/issues/5747).


### PR DESCRIPTION
The rule `InvalidPackageDeclaration` is mentioned as not working with the compiler plugin (#5747), but that issue has been fixed.