### PR TITLE
Use new --isolated-projects flag in tests

### DIFF
--- a/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/IsolatedProjectsSpec.kt
+++ b/detekt-gradle-plugin/src/functionalTest/kotlin/dev/detekt/gradle/IsolatedProjectsSpec.kt
@@ -10,7 +10,7 @@ class IsolatedProjectsSpec {
     fun `detekt task supports isolated projects`() {
         val gradleRunner = DslTestBuilder.kotlin().build()
 
-        val buildResult = gradleRunner.runTasks("-Dorg.gradle.unsafe.isolated-projects=true", "detekt")
+        val buildResult = gradleRunner.runTasks("--isolated-projects", "detekt")
 
         assertThat(buildResult.output).contains("Isolated Projects is an incubating feature.")
     }
@@ -28,7 +28,7 @@ class IsolatedProjectsSpec {
                 .withDetektConfig(detektConfig)
                 .build()
 
-            val buildResult = gradleRunner.runTasks("-Dorg.gradle.unsafe.isolated-projects=true", "detektBaseline")
+            val buildResult = gradleRunner.runTasks("--isolated-projects", "detektBaseline")
 
             assertThat(buildResult.output).contains("Isolated Projects is an incubating feature.")
         }
@@ -41,7 +41,7 @@ class IsolatedProjectsSpec {
             val gradleRunner = DslTestBuilder.kotlin().build()
 
             val buildResult = gradleRunner.runTasks(
-                "-Dorg.gradle.unsafe.isolated-projects=true",
+                "--isolated-projects",
                 "detektGenerateConfig"
             )
 

--- a/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
+++ b/detekt-gradle-plugin/src/testFixtures/kotlin/dev/detekt/gradle/testkit/DslGradleRunner.kt
@@ -143,7 +143,7 @@ constructor(
                 add("-Pdetekt-dry-run=true")
             }
             if (!disableIP) {
-                add("-Dorg.gradle.unsafe.isolated-projects=true")
+                add("--isolated-projects")
             }
             if (failOnGradleWarnings) {
                 add("--warning-mode=fail")


### PR DESCRIPTION
The Isolated Projects feature is promoted from experimental to incubating in Gradle 9.7 and has a new CLI flag to enable it: https://docs.gradle.org/9.7.0/release-notes.html#isolated-projects-is-now-incubating