### PR TITLE
Do not build the website for PRs targeting release/1.x

### DIFF
--- a/.github/workflows/website.yaml
+++ b/.github/workflows/website.yaml
@@ -4,8 +4,12 @@ on:
   push:
     branches:
       - main
-      - release/1.xs
   pull_request:
+    # The website is built and deployed from main only. On release/1.x the Docusaurus build has been
+    # failing on its own (SSR of introduction/configurations throws "React is not defined"), and
+    # fixing 1.x docs tooling is not worth it, so PRs targeting that branch skip it.
+    branches-ignore:
+      - release/1.x
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}


### PR DESCRIPTION
`build-detekt-docs` is red on every PR against `release/1.x`, independently of what the PR changes:

```
[ERROR] Docusaurus server-side rendering could not render static page with path /docs/1.21.0/introduction/configurations.
[ERROR] Docusaurus server-side rendering could not render static page with path /docs/1.22.0/introduction/configurations.
[ERROR] Docusaurus server-side rendering could not render static page with path /docs/next/introduction/configurations.
[ERROR] Docusaurus server-side rendering could not render static page with path /docs/introduction/configurations.
ReferenceError: React is not defined
[ERROR] Unable to build website for locale en.
```

The website is built and deployed from `main` only — the deploy step is already gated on
`github.ref == 'refs/heads/main'` — so running the build for PRs targeting `release/1.x` buys
nothing and just costs a red check plus ~5 minutes of CI per PR. This adds `branches-ignore` for
that base branch.

Also drops `release/1.xs` from the push trigger: the typo meant it never matched anything, and
un-typo-ing it would start deploying 1.x docs over the live site, which is not what we want.

Fixing the Docusaurus 2.4.1 / Node 16 SSR failure on 1.x would be the alternative, but that
toolchain is not worth reviving on a branch we are about to put a relocation tombstone on.

Unblocks the checks on #9590.