### PR TITLE
feat(rules): add ignoreSealedClasses option to AbstractClassCanBeInterface

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -550,6 +550,7 @@ style:
     active: true
   AbstractClassCanBeInterface:
     active: true
+    ignoreSealedClasses: false
   AlsoCouldBeApply:
     active: false
   BracesOnIfStatements:

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -3,10 +3,12 @@ package dev.detekt.rules.style
 import com.intellij.psi.PsiElement
 import dev.detekt.api.ActiveByDefault
 import dev.detekt.api.Config
+import dev.detekt.api.Configuration
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
+import dev.detekt.api.config
 import dev.detekt.psi.isAbstract
 import dev.detekt.psi.isConstant
 import dev.detekt.psi.isInternal
@@ -77,6 +79,13 @@ class AbstractClassCanBeInterface(config: Config) :
     ),
     RequiresAnalysisApi {
 
+    @Configuration(
+        "if sealed classes should be ignored. `sealed class` dispatches virtually while `sealed interface` " +
+            "dispatches through an interface table, so projects with heavy sealed hierarchies may prefer to keep " +
+            "classes and opt out of this check."
+    )
+    private val ignoreSealedClasses: Boolean by config(false)
+
     override fun visitClass(klass: KtClass) {
         check(klass)
         super.visitClass(klass)
@@ -103,7 +112,7 @@ class AbstractClassCanBeInterface(config: Config) :
         when {
             klass.isInterface() -> false
             klass.isLocal -> false
-            klass.isSealed() -> true
+            klass.isSealed() -> !ignoreSealedClasses
             else -> klass.isAbstract()
         }
 

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -3,6 +3,7 @@ package dev.detekt.rules.style
 import dev.detekt.api.Config
 import dev.detekt.rules.style.AbstractClassCanBeInterface.Companion.NO_CONCRETE_MEMBER
 import dev.detekt.rules.style.AbstractClassCanBeInterface.Companion.SEALED_NO_CONCRETE_MEMBER
+import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.junit.KotlinCoreEnvironmentTest
 import dev.detekt.test.lintWithContext
@@ -383,6 +384,61 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
                 abstract class Test(val x: Int) : I
             """.trimIndent()
             assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `ignoreSealedClasses config` {
+        private val ignoringSealed =
+            AbstractClassCanBeInterface(TestConfig("ignoreSealedClasses" to true))
+
+        @Test
+        fun `does not report a sealed class that would otherwise be reported`() {
+            val code = """
+                sealed class Result {
+                    data class Success(val data: Int) : Result()
+                    data class Failure(val reason: String) : Result()
+                }
+            """.trimIndent()
+            assertThat(ignoringSealed.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report a sealed class with only abstract members`() {
+            val code = """
+                sealed class Result {
+                    abstract val value: Int
+                    abstract fun f()
+                }
+            """.trimIndent()
+            assertThat(ignoringSealed.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `still reports a plain abstract class`() {
+            // The opt-out is scoped to sealed hierarchies: an abstract class carries no
+            // dispatch trade-off, so enabling it must not silence the rule wholesale.
+            val code = """
+                abstract class A {
+                    abstract val i: Int
+                    abstract fun f()
+                }
+            """.trimIndent()
+            assertThat(ignoringSealed.lintWithContext(env, code))
+                .singleElement()
+                .hasMessage(NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `defaults to false so sealed classes are reported`() {
+            val code = """
+                sealed class Result {
+                    data class Success(val data: Int) : Result()
+                }
+            """.trimIndent()
+            assertThat(AbstractClassCanBeInterface(Config.empty).lintWithContext(env, code))
+                .singleElement()
+                .hasMessage(SEALED_NO_CONCRETE_MEMBER)
         }
     }
 


### PR DESCRIPTION
Closes #9281

@BraisGabin marked this [up for grabs](https://github.com/detekt/detekt/issues/9281#issuecomment-5083392368) on 26 July, so I picked it up.

## Problem

`AbstractClassCanBeInterface` reports `sealed class` and `abstract class` under the same switch. As @eygraber notes in the issue, a `sealed class` dispatches virtually while a `sealed interface` dispatches through an interface table, so a project with heavy sealed hierarchies may deliberately keep classes. Today the only way to opt out of that half is to disable the rule entirely — which also gives up the abstract-class check.

## Change

A new `ignoreSealedClasses` option, **default `false`**, so existing behaviour and existing configs are unchanged. It short-circuits the sealed branch of `shouldCheck`:

```kotlin
klass.isSealed() -> !ignoreSealedClasses
```

The option is scoped to sealed hierarchies on purpose: a plain `abstract class` carries no dispatch trade-off, so enabling it must not turn into a rule-wide off switch. There is a test asserting exactly that.

## Tests

Four new cases in `AbstractClassCanBeInterfaceSpec`:

- a sealed class that would otherwise be reported is silenced when the option is on
- a sealed class with only abstract members likewise
- **a plain abstract class is still reported** with the option on
- the default (`false`) still reports sealed classes, pinning backwards compatibility

## Verification

- `./gradlew :detekt-rules-style:test --tests "*AbstractClassCanBeInterfaceSpec*"` — BUILD SUCCESSFUL
- `./gradlew :detekt-rules-style:detektMain :detekt-rules-style:detektTest` — clean
- `./gradlew generateDocumentation` — `default-detekt-config.yml` regenerated (`ignoreSealedClasses: false`), committed in the same change

## Open question for maintainers

I kept the default at `false` because changing it would alter behaviour for every existing user. If you would rather the sealed check be opt-**in** given the noise @BraisGabin mentioned seeing on his own project, flipping the default is a one-line change plus a config regeneration — happy to do it in this PR.

## AI disclosure

Written with AI assistance (Claude), credited as commit co-author per `AGENTS.md`. The design decision, the choice to scope the option to sealed classes only, and every verification command above were reviewed and run by me on the real build.