### PR TITLE
Enable PTS by default in DGP

### DIFF
--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -4,3 +4,6 @@ org.gradle.warning.mode=fail
 dependency.analysis.print.build.health=true
 # Don't add Gradle API dependency to compileOnlyApi configuration. See https://github.com/gradle/gradle/blob/v9.5.0/platforms/extensibility/plugin-development/src/main/java/org/gradle/plugin/devel/plugins/JavaGradlePluginPlugin.java#L174-L182
 systemProp.org.gradle.unsafe.suppress-gradle-api=true
+
+# Enable Predictive Test Selection by default: https://docs.gradle.com/enterprise/predictive-test-selection/
+enablePTS=true

--- a/detekt-gradle-plugin/settings.gradle.kts
+++ b/detekt-gradle-plugin/settings.gradle.kts
@@ -45,6 +45,19 @@ plugins {
 
 val isCiBuild = providers.environmentVariable("CI").isPresent
 
+develocity {
+    buildScan {
+        // Publish to scans.gradle.com when `--scan` is used explicitly
+        if (!gradle.startParameter.isBuildScan) {
+            server = "https://community.develocity.cloud"
+            projectId = "detekt"
+            publishing.onlyIf { it.isAuthenticated }
+        }
+
+        uploadInBackground = !isCiBuild
+    }
+}
+
 // Ensure buildCache config is kept in sync with all builds (root, build-logic & detekt-gradle-plugin)
 buildCache {
     local {


### PR DESCRIPTION
Predictive Test Selection cannot be used when executing included build tests from the root build. This commit doesn't change that, but does allow running tests with PTS if executing a task like `./gradlew functionalTest` from the `detekt-gradle-plugin` working directory.