### PR TITLE
fix: report UnnecessaryFullyQualifiedName when a same-package class shares the name but is unused

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -255,20 +255,29 @@ class UnnecessaryFullyQualifiedName(config: Config) :
 
     context(session: KaSession)
     private fun findLocalSymbols(element: KtElement, name: Name): Sequence<KaSymbol> {
-        // Same-package declarations are overridden by an added explicit import, so they only collide
-        // when the simple name is actually used unqualified somewhere in the file.
-        val packageScopeCollides = isUsedUnqualified(element.containingKtFile, name)
         // Default imports are overridden by an added explicit import, so a default symbol with the same
-        // name is not a real collision (only explicit imports are).
+        // name is not a real collision (only explicit imports are). Same-package declarations are
+        // overridden too, so they only collide when the simple name is actually used unqualified
+        // somewhere in the file.
         val scope = with(session) {
             element.containingKtFile.scopeContext(element).compositeScope {
                 it !is KaScopeKind.DefaultSimpleImportingScope &&
                     it !is KaScopeKind.DefaultStarImportingScope &&
-                    (packageScopeCollides || it !is KaScopeKind.PackageMemberScope)
+                    (it !is KaScopeKind.PackageMemberScope || collidesWithPackageScope(element.containingKtFile, name))
             }
         }
         return scope.classifiers(name) + scope.callables(name)
     }
+
+    // An explicit import already shadows the same-package declaration, so any unqualified use in the
+    // file resolves to the import, not to the package member -- there is nothing left to collide with.
+    private fun collidesWithPackageScope(file: KtFile, name: Name): Boolean =
+        !hasExplicitImport(file, name) && isUsedUnqualified(file, name)
+
+    private fun hasExplicitImport(file: KtFile, name: Name): Boolean =
+        file.importDirectives.any {
+            !it.isAllUnder && (it.aliasName?.let(Name::identifier) ?: it.importedFqName?.shortName()) == name
+        }
 
     private fun isUsedUnqualified(file: KtFile, name: Name): Boolean =
         file.anyDescendantOfType<KtSimpleNameExpression> {

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedName.kt
@@ -29,14 +29,18 @@ import org.jetbrains.kotlin.psi.KtClassLiteralExpression
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
 import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.psiUtil.anyDescendantOfType
 import org.jetbrains.kotlin.psi.psiUtil.getParentOfType
 import org.jetbrains.kotlin.psi.psiUtil.getPossiblyQualifiedCallExpression
+import org.jetbrains.kotlin.psi.psiUtil.getReceiverExpression
 import org.jetbrains.kotlin.psi.psiUtil.parents
 
 /**
@@ -251,15 +255,27 @@ class UnnecessaryFullyQualifiedName(config: Config) :
 
     context(session: KaSession)
     private fun findLocalSymbols(element: KtElement, name: Name): Sequence<KaSymbol> {
+        // Same-package declarations are overridden by an added explicit import, so they only collide
+        // when the simple name is actually used unqualified somewhere in the file.
+        val packageScopeCollides = isUsedUnqualified(element.containingKtFile, name)
         // Default imports are overridden by an added explicit import, so a default symbol with the same
         // name is not a real collision (only explicit imports are).
         val scope = with(session) {
             element.containingKtFile.scopeContext(element).compositeScope {
-                it !is KaScopeKind.DefaultSimpleImportingScope && it !is KaScopeKind.DefaultStarImportingScope
+                it !is KaScopeKind.DefaultSimpleImportingScope &&
+                    it !is KaScopeKind.DefaultStarImportingScope &&
+                    (packageScopeCollides || it !is KaScopeKind.PackageMemberScope)
             }
         }
         return scope.classifiers(name) + scope.callables(name)
     }
+
+    private fun isUsedUnqualified(file: KtFile, name: Name): Boolean =
+        file.anyDescendantOfType<KtSimpleNameExpression> {
+            it.getReferencedNameAsName() == name &&
+                it.getReceiverExpression() == null &&
+                !isInImportOrPackage(it)
+        }
 
     context(session: KaSession)
     private fun hasOuterClassCollision(element: KtElement, symbol: KaClassSymbol): Boolean =

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1254,6 +1254,45 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code, importedOuter, otherOuter)).isEmpty()
         }
+
+        @Test
+        fun `does report when a class is defined in the same package but not used`() {
+            val code = """
+                package foo
+
+                class Asdf
+
+                fun main() {
+                    bar.Asdf("")
+                }
+            """.trimIndent()
+            val extraClassCode = """
+                package bar
+                class Asdf(string: String)
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, extraClassCode)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report when a class is defined in the same package and it is used`() {
+            val code = """
+                package foo
+
+                class Asdf
+
+                fun main() {
+                    Asdf()
+                    bar.Asdf("")
+                }
+            """.trimIndent()
+            val extraClassCode = """
+                package bar
+                class Asdf(string: String)
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, extraClassCode)).isEmpty()
+        }
     }
 
     // https://github.com/detekt/detekt/issues/9282

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnnecessaryFullyQualifiedNameSpec.kt
@@ -1293,6 +1293,28 @@ class UnnecessaryFullyQualifiedNameSpec(val env: KotlinEnvironmentContainer) {
 
             assertThat(subject.lintWithContext(env, code, extraClassCode)).isEmpty()
         }
+
+        @Test
+        fun `does report when the same-package class is shadowed by an explicit import`() {
+            val code = """
+                package foo
+
+                import bar.Asdf
+
+                class Asdf
+
+                fun main() {
+                    Asdf("")
+                    bar.Asdf("")
+                }
+            """.trimIndent()
+            val extraClassCode = """
+                package bar
+                class Asdf(string: String)
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code, extraClassCode)).hasSize(1)
+        }
     }
 
     // https://github.com/detekt/detekt/issues/9282


### PR DESCRIPTION
Closes #9572

### Problem

`UnnecessaryFullyQualifiedName` treats any same-package declaration with a matching simple name as a name collision and stays silent. That is too conservative: in Kotlin an explicit import takes precedence over a declaration in the same package, so `bar.Asdf` in a file of package `foo` can still be replaced by `import bar.Asdf` — unless the file actually uses the simple name `Asdf` unqualified to mean `foo.Asdf`.

This matters in Android modules, where the generated `<namespace>.R` class makes every other `R` reference unreportable.

### Fix

In `findLocalSymbols`, the `PackageMemberScope` is only consulted when the simple name appears unqualified somewhere in the file. All other scopes (nested classes, members, type parameters, explicit imports) behave as before.

### Tests

Added the two cases from the issue to the `name collisions` group. Full `:detekt-rules-style:test` and `:detekt-rules-style:detektMain` pass locally.

---

Per the repo AI policy: this change was written with Claude (Opus 5) and is credited as commit co-author.