### PR TITLE
docs: explain ForbiddenImport glob matching and fix its code examples

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
@@ -29,10 +29,39 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *     - 'java.util.UUID'
  * ```
  *
+ * A pattern is matched against the fully qualified name of the import and has to match it
+ * completely, so `java.util.Date` does not match the import `java.util.DateFormat`.
+ * Two wildcards are supported:
+ *
+ * - `*` matches zero or more characters, **including** the package separator `.`. The pattern
+ *   `java.util.*` therefore reports `import java.util.Date` as well as
+ *   `import java.util.concurrent.Future`.
+ * - `?` matches exactly one character, so `java.util.Dat?` reports `import java.util.Date`
+ *   but neither `import java.util.Dat` nor `import java.util.Dates`.
+ *
+ * A `.` is always a literal character and cannot be escaped: a pattern written as
+ * `java\.util\.Date` matches nothing at all. Write `java.util.Date` instead.
+ * A pattern that is not a valid expression fails the analysis with a pattern syntax error.
+ *
+ * An import is reported only if it matches [forbiddenImports] and no entry of
+ * [allowedImports], so `allowedImports` always wins. Aliased imports are matched by their
+ * original name, which means `import java.util.List as JList` is reported by the pattern
+ * `java.util.List`.
+ *
+ * Star imports are matched without their trailing star, so `import java.util.*` is checked
+ * as `java.util`. The pattern `java.util.*` consequently does not report it, while the
+ * pattern `java.util` does, and `allowedImports: ['java.util.UUID']` also exempts
+ * `import java.util.UUID.*`. This is tracked in
+ * [#9564](https://github.com/detekt/detekt/issues/9564).
+ *
  * <noncompliant>
  * import kotlin.jvm.JvmField
- * import kotlin.SinceKotlin
+ * import java.util.Date
  * </noncompliant>
+ *
+ * <compliant>
+ * import java.util.UUID
+ * </compliant>
  */
 class ForbiddenImport(config: Config) :
     Rule(
@@ -43,6 +72,8 @@ class ForbiddenImport(config: Config) :
 
     @Configuration(
         "List of imports, specified as glob patterns, that are forbidden. " +
+            "A pattern has to match the whole fully qualified name, where `*` matches zero or more " +
+            "characters including `.` and `?` matches exactly one character. " +
             "It is recommended to also specify a reason."
     )
     private val forbiddenImports: List<Forbidden> by config(valuesWithReason()) { list ->
@@ -51,7 +82,8 @@ class ForbiddenImport(config: Config) :
 
     @Configuration(
         "List of imports, specified as glob patterns, to explicitly allow. " +
-            "Use this to specify exceptions to the forbidden imports."
+            "Use this to specify exceptions to the forbidden imports. " +
+            "An import that matches both lists is not reported."
     )
     private val allowedImports: List<Regex> by config(emptyList<String>()) { list ->
         list.map { it.pathGlobToRegex() }

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ForbiddenImport.kt
@@ -29,19 +29,8 @@ import org.jetbrains.kotlin.psi.KtImportDirective
  *     - 'java.util.UUID'
  * ```
  *
- * A pattern is matched against the fully qualified name of the import and has to match it
- * completely, so `java.util.Date` does not match the import `java.util.DateFormat`.
- * Two wildcards are supported:
- *
- * - `*` matches zero or more characters, **including** the package separator `.`. The pattern
- *   `java.util.*` therefore reports `import java.util.Date` as well as
- *   `import java.util.concurrent.Future`.
- * - `?` matches exactly one character, so `java.util.Dat?` reports `import java.util.Date`
- *   but neither `import java.util.Dat` nor `import java.util.Dates`.
- *
- * A `.` is always a literal character and cannot be escaped: a pattern written as
- * `java\.util\.Date` matches nothing at all. Write `java.util.Date` instead.
- * A pattern that is not a valid expression fails the analysis with a pattern syntax error.
+ * Patterns are matched against the fully qualified name of the import and follow detekt's
+ * [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns).
  *
  * An import is reported only if it matches [forbiddenImports] and no entry of
  * [allowedImports], so `allowedImports` always wins. Aliased imports are matched by their

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenImportSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/ForbiddenImportSpec.kt
@@ -6,8 +6,10 @@ import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.lint
 import dev.detekt.test.toConfig
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import java.util.regex.PatternSyntaxException
 
 private const val FORBIDDEN_IMPORTS = "forbiddenImports"
 private const val ALLOWED_IMPORTS = "allowedImports"
