### PR TITLE
docs: link glob-configured rules to pattern docs

### DIFF
--- a/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
@@ -34,7 +34,7 @@ class ForbiddenPublicDataClass(config: Config) :
     @Configuration(
         "Ignores classes in packages matched by these simple glob patterns. Each pattern is matched against " +
             "the package name. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val ignorePackages: List<Regex> by config(listOf("*.internal", "*.internal.*")) { packages ->
         packages.distinct().map(String::pathGlobToRegex)

--- a/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
+++ b/detekt-rules-libraries/src/main/kotlin/dev/detekt/rules/libraries/ForbiddenPublicDataClass.kt
@@ -31,7 +31,11 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierTypeOrDefault
 class ForbiddenPublicDataClass(config: Config) :
     Rule(config, "The data classes are bad for the binary compatibility in public APIs. Avoid to use it.") {
 
-    @Configuration("ignores classes in the specified packages.")
+    @Configuration(
+        "Ignores classes in packages matched by these simple glob patterns. Each pattern is matched against " +
+            "the package name. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val ignorePackages: List<Regex> by config(listOf("*.internal", "*.internal.*")) { packages ->
         packages.distinct().map(String::pathGlobToRegex)
     }

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
@@ -16,7 +16,10 @@ import org.jetbrains.kotlin.psi.KtClassOrObject
  */
 class ForbiddenClassName(config: Config) : Rule(config, "Forbidden class name as per configuration detected.") {
 
-    @Configuration("List of glob patterns to be disallowed as class names")
+    @Configuration(
+        "List of simple glob patterns to be disallowed. Each pattern is matched against the class name. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val forbiddenName: List<Regex> by config(emptyList<String>()) { patterns ->
         patterns.map(String::pathGlobToRegex)
     }

--- a/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
+++ b/detekt-rules-naming/src/main/kotlin/dev/detekt/rules/naming/ForbiddenClassName.kt
@@ -18,7 +18,7 @@ class ForbiddenClassName(config: Config) : Rule(config, "Forbidden class name as
 
     @Configuration(
         "List of simple glob patterns to be disallowed. Each pattern is matched against the class name. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val forbiddenName: List<Regex> by config(emptyList<String>()) { patterns ->
         patterns.map(String::pathGlobToRegex)

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
@@ -41,7 +41,7 @@ class AvoidReferentialEquality(config: Config) :
     @Configuration(
         "Specifies those types for which referential equality checks are considered a rule violation. " +
             "Each simple glob pattern is matched against the fully qualified type name. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val forbiddenTypePatterns: List<Regex> by config(
         listOf(

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/AvoidReferentialEquality.kt
@@ -40,8 +40,8 @@ class AvoidReferentialEquality(config: Config) :
 
     @Configuration(
         "Specifies those types for which referential equality checks are considered a rule violation. " +
-            "The types are defined by a list of simple glob patterns (supporting `*` and `?` wildcards) " +
-            "that match the fully qualified type name."
+            "Each simple glob pattern is matched against the fully qualified type name. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
     )
     private val forbiddenTypePatterns: List<Regex> by config(
         listOf(

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -68,7 +68,10 @@ class IgnoredReturnValue(config: Config) :
     @Configuration("If the rule should check only methods matching to configuration, or all methods")
     private val restrictToConfig: Boolean by config(defaultValue = true)
 
-    @Configuration("List of glob patterns to be used as inspection annotation")
+    @Configuration(
+        "List of simple glob patterns for annotation names that require return values to be used. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val returnValueAnnotations: List<Regex> by config(
         listOf(
             "CheckResult",
@@ -80,7 +83,10 @@ class IgnoredReturnValue(config: Config) :
         it.map(String::pathGlobToRegex)
     }
 
-    @Configuration("Annotations to skip this inspection")
+    @Configuration(
+        "List of simple glob patterns for annotation names that skip this inspection. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val ignoreReturnValueAnnotations: List<Regex> by config(
         listOf(
             "CanIgnoreReturnValue",
@@ -90,7 +96,10 @@ class IgnoredReturnValue(config: Config) :
         it.map(String::pathGlobToRegex)
     }
 
-    @Configuration("List of return types that should not be ignored")
+    @Configuration(
+        "List of simple glob patterns for return type names that should not be ignored. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val returnValueTypes: List<Regex> by config(
         listOf(
             "kotlin.Function*",

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/IgnoredReturnValue.kt
@@ -70,7 +70,7 @@ class IgnoredReturnValue(config: Config) :
 
     @Configuration(
         "List of simple glob patterns for annotation names that require return values to be used. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val returnValueAnnotations: List<Regex> by config(
         listOf(
@@ -85,7 +85,7 @@ class IgnoredReturnValue(config: Config) :
 
     @Configuration(
         "List of simple glob patterns for annotation names that skip this inspection. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val ignoreReturnValueAnnotations: List<Regex> by config(
         listOf(
@@ -98,7 +98,7 @@ class IgnoredReturnValue(config: Config) :
 
     @Configuration(
         "List of simple glob patterns for return type names that should not be ignored. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val returnValueTypes: List<Regex> by config(
         listOf(

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -40,7 +40,10 @@ class FunctionOnlyReturningConstant(config: Config) :
     @Configuration("if actual functions should be ignored")
     private val ignoreActualFunction: Boolean by config(true)
 
-    @Configuration("excluded functions")
+    @Configuration(
+        "Simple glob patterns for function names to exclude from this rule. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val excludedFunctions: List<Regex> by config(emptyList<String>()) { it.map(String::pathGlobToRegex) }
 
     override fun visitNamedFunction(function: KtNamedFunction) {

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/FunctionOnlyReturningConstant.kt
@@ -42,7 +42,7 @@ class FunctionOnlyReturningConstant(config: Config) :
 
     @Configuration(
         "Simple glob patterns for function names to exclude from this rule. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val excludedFunctions: List<Regex> by config(emptyList<String>()) { it.map(String::pathGlobToRegex) }
 

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
@@ -46,7 +46,10 @@ class ReturnCount(config: Config) : Rule(config, "Restrict the number of return 
     @Configuration("define the maximum number of return statements allowed per function")
     private val max: Int by config(2)
 
-    @Configuration("define a list of function names to be ignored by this check")
+    @Configuration(
+        "Define a list of simple glob patterns for function names to be ignored by this check. " +
+            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+    )
     private val excludedFunctions: List<Regex> by config(listOf("equals")) { it.map(String::pathGlobToRegex) }
 
     @Configuration("if labeled return statements should be ignored")

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/ReturnCount.kt
@@ -48,7 +48,7 @@ class ReturnCount(config: Config) : Rule(config, "Restrict the number of return 
 
     @Configuration(
         "Define a list of simple glob patterns for function names to be ignored by this check. " +
-            "See the [simple glob syntax](https://detekt.dev/docs/next/introduction/glob-patterns#simple-patterns)."
+            "See the [simple glob syntax](https://detekt.dev/docs/introduction/glob-patterns#simple-patterns)."
     )
     private val excludedFunctions: List<Regex> by config(listOf("equals")) { it.map(String::pathGlobToRegex) }
 


### PR DESCRIPTION
## Summary

- clarify what values the remaining simple-glob configuration options match
- link the six affected rules to the shared Glob Patterns documentation
- keep wildcard semantics centralised in the shared simple-pattern reference

## Validation

- `./gradlew generateDocumentation`
- `./gradlew detektMain detektTest`
- `node website/scripts/generate-docs.mjs`
- `./gradlew --no-daemon --max-workers=1 --no-parallel build -x dokkaGenerate`

AI assistance: This PR was prepared with assistance from Codex.

Closes #9574
