### PR TITLE
docs: clarify multipreview annotation suppression

### DIFF
--- a/website/docs/introduction/compose.mdx
+++ b/website/docs/introduction/compose.mdx
@@ -97,9 +97,16 @@ private fun FooLazyColumnPreview() { // Violation for FooLazyColumnPreview()
 }
 ```
 
+[Multipreview annotations](https://developer.android.com/develop/ui/compose/tooling/previews#multi-preview)
+are themselves annotated with `@Preview`, but `ignoreAnnotated` does not follow meta-annotations.
+Add every multipreview annotation used on preview functions explicitly. This includes custom
+annotations and AndroidX templates such as `PreviewScreenSizes`, `PreviewFontScale`,
+`PreviewLightDark`, and `PreviewDynamicColors`.
+
 #### Recommended configuration
 
-* Set `ignoreAnnotated` to `['Preview']`
+* Set `ignoreAnnotated` to include `Preview` and every multipreview annotation used by the project,
+  for example `['Preview', 'PreviewLightDark', 'AppPreviews']`
 
 ### TooManyFunctions for Compose
 

--- a/website/docs/introduction/suppressors.mdx
+++ b/website/docs/introduction/suppressors.mdx
@@ -28,6 +28,11 @@ Suppress all the issues that are raised under a code that is annotated with the 
 
 `ignoreAnnotated: List<String>`: The annotations can be defined just by its name or with its fully qualified name. If you don't run detekt with type solving the fully qualified name does not work.
 
+`ignoreAnnotated` checks annotations applied directly to the reported code or its containing
+declarations. It does not follow meta-annotations. For example, ignoring `Preview` does not
+suppress findings under a declaration annotated with `@AppPreviews` when `AppPreviews` is itself
+annotated with `@Preview`; add `AppPreviews` explicitly.
+
 ### Function Suppressor
 
 Suppress any issue raised under a function definition that matches the signatures defined at `ignoreFunction`.

--- a/website/versioned_docs/version-2.0.0-alpha.6/introduction/compose.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.6/introduction/compose.mdx
@@ -97,9 +97,16 @@ private fun FooLazyColumnPreview() { // Violation for FooLazyColumnPreview()
 }
 ```
 
+[Multipreview annotations](https://developer.android.com/develop/ui/compose/tooling/previews#multi-preview)
+are themselves annotated with `@Preview`, but `ignoreAnnotated` does not follow meta-annotations.
+Add every multipreview annotation used on preview functions explicitly. This includes custom
+annotations and AndroidX templates such as `PreviewScreenSizes`, `PreviewFontScale`,
+`PreviewLightDark`, and `PreviewDynamicColors`.
+
 #### Recommended configuration
 
-* Set `ignoreAnnotated` to `['Preview']`
+* Set `ignoreAnnotated` to include `Preview` and every multipreview annotation used by the project,
+  for example `['Preview', 'PreviewLightDark', 'AppPreviews']`
 
 ### TooManyFunctions for Compose
 

--- a/website/versioned_docs/version-2.0.0-alpha.6/introduction/suppressors.mdx
+++ b/website/versioned_docs/version-2.0.0-alpha.6/introduction/suppressors.mdx
@@ -28,6 +28,11 @@ Suppress all the issues that are raised under a code that is annotated with the 
 
 `ignoreAnnotated: List<String>`: The annotations can be defined just by its name or with its fully qualified name. If you don't run detekt with type solving the fully qualified name does not work.
 
+`ignoreAnnotated` checks annotations applied directly to the reported code or its containing
+declarations. It does not follow meta-annotations. For example, ignoring `Preview` does not
+suppress findings under a declaration annotated with `@AppPreviews` when `AppPreviews` is itself
+annotated with `@Preview`; add `AppPreviews` explicitly.
+
 ### Function Suppressor
 
 Suppress any issue raised under a function definition that matches the signatures defined at `ignoreFunction`.


### PR DESCRIPTION
## Summary
- Document that `ignoreAnnotated` matches annotations applied to reported code or containing declarations and does not follow meta-annotations.
- Update Compose guidance with AndroidX multipreview templates and custom annotations that must be configured explicitly.
- Apply the correction to both `next` and the current `2.0.0-alpha.6` documentation.

This follows the maintainer-approved documentation approach in #9562 and preserves consistent behavior in full and light analysis modes.

## Verification
- `./gradlew :detekt-generator:generateWebsite`
- `yarn build` (Node 24, Yarn 1.22.22)
- `./gradlew publishToMavenLocal`
- `./gradlew build -x dokkaGenerate`
- `./gradlew detektMain detektTest`

## AI assistance
OpenAI Codex assisted with issue research, documentation wording, implementation, and validation. This is disclosed here and in the commit co-author trailer.

Fixes #9562