@@ -126,5 +128,63 @@ class ForbiddenImportSpec {
         val findings = ForbiddenImport(config).lint(code, compile = false)
         assertThat(findings).singleElement()
             .hasMessage("The import `net.example.R.dimen` has been forbidden in the detekt config.")
+    }
+
+    @Test
+    @DisplayName("should match exactly one character for ? in kotlin.SinceKotli?")
+    fun singleCharacterWildcardMatchesOneCharacter() {
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.SinceKotli?")))
+            .lint(code, compile = false)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    @DisplayName("should not match a missing character for ? in kotlin.SinceKotlin?")
+    fun singleCharacterWildcardRequiresACharacter() {
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.SinceKotlin?")))
+            .lint(code, compile = false)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    @DisplayName("should not match anything when a dot is escaped as \\.")
+    fun dotsCannotBeEscaped() {
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("""kotlin\.SinceKotlin""")))
+            .lint(code, compile = false)
+        assertThat(findings).isEmpty()
+    }
+
+    @Test
+    fun `should fail the analysis when a pattern is not valid`() {
+        val rule = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.[")))
+        assertThatThrownBy { rule.lint(code, compile = false) }
+            .isInstanceOf(PatternSyntaxException::class.java)
+    }
+
+    @Test
+    fun `should report an aliased import by its original name`() {
+        val aliasedCode = "import kotlin.SinceKotlin as Since"
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.SinceKotlin")))
+            .lint(aliasedCode, compile = false)
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    @DisplayName("should match a star import without its trailing star")
+    fun starImportIsMatchedWithoutItsStar() {
+        val starCode = "import kotlin.jvm.*"
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.jvm")))
+            .lint(starCode, compile = false)
+        assertThat(findings).singleElement()
+            .hasMessage("The import `kotlin.jvm` has been forbidden in the detekt config.")
+    }
+
+    @Test
+    @DisplayName("should not report a star import for the pattern kotlin.jvm.*")
+    fun starImportIsNotMatchedByAPatternWithATrailingStar() {
+        val starCode = "import kotlin.jvm.*"
+        val findings = ForbiddenImport(TestConfig(FORBIDDEN_IMPORTS to listOf("kotlin.jvm.*")))
+            .lint(starCode, compile = false)
+        assertThat(findings).isEmpty()
     }
 }

--- a/website/docs/introduction/glob-patterns.mdx
+++ b/website/docs/introduction/glob-patterns.mdx
@@ -1,0 +1,65 @@
+---
+id: glob-patterns
+title: "Glob Patterns"
+keywords: [glob, pattern, wildcard, configuration]
+sidebar_position: 12
+---
+
+Several rule configuration options accept glob patterns instead of literal names, so that a
+single entry can cover a whole package or a family of declarations. detekt supports two
+pattern flavors. They differ in whether `*` and `?` stop at the package separator, so check
+the documentation of the option you are configuring to see which one applies.
+
+Both flavors are anchored: a pattern has to match the **whole** name, not just a part of it.
+`java.util.Date` therefore never matches `java.util.DateFormat`.
+
+In either flavor, a pattern that is not a valid expression, such as `a[b`, fails the analysis
+with a pattern syntax error.
+
+Neither flavor is related to the file path globs used by `excludes` and `includes`, which are
+described in [detekt Configuration File](configurations.mdx).
+
+## Simple patterns
+
+In this flavor `*` matches zero or more characters and `?` matches exactly one character.
+Neither one stops at the package separator, so `*` and `?` can both match a `.`.
+
+| Pattern | Matches | Does not match |
+| --- | --- | --- |
+| `java.util.Date` | `java.util.Date` | `java.util.DateFormat` |
+| `java.util.*` | `java.util.Date`, `java.util.concurrent.Future` | `java.util` |
+| `java.util.Dat?` | `java.util.Date` | `java.util.Dat`, `java.util.Dates` |
+| `java?util` | `java.util`, `java_util` | `javautil` |
+| `*.internal.*` | `com.example.internal.Foo` | `com.example.Foo` |
+
+Because `*` also matches an empty string, `java.util.*` covers everything below `java.util`
+but not `java.util` itself. Write two entries if you need both.
+
+A `.` is always a literal character and cannot be escaped. A pattern written as
+`java\.util\.Date` does not match `java.util.Date`, or any other ordinary qualified name, so
+write `java.util.Date` instead.
+
+## Package-aware patterns
+
+In this flavor `*` and `?` stop at the package separator, and `**` is used to cross it:
+
+- `*` matches zero or more characters within a single segment.
+- `?` matches exactly one character within a single segment.
+- `**` crosses package separators and must be followed by a `.`. Write it as a complete
+  segment, as in `a.**.Foo`; attached to other characters, as in `pre**.Foo`, it no longer
+  matches whole segments.
+
+| Pattern | Matches | Does not match |
+| --- | --- | --- |
+| `test.Foo` | `test.Foo` | `test.bar.Foo` |
+| `test?Foo` | `testXFoo` | `test.Foo` |
+| `**.Foo` | `test.Foo`, `test.bar.Foo` | `Foo` |
+| `**.F*` | `test.Foo`, `test.bar.Foo` | `Foo` |
+| `a.**.d.Foo` | `a.b.c.d.Foo` | `a.d.Foo` |
+
+Written as a complete segment, `**` needs at least one segment to match, so
+`a.**.b.c.d.Foo` does not match `a.b.c.d.Foo`.
+
+This flavor is used by options that treat `.` as a package separator, most notably the
+`ignoreAnnotated` option described in [Suppressors](suppressors.mdx). It is the only flavor
+that understands `**`.

--- a/website/versioned_docs/version-2.0.0-alpha.5/introduction/glob-patterns.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/introduction/glob-patterns.mdx
@@ -1,0 +1,65 @@
+---
+id: glob-patterns
+title: "Glob Patterns"
+keywords: [glob, pattern, wildcard, configuration]
+sidebar_position: 12
+---
+
+Several rule configuration options accept glob patterns instead of literal names, so that a
+single entry can cover a whole package or a family of declarations. detekt supports two
+pattern flavors. They differ in whether `*` and `?` stop at the package separator, so check
+the documentation of the option you are configuring to see which one applies.
+
+Both flavors are anchored: a pattern has to match the **whole** name, not just a part of it.
+`java.util.Date` therefore never matches `java.util.DateFormat`.
+
+In either flavor, a pattern that is not a valid expression, such as `a[b`, fails the analysis
+with a pattern syntax error.
+
+Neither flavor is related to the file path globs used by `excludes` and `includes`, which are
+described in [detekt Configuration File](configurations.mdx).
+
+## Simple patterns
+
+In this flavor `*` matches zero or more characters and `?` matches exactly one character.
+Neither one stops at the package separator, so `*` and `?` can both match a `.`.
+
+| Pattern | Matches | Does not match |
+| --- | --- | --- |
+| `java.util.Date` | `java.util.Date` | `java.util.DateFormat` |
+| `java.util.*` | `java.util.Date`, `java.util.concurrent.Future` | `java.util` |
+| `java.util.Dat?` | `java.util.Date` | `java.util.Dat`, `java.util.Dates` |
+| `java?util` | `java.util`, `java_util` | `javautil` |
+| `*.internal.*` | `com.example.internal.Foo` | `com.example.Foo` |
+
+Because `*` also matches an empty string, `java.util.*` covers everything below `java.util`
+but not `java.util` itself. Write two entries if you need both.
+
+A `.` is always a literal character and cannot be escaped. A pattern written as
+`java\.util\.Date` does not match `java.util.Date`, or any other ordinary qualified name, so
+write `java.util.Date` instead.
+
+## Package-aware patterns
+
+In this flavor `*` and `?` stop at the package separator, and `**` is used to cross it:
+
+- `*` matches zero or more characters within a single segment.
+- `?` matches exactly one character within a single segment.
+- `**` crosses package separators and must be followed by a `.`. Write it as a complete
+  segment, as in `a.**.Foo`; attached to other characters, as in `pre**.Foo`, it no longer
+  matches whole segments.
+
+| Pattern | Matches | Does not match |
+| --- | --- | --- |
+| `test.Foo` | `test.Foo` | `test.bar.Foo` |
+| `test?Foo` | `testXFoo` | `test.Foo` |
+| `**.Foo` | `test.Foo`, `test.bar.Foo` | `Foo` |
+| `**.F*` | `test.Foo`, `test.bar.Foo` | `Foo` |
+| `a.**.d.Foo` | `a.b.c.d.Foo` | `a.d.Foo` |
+
+Written as a complete segment, `**` needs at least one segment to match, so
+`a.**.b.c.d.Foo` does not match `a.b.c.d.Foo`.
+
+This flavor is used by options that treat `.` as a package separator, most notably the
+`ignoreAnnotated` option described in [Suppressors](suppressors.mdx). It is the only flavor
+that understands `**`.

--- a/website/versioned_docs/version-2.0.0-alpha.5/rules/style.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.5/rules/style.mdx
@@ -1041,23 +1041,43 @@ ForbiddenImport:
     - 'java.util.UUID'
 ```
 
+Patterns are matched against the fully qualified name of the import and follow detekt's
+[simple glob syntax](../introduction/glob-patterns.mdx#simple-patterns).
+
+An import is reported only if it matches [forbiddenImports] and no entry of
+[allowedImports], so `allowedImports` always wins. Aliased imports are matched by their
+original name, which means `import java.util.List as JList` is reported by the pattern
+`java.util.List`.
+
+Star imports are matched without their trailing star, so `import java.util.*` is checked
+as `java.util`. The pattern `java.util.*` consequently does not report it, while the
+pattern `java.util` does, and `allowedImports: ['java.util.UUID']` also exempts
+`import java.util.UUID.*`. This is tracked in
+[#9564](https://github.com/detekt/detekt/issues/9564).
+
 **Active by default**: No
 
 #### Configuration options:
 
 * ``forbiddenImports`` (default: ``[]``)
 
-  List of imports, specified as glob patterns, that are forbidden. It is recommended to also specify a reason.
+  List of imports, specified as glob patterns, that are forbidden. A pattern has to match the whole fully qualified name, where `*` matches zero or more characters including `.` and `?` matches exactly one character. It is recommended to also specify a reason.
 
 * ``allowedImports`` (default: ``[]``)
 
-  List of imports, specified as glob patterns, to explicitly allow. Use this to specify exceptions to the forbidden imports.
+  List of imports, specified as glob patterns, to explicitly allow. Use this to specify exceptions to the forbidden imports. An import that matches both lists is not reported.
 
 #### Noncompliant Code:
 
 ```kotlin
 import kotlin.jvm.JvmField
-import kotlin.SinceKotlin
+import java.util.Date
+```
+
+#### Compliant Code:
+
+```kotlin
+import java.util.UUID
 ```
 
 ### ForbiddenMethodCall


### PR DESCRIPTION
Issue #6088 raised four problems with `ForbiddenImport`. Two of them (a real usage example in the docs, and the `forbiddenPatterns` naming) were already fixed by #9302 and #8747. This PR covers the two that are still open: the confusing code examples, and the lack of any documentation for how the glob patterns actually work.

The `<noncompliant>` block listed `import kotlin.SinceKotlin`, which is not forbidden by the YAML configuration shown a few lines above it, so the example contradicted itself. There was also no `<compliant>` block, which means the generated website page has no "Compliant Code" section and never demonstrates what `allowedImports` is for. The examples now use `java.util.Date` (forbidden by the example config) and `java.util.UUID` (explicitly allowed by it), so the config, the violation and the exemption tell one story.

For the glob semantics, the interesting part is the behavior you cannot guess from the config key alone. `pathGlobToRegex` anchors the pattern against the whole fully qualified name, and its `*` crosses the package separator, so `java.util.*` reports `java.util.concurrent.Future` too. A `.` is always literal and writing `java\.util\.Date` silently matches nothing rather than erroring. An invalid pattern fails the analysis at the first import it visits. The KDoc now spells all of this out, along with aliased-import handling and the fact that `allowedImports` wins. The two `@Configuration` descriptions carry a short version of the same rules, since those strings are the only docs visible from the config reference on the website.

Star imports get their own paragraph. `KtImportDirective.importedFqName` drops the trailing star, so `import java.util.*` is matched as `java.util`: the pattern `java.util.*` does not report it, and `allowedImports: ['java.util.UUID']` unexpectedly exempts `import java.util.UUID.*`. That is surprising enough to document explicitly, but changing it is a behavior decision rather than a docs one, so I filed it as #9564 and linked it from the KDoc instead of fixing it here. #6075 is also looking at reworking literal/regex/glob handling across all config for 2.0, which seems like the better place for that call.

Everything documented is covered by a test so the docs cannot drift from the implementation. No rule behavior changes, and `default-detekt-config.yml` regenerates unchanged.

Fixes: #6088