### PR TITLE
Publish Maven relocation metadata in a final 1.x release

### DIFF
--- a/build-logic/src/main/kotlin/packaging.gradle.kts
+++ b/build-logic/src/main/kotlin/packaging.gradle.kts
@@ -4,6 +4,54 @@ plugins {
     signing
 }
 
+// A POM carrying <distributionManagement><relocation> is a redirect: every consumer of that version
+// is resolved to the new coordinates instead. It must therefore only ever be attached to the final,
+// dedicated 1.x release that exists solely to point at detekt 2.x - never to a regular bugfix
+// release. See scripts/release-relocation.sh.
+val publishRelocationInfo = "publishRelocationInfo".byProperty.toBoolean()
+
+// The group all detekt artifacts moved to in 2.x.
+val relocationGroupId = "dev.detekt"
+
+// The 2.x release the relocation points at. It has to be on Maven Central before we publish this.
+val relocationVersion = "2.0.0"
+
+val migrationGuide = "https://detekt.dev/docs/introduction/migrationguide"
+
+// Shown verbatim by Maven ("[WARNING] ... has been relocated ...: <message>"). Gradle ignores it and
+// logs its own wording at --info instead, so this cannot be the only place we point at the guide.
+val relocationMessage =
+    "detekt 2.x is published under the '$relocationGroupId' group, and some artifacts were renamed. " +
+        "See the migration guide at $migrationGuide"
+
+// The POM description is what Maven Central's search UI and mvnrepository.com render on the
+// artifact page, so it is the one channel a Gradle user is likely to actually read.
+val relocationDescription =
+    "DEPRECATED - this is the final detekt 1.x release. detekt 2.x is published under the " +
+        "'$relocationGroupId' group, and some artifacts were renamed. Migration guide: $migrationGuide"
+
+// Artifacts that have no counterpart in 2.x and are therefore not relocated.
+val notRelocated = setOf(
+    "detekt-report-txt", // https://github.com/detekt/detekt/pull/7470
+    "detekt-sample-extensions",
+    "detekt-compiler-plugin", // not released as of 2.0.0
+)
+
+// Modules renamed in 2.x: 1.x project name -> 2.x artifactId.
+val artifactRenames = mapOf(
+    "detekt-formatting" to "detekt-rules-ktlint-wrapper", // https://github.com/detekt/detekt/pull/8474
+    "detekt-report-xml" to "detekt-report-checkstyle", // https://github.com/detekt/detekt/pull/8656
+    "detekt-report-md" to "detekt-report-markdown", // https://github.com/detekt/detekt/pull/8735
+    "detekt-rules-empty" to "detekt-rules-empty-blocks", // https://github.com/detekt/detekt/pull/8888
+    "detekt-rules-documentation" to "detekt-rules-comments", // https://github.com/detekt/detekt/pull/8889
+    "detekt-rules-errorprone" to "detekt-rules-potential-bugs", // https://github.com/detekt/detekt/pull/8887
+)
+
+// Gradle plugin marker publications are never relocated. A marker is derived from the plugin id,
+// and the id changed to 'dev.detekt' in 2.x, so a relocated marker would resolve the 2.x plugin jar
+// and then fail with "plugin with id 'io.gitlab.arturbosch.detekt' not found".
+val MavenPublication.isPluginMarker: Boolean get() = name.endsWith("PluginMarkerMaven")
+
 publishing {
     repositories {
         maven {
@@ -26,14 +74,24 @@ publishing {
     // We don't need to configure publishing for the Gradle plugin.
     if (project.name != "detekt-gradle-plugin") {
         publications.register<MavenPublication>(DETEKT_PUBLICATION) {
-            from(components["java"])
+            // The relocation release carries no code. A relocated version's jar is never fetched by
+            // any resolver, so attaching the java component would only upload dead weight to
+            // Maven Central - and a jar reachable by explicit coordinates that hands out 1.x code
+            // with no warning attached.
+            if (!publishRelocationInfo) {
+                from(components["java"])
+            }
         }
     }
     publications.withType<MavenPublication> {
         artifactId = project.name
         version = Versions.currentOrSnapshot()
+        val relocate = publishRelocationInfo && !isPluginMarker && project.name !in notRelocated
         pom {
-            description.set("Static code analysis for Kotlin")
+            if (publishRelocationInfo) {
+                packaging = "pom"
+            }
+            description.set(if (relocate) relocationDescription else "Static code analysis for Kotlin")
             name.set("detekt")
             url.set("https://detekt.dev")
             licenses {
@@ -53,7 +111,71 @@ publishing {
             scm {
                 url.set("https://github.com/detekt/detekt")
             }
+            if (relocate) {
+                val newArtifactId = artifactRenames[project.name]
+                distributionManagement {
+                    relocation {
+                        groupId = relocationGroupId
+                        if (newArtifactId != null) {
+                            artifactId = newArtifactId
+                        }
+                        version = relocationVersion
+                        message = relocationMessage
+                    }
+                }
+            }
         }
+    }
+}
+
+// Relocation only exists in the POM. Gradle prefers Gradle Module Metadata, which has no equivalent
+// of it, so publishing the .module files alongside would make the redirect invisible to every
+// Gradle consumer - and Gradle is how most people consume detekt. The relocation release therefore
+// ships POM metadata only.
+tasks.withType<GenerateModuleMetadata>().configureEach {
+    enabled = !publishRelocationInfo
+}
+
+// Keeping jars out of the relocation release takes two passes, because artifacts reach a
+// publication by two different routes and at two different times:
+//
+//  - through the java component, which java-gradle-plugin attaches to detekt-gradle-plugin's
+//    publications in its own afterEvaluate - too late to clear the artifact list up front, so the
+//    variants have to be stripped off the component itself
+//  - added directly by a module's build script, e.g. detekt-cli attaching its shadow jar, which
+//    happens after this plugin is applied and so needs a late pass
+// Both passes run in afterEvaluate: sourcesElements and javadocElements are only registered on the
+// java component once module.gradle.kts has called withSourcesJar()/withJavadocJar().
+if (publishRelocationInfo) {
+    afterEvaluate {
+        val javaComponent = components["java"] as AdhocComponentWithVariants
+        listOf("apiElements", "runtimeElements", "sourcesElements", "javadocElements")
+            .mapNotNull(configurations::findByName)
+            .forEach { javaComponent.withVariantsFromConfiguration(it) { skip() } }
+        publishing.publications.withType<MavenPublication>().configureEach {
+            setArtifacts(emptyList<Any>())
+        }
+    }
+}
+
+// Gradle plugin markers are not relocated, so in a relocation release they would resolve to a
+// version whose plugin jar no longer exists. Publishing them would only turn "no such version" into
+// a later, more confusing failure, so the relocation release leaves them out.
+if (publishRelocationInfo) {
+    // Matched on the task name rather than on `publication`, which is still null while the task is
+    // being created.
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        if (name.contains("PluginMarkerMavenPublication")) {
+            enabled = false
+        }
+    }
+}
+
+// Modules with no 2.x counterpart have nothing to point at, and a code-free release of them would
+// be meaningless, so the relocation release skips them altogether.
+if (publishRelocationInfo && project.name in notRelocated) {
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        enabled = false
     }
 }
 

--- a/scripts/release-relocation.sh
+++ b/scripts/release-relocation.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+# Publishes the final detekt 1.x release. It contains no new code: its only purpose is to tell
+# Maven and Gradle consumers that detekt moved to the `dev.detekt` group in 2.x, via the
+# <distributionManagement><relocation> block that `-PpublishRelocationInfo=true` adds to every POM.
+#
+# Relocation cannot be applied retroactively - a POM on Maven Central is immutable - so this only
+# reaches users who bump to this version. Anyone pinned to an older 1.x release is unaffected.
+#
+# Before running:
+#   - detekt 2.0.0 must already be on Maven Central (that is what the relocation points at,
+#     see `relocationVersion` in build-logic/src/main/kotlin/packaging.gradle.kts)
+#   - Versions.DETEKT must be bumped to the relocation release version
+#
+# Unlike scripts/release.sh this deliberately skips `:detekt-gradle-plugin:publishPlugins`: the
+# Gradle Plugin Portal has no concept of relocation, and the 2.x plugin is published under the new
+# `dev.detekt` plugin id.
+#
+# No jars are produced: the release consists of relocation POMs only, because the jar of a relocated
+# version is never fetched by any resolver. Hence no `gradle build` step either. Modules with no 2.x
+# counterpart and the Gradle plugin markers are not published at all.
+set -e
+gradle publishAllToMavenCentral --max-workers 1 -PpublishRelocationInfo=true
+gradle githubRelease
+gradle closeAndReleaseSonatypeStagingRepository


### PR DESCRIPTION
Closes #8912
Closes #8920 — the artifact mapping is taken from there, thanks @atulgpt.

This is AI generated 👇

## What

Adds Maven relocation metadata to the detekt 1.x POMs, so consumers are told that detekt moved to the `dev.detekt` group in 2.x, plus the artifacts that were renamed along the way.

It is **opt-in** via `-PpublishRelocationInfo=true` and meant for one single, final 1.x release that ships no code at all (i.e. is a **tombstone release**) — only relocation POMs. See `scripts/release-relocation.sh`. Regular builds,
snapshots and normal bugfix releases are completely unaffected.

## Why it has to be a dedicated release

A `<distributionManagement><relocation>` block is a redirect: every consumer of *that version* is resolved to the new coordinates instead, and the published jar is never fetched. Attaching it to a normal release (say 1.23.9) would silently move everyone who upgrades onto `dev.detekt:*:2.0.0`.

It also cannot be applied retroactively — POMs on Maven Central are immutable — so this only ever reaches people who bump to the relocation release. Anyone pinned to 1.23.8 or earlier is unaffected, forever. That is inherent to the mechanism, not a limitation of this PR.

## What the release contains

Since a relocated version's jar is never fetched by any resolver, publishing one would be dead weight on Central — and a jar still reachable by explicit coordinates, handing out 1.x code with no warning attached. So the release is POM-only. `tree ~/.m2/repository`, detekt artifacts only, after `./gradlew -PpublishRelocationInfo=true publishToMavenLocal`:

```
io/gitlab/arturbosch/detekt
├── detekt-api
│   └── 1.23.8
│       └── detekt-api-1.23.8.pom
├── detekt-cli
│   └── 1.23.8
│       └── detekt-cli-1.23.8.pom
├── detekt-core
│   └── 1.23.8
│       └── detekt-core-1.23.8.pom
├── detekt-formatting
│   └── 1.23.8
│       └── detekt-formatting-1.23.8.pom
├── detekt-generator
│   └── 1.23.8
│       └── detekt-generator-1.23.8.pom
├── detekt-gradle-plugin
│   └── 1.23.8
│       └── detekt-gradle-plugin-1.23.8.pom
├── detekt-metrics
│   └── 1.23.8
│       └── detekt-metrics-1.23.8.pom
├── detekt-parser
│   └── 1.23.8
│       └── detekt-parser-1.23.8.pom
├── detekt-psi-utils
│   └── 1.23.8
│       └── detekt-psi-utils-1.23.8.pom
├── detekt-report-html
│   └── 1.23.8
│       └── detekt-report-html-1.23.8.pom
├── detekt-report-md
│   └── 1.23.8
│       └── detekt-report-md-1.23.8.pom
├── detekt-report-sarif
│   └── 1.23.8
│       └── detekt-report-sarif-1.23.8.pom
├── detekt-report-xml
│   └── 1.23.8
│       └── detekt-report-xml-1.23.8.pom
├── detekt-rules
│   └── 1.23.8
│       └── detekt-rules-1.23.8.pom
├── detekt-rules-complexity
│   └── 1.23.8
│       └── detekt-rules-complexity-1.23.8.pom
├── detekt-rules-coroutines
│   └── 1.23.8
│       └── detekt-rules-coroutines-1.23.8.pom
├── detekt-rules-documentation
│   └── 1.23.8
│       └── detekt-rules-documentation-1.23.8.pom
├── detekt-rules-empty
│   └── 1.23.8
│       └── detekt-rules-empty-1.23.8.pom
├── detekt-rules-errorprone
│   └── 1.23.8
│       └── detekt-rules-errorprone-1.23.8.pom
├── detekt-rules-exceptions
│   └── 1.23.8
│       └── detekt-rules-exceptions-1.23.8.pom
├── detekt-rules-libraries
│   └── 1.23.8
│       └── detekt-rules-libraries-1.23.8.pom
├── detekt-rules-naming
│   └── 1.23.8
│       └── detekt-rules-naming-1.23.8.pom
├── detekt-rules-performance
│   └── 1.23.8
│       └── detekt-rules-performance-1.23.8.pom
├── detekt-rules-ruleauthors
│   └── 1.23.8
│       └── detekt-rules-ruleauthors-1.23.8.pom
├── detekt-rules-style
│   └── 1.23.8
│       └── detekt-rules-style-1.23.8.pom
├── detekt-test
│   └── 1.23.8
│       └── detekt-test-1.23.8.pom
├── detekt-test-utils
│   └── 1.23.8
│       └── detekt-test-utils-1.23.8.pom
├── detekt-tooling
│   └── 1.23.8
│       └── detekt-tooling-1.23.8.pom
└── detekt-utils
    └── 1.23.8
        └── detekt-utils-1.23.8.pom
```

No `io/github/detekt` tree is produced at all. Versions read `1.23.8` only because that is what is on the branch right now; the real release bumps `Versions.DETEKT` first. Central additionally receives `.asc` signatures and checksums per file — signing is off locally, so they are not listed.

What is deliberately **not** in there:

- **`detekt-report-txt`, `detekt-sample-extensions`, `detekt-compiler-plugin`** — no 2.x
  counterpart, so nothing to relocate to and no point in a code-free release of them.
- **Both Gradle plugin marker POMs** — a marker is derived from the plugin id, and the id changed to `dev.detekt` in 2.x. Relocating a marker would resolve the 2.x plugin jar and then fail with `plugin with id 'io.gitlab.arturbosch.detekt' not found`; publishing an un-relocated one just turns "no such version" into that same failure later on. Leaving them out means `id("io.gitlab.arturbosch.detekt") version "<relocation release>"` fails immediately and clearly, while `detekt-gradle-plugin` as a plain dependency (buildSrc, convention plugins) still gets redirected properly.

## Why Gradle Module Metadata is disabled for that release

Relocation is a POM-only concept. Gradle prefers Gradle Module Metadata, which has no equivalent, so with the `.module` files published the redirect is invisible to every Gradle consumer. Verified locally against `~/.m2` with a probe project:

**With `.module` published** — relocation ignored, 1.x graph resolves as usual:

```
EDGE: root project : -> io.gitlab.arturbosch.detekt:detekt-api:1.23.8
EDGE: io.gitlab.arturbosch.detekt:detekt-api:1.23.8 -> io.gitlab.arturbosch.detekt:detekt-utils:1.23.8
...
FILES: [detekt-api-1.23.8.jar, detekt-utils-1.23.8.jar, ...]
```

**Without `.module`** — Gradle honours the relocation, drops the original dependencies and points at the new coordinates (unresolved here only because 2.0.0 is not released yet):

```
EDGE: root project : -> io.gitlab.arturbosch.detekt:detekt-api:1.23.8
UNRESOLVED: dev.detekt:detekt-api:2.0.0 <- io.gitlab.arturbosch.detekt:detekt-api:1.23.8
            cause=Could not find dev.detekt:detekt-api:2.0.0
```

So `GenerateModuleMetadata` is disabled when `-PpublishRelocationInfo=true`, and only then.

## Where the message actually reaches people

| Consumer | What they see |
|---|---|
| Maven | `[WARNING] ... has been relocated to dev.detekt:...:2.0.0: <message>` — our text verbatim, migration guide link included |
| Gradle, `--info` | Gradle's own fixed wording: `io.gitlab.arturbosch.detekt:detekt-api:1.23.8 is relocated to dev.detekt:detekt-api:2.0.0. Please update your dependencies.` Our `<message>` is **ignored** |
| Gradle, default log level | nothing — the redirect is silent |
| Maven Central search / mvnrepository | the POM `<description>` |

Since Gradle never surfaces `<message>`, the relocation release also overrides the POM description to `DEPRECATED - this is the final detekt 1.x release. ... Migration guide: <link>`. That is the one producer-side channel a Gradle user is likely to actually read. Normal releases keep the usual `Static code analysis for Kotlin` description.

If we want Gradle users warned at default log level, that needs a *separate* final 1.x release that still carries code and logs a deprecation warning from the plugin — it cannot be combined with relocation, because a relocated version's jar is never fetched. Happy to do that as a follow-up.

## Mapping

| 1.x                          | 2.x                             |
|------------------------------|---------------------------------|
| `detekt-formatting`          | `detekt-rules-ktlint-wrapper`   |
| `detekt-report-xml`          | `detekt-report-checkstyle`      |
| `detekt-report-md`           | `detekt-report-markdown`        |
| `detekt-rules-empty`         | `detekt-rules-empty-blocks`     |
| `detekt-rules-documentation` | `detekt-rules-comments`         |
| `detekt-rules-errorprone`    | `detekt-rules-potential-bugs`   |

Everything else keeps its artifactId and only changes group.

## Verification

Both paths were run end to end against `~/.m2`:

| | default | `-PpublishRelocationInfo=true` |
|---|---|---|
| jars / sources / javadoc | published | none |
| `.module` files | published | none |
| `published-with-gradle-metadata` POM marker | present | gone |
| relocation block | absent | present |
| plugin markers | published | not published |
| `detekt-report-txt`, `detekt-compiler-plugin` | published | not published |
| POM `<description>` | `Static code analysis for Kotlin` | `DEPRECATED - ...` |
| Gradle consumer resolving `detekt-api:1.23.8` | full 1.x graph + jars | redirected to `dev.detekt:detekt-api:2.0.0` |
