### PR TITLE
Do not credit unmerged pull requests in the changelog

### DIFF
--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -44,8 +44,6 @@ class GithubMilestoneReport : CliktCommand() {
     @Suppress("LongMethod")
     override fun run() {
         // connect to GitHub
-        // A token is optional, but recommended: the merged check below costs one request per pull
-        // request, and anonymous access is capped at 60 requests per hour.
         val token: String? = githubToken()
         val github: GitHub = if (token != null) {
             GitHub.connectUsingOAuth(token)
@@ -72,15 +70,6 @@ class GithubMilestoneReport : CliktCommand() {
             ghIssues = ghIssues.filter { "pick request" in it.labels.map { it.name } }
         }
 
-        // `GHIssueState.CLOSED` also matches pull requests that were closed without ever being
-        // merged, and the issue payload carries no merged flag, so every remaining candidate has to
-        // be resolved to a `GHPullRequest`. Crediting an unmerged pull request advertises a feature
-        // that never shipped: the 2.0.0-alpha.6 notes credited #7025, #7040 and #7662, all three of
-        // which were closed unmerged two days before that release.
-        //
-        // This costs one request per candidate, so it deliberately runs last, once the free local
-        // filters above have narrowed the set. Prefer `-f` (and a `github.token`) on a milestone
-        // that already has changelog entries, otherwise this walks every pull request in it.
         ghIssues = ghIssues.filter { ghRepository.getPullRequest(it.number).isMerged }
 
         val ghContributors = ghIssues.map { it.user.login }.distinct().sorted()

--- a/scripts/github-milestone-report.main.kts
+++ b/scripts/github-milestone-report.main.kts
@@ -25,6 +25,7 @@ import java.io.File
 import java.net.URL
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.Properties
 
 class GithubMilestoneReport : CliktCommand() {
 
@@ -43,7 +44,14 @@ class GithubMilestoneReport : CliktCommand() {
     @Suppress("LongMethod")
     override fun run() {
         // connect to GitHub
-        val github: GitHub = GitHub.connectAnonymously()
+        // A token is optional, but recommended: the merged check below costs one request per pull
+        // request, and anonymous access is capped at 60 requests per hour.
+        val token: String? = githubToken()
+        val github: GitHub = if (token != null) {
+            GitHub.connectUsingOAuth(token)
+        } else {
+            GitHub.connectAnonymously()
+        }
         val ghRepository: GHRepository = github.getUser(user).getRepository(project)
         val milestones = ghRepository.listMilestones(GHIssueState.OPEN).toMutableList()
         milestones.sortBy { it.number }
@@ -63,6 +71,18 @@ class GithubMilestoneReport : CliktCommand() {
         if (filterPickRequests) {
             ghIssues = ghIssues.filter { "pick request" in it.labels.map { it.name } }
         }
+
+        // `GHIssueState.CLOSED` also matches pull requests that were closed without ever being
+        // merged, and the issue payload carries no merged flag, so every remaining candidate has to
+        // be resolved to a `GHPullRequest`. Crediting an unmerged pull request advertises a feature
+        // that never shipped: the 2.0.0-alpha.6 notes credited #7025, #7040 and #7662, all three of
+        // which were closed unmerged two days before that release.
+        //
+        // This costs one request per candidate, so it deliberately runs last, once the free local
+        // filters above have narrowed the set. Prefer `-f` (and a `github.token`) on a milestone
+        // that already has changelog entries, otherwise this walks every pull request in it.
+        ghIssues = ghIssues.filter { ghRepository.getPullRequest(it.number).isMerged }
+
         val ghContributors = ghIssues.map { it.user.login }.distinct().sorted()
 
         val milestoneTitle = ghMilestone.title.trim()
@@ -125,6 +145,21 @@ class GithubMilestoneReport : CliktCommand() {
         tempFile.writeText(content)
 
         println("\nContent saved to ${tempFile.path}")
+    }
+
+    /**
+     * Reads `github.token` from the user's Gradle properties, the same property the release build
+     * already uses (see `build-logic/src/main/kotlin/releasing.gradle.kts`), so the credential does
+     * not need storing in a second place. Returns `null` when it is absent, in which case the
+     * script falls back to anonymous access.
+     */
+    private fun githubToken(): String? {
+        val propertiesFile = File(System.getProperty("user.home"), ".gradle/gradle.properties")
+        if (!propertiesFile.isFile) return null
+        val properties = Properties().apply {
+            propertiesFile.inputStream().use { load(it) }
+        }
+        return properties.getProperty("github.token")?.takeIf { it.isNotBlank() }
     }
 
     private fun formatContributors(ghContributors: List<String>): String {

--- a/website/src/pages/changelog-2.0.0.mdx
+++ b/website/src/pages/changelog-2.0.0.mdx
@@ -43,8 +43,6 @@ This is an alpha release of Detekt 2.0.0. It's built against Kotlin 2.4.10, Grad
 - Extend `PropertyUsedBeforeDeclaration` to follow private init calls - [#9334](https://github.com/detekt/detekt/pull/9334)
 - Add configuration ignoredFullyQualifiedNames to UnnecessaryFullyQualifiedName rule - [#9301](https://github.com/detekt/detekt/pull/9301)
 - Expose multiline parameter in `ClassSignature` - [#9084](https://github.com/detekt/detekt/pull/9084)
-- Extract interfaces from detekt Gradle tasks - [#7662](https://github.com/detekt/detekt/pull/7662)
-- Allow setting default autocorrect mode with Gradle property - [#7040](https://github.com/detekt/detekt/pull/7040)
 
 ### Dependency Updates
 

--- a/website/src/pages/changelog-2.0.0.mdx
+++ b/website/src/pages/changelog-2.0.0.mdx
@@ -37,8 +37,6 @@ This is an alpha release of Detekt 2.0.0. It's built against Kotlin 2.4.10, Grad
 - Extend `PropertyUsedBeforeDeclaration` to follow private init calls - [#9334](https://github.com/detekt/detekt/pull/9334)
 - Add configuration ignoredFullyQualifiedNames to UnnecessaryFullyQualifiedName rule - [#9301](https://github.com/detekt/detekt/pull/9301)
 - Expose multiline parameter in `ClassSignature` - [#9084](https://github.com/detekt/detekt/pull/9084)
-- Extract interfaces from detekt Gradle tasks - [#7662](https://github.com/detekt/detekt/pull/7662)
-- Allow setting default autocorrect mode with Gradle property - [#7040](https://github.com/detekt/detekt/pull/7040)
 
 ### Dependency Updates
 


### PR DESCRIPTION
This is AI generated 👇

## The bug

`scripts/github-milestone-report.main.kts` builds the release notes from the milestone's closed issues, keeping the ones that are pull requests:

```kotlin
ghRepository.getIssues(GHIssueState.CLOSED, ghMilestone)
    .filter { it.pullRequest != null }
```

`GHIssueState.CLOSED` also matches pull requests that were **closed without ever being merged**. Any PR that is milestoned and then closed unmerged gets credited as a shipped change.

## It already bit us

[#7025](https://github.com/detekt/detekt/pull/7025), [#7040](https://github.com/detekt/detekt/pull/7040) and [#7662](https://github.com/detekt/detekt/pull/7662) were all closed unmerged within 55 seconds of each other on 2026-06-15, two days before the 2.0.0-alpha.6 notes were prepared. All three were credited.

[#9573](https://github.com/detekt/detekt/pull/9573) removed the #7025 line by hand as "incorrect". The other two are **still live** in `changelog-2.0.0.mdx` and in the published GitHub release notes for alpha.6, advertising:

- a Gradle property for setting the default autocorrect mode (#7040)
- `DetektBase` / `CommonCompilationArgs` / `JvmCompilationArgs` / `DetektCliTool` task interfaces (#7662)

Neither exists on `main`.

## The fix

Filter on merged state, and drop the two stale lines.

The issue payload carries no merged flag (`GHIssue.PullRequest` in github-api 1.330 exposes only `getDiffUrl`/`getPatchUrl`/`getUrl`), so each candidate must be resolved to a `GHPullRequest`. That costs one request per pull request, which drove two secondary choices:

- **The check runs after the existing local filters**, not before, so `-f` on a milestone that already has changelog entries keeps a re-run cheap. Placed first it would walk all ~1180 closed items in milestone 42.
- **The script authenticates when `github.token` is set** in `~/.gradle/gradle.properties` — the same property `build-logic/src/main/kotlin/releasing.gradle.kts:13` already reads, so the credential is not stored in a second place. Absent it, behaviour is unchanged and access stays anonymous (60 req/hr).

I deliberately did not switch to the search API (`GHIssueSearchBuilder.isMerged()`), which would be cheaper but caps at 1000 results — milestone 42 already has 1184 closed items, and silent truncation is worse than slow.

## Verification

Both runs use `-m 42 -f` against this branch's changelog, so the two PRs are not filtered as pre-existing and only the merged check can exclude them:

| script | `#7662` / `#7040` in output |
|---|---|
| `main` | **both emitted** |
| this branch | **neither emitted** |

Also confirmed the script compiles and runs (`--help`), and that the token is picked up from `gradle.properties` with `GITHUB_TOKEN` explicitly unset from the environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)