### PR TITLE
`ElseCaseInsteadOfExhaustiveWhen`: fix false negative when the subject is a variable

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Main.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Main.kt
@@ -38,7 +38,7 @@ fun main(args: Array<String>) {
             }
         }
 
-        else -> Unit // print nothing extra when there is no error
+        null -> Unit // print nothing extra when there is no error
     }
     exitProcess(result.exitCode())
 }

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/runners/Runner.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/runners/Runner.kt
@@ -5,6 +5,8 @@ import dev.detekt.cli.createSpec
 import dev.detekt.tooling.api.AnalysisResult
 import dev.detekt.tooling.api.Detekt
 import dev.detekt.tooling.api.DetektProvider
+import dev.detekt.tooling.api.InvalidConfig
+import dev.detekt.tooling.api.IssuesFound
 import dev.detekt.tooling.api.UnexpectedError
 import dev.detekt.tooling.api.spec.ProcessingSpec
 import dev.detekt.tooling.internal.NotApiButProbablyUsedByUsers
@@ -25,7 +27,8 @@ class Runner(private val spec: ProcessingSpec) :
         val result = call()
         when (val error = result.error) {
             is UnexpectedError -> throw error.cause
-            else -> error?.let { throw it }
+            is InvalidConfig, is IssuesFound -> throw error
+            null -> Unit
         }
     }
 

--- a/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ElseCaseInsteadOfExhaustiveWhen.kt
+++ b/detekt-rules-potential-bugs/src/main/kotlin/dev/detekt/rules/potentialbugs/ElseCaseInsteadOfExhaustiveWhen.kt
@@ -69,11 +69,13 @@ class ElseCaseInsteadOfExhaustiveWhen(config: Config) :
     }
 
     private fun checkForElseCaseInsteadOfExhaustiveWhenExpression(whenExpression: KtWhenExpression) {
-        val subjectExpression = whenExpression.subjectExpression ?: return
+        val subjectVariable = whenExpression.subjectVariable
+        val subjectExpression = whenExpression.subjectExpression
+        if (subjectVariable == null && subjectExpression == null) return
         if (whenExpression.elseExpression == null) return
 
         analyze(whenExpression) {
-            val subjectType = subjectExpression.expressionType
+            val subjectType = subjectVariable?.returnType ?: subjectExpression?.expressionType
             val subjectSymbol = subjectType?.symbol as? KaClassSymbol
             if (ignoredSubjectTypes.contains(subjectSymbol?.classId?.asFqNameString())) {
                 return

--- a/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
+++ b/detekt-rules-potential-bugs/src/test/kotlin/dev/detekt/rules/potentialbugs/ElseCaseInsteadOfExhaustiveWhenSpec.kt
@@ -58,6 +58,47 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinEnvironmentCont
         }
 
         @Test
+        fun `reports when enum _when_ expression with subject variable contains _else_ case`() {
+            val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+                
+                fun whenOnEnumFail(c: Color) {
+                    val x = when (val subject = c) {
+                        Color.BLUE -> 1
+                        Color.GREEN -> 2
+                        else -> 100
+                    }
+                }
+            """.trimIndent()
+            val actual = subject.lintWithContext(env, code)
+            assertThat(actual).hasSize(1)
+        }
+
+        @Test
+        fun `does not report when enum _when_ expression with subject variable does not contain _else_ case`() {
+            val code = """
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+                
+                fun whenOnEnumPass(c: Color) {
+                    val x = when (val subject = c) {
+                        Color.BLUE -> 1
+                        Color.GREEN -> 2
+                        Color.RED -> 3
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `does not report when enum _when_ expression does not contain _else_ case`() {
             val code = """
                 enum class Color {
@@ -134,6 +175,26 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinEnvironmentCont
         }
 
         @Test
+        fun `reports when sealed _when_ expression with subject variable contains _else_ case`() {
+            val code = """
+                sealed class Variant {
+                    object VariantA : Variant()
+                    class VariantB : Variant()
+                    object VariantC : Variant()
+                }
+                
+                fun whenOnSealedFail(v: Variant) {
+                    val x = when (val subject = v) {
+                        is Variant.VariantA -> "a"
+                        is Variant.VariantB -> "b"
+                        else -> "other"
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
         fun `does not report when sealed _when_ expression does not contain _else_ case`() {
             val code = """
                 sealed class Variant {
@@ -169,6 +230,32 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinEnvironmentCont
                 
                 fun whenOnEnumPasses(c: Color) {
                     when (c) {
+                        Color.BLUE -> {}
+                        Color.GREEN -> {}
+                        else -> {}
+                    }
+                }
+            """.trimIndent()
+            assertThat(
+                ElseCaseInsteadOfExhaustiveWhen(
+                    TestConfig("ignoredSubjectTypes" to listOf("com.example.Color"))
+                ).lintWithContext(env, code)
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report if _when_ with subject variable contains _else_ case for ignored _enum_ subject type`() {
+            val code = """
+                package com.example
+                
+                enum class Color {
+                    RED,
+                    GREEN,
+                    BLUE
+                }
+                
+                fun whenOnEnumPasses(c: Color) {
+                    when (val subject = c) {
                         Color.BLUE -> {}
                         Color.GREEN -> {}
                         else -> {}
@@ -328,6 +415,20 @@ class ElseCaseInsteadOfExhaustiveWhenSpec(private val env: KotlinEnvironmentCont
                         true -> 1
                         false -> 2
                         else -> 100
+                    }
+                }
+            """.trimIndent()
+            val actual = subject.lintWithContext(env, code)
+            assertThat(actual).hasSize(1)
+        }
+
+        @Test
+        fun `reports when boolean _when_ expression with subject variable contains _else_ case`() {
+            val code = """
+                fun whenOnBooleanFail(b: Boolean) {
+                    when (val subject = b) {
+                        true -> {}
+                        else -> {}
                     }
                 }
             """.trimIndent()


### PR DESCRIPTION
Fixes #9607.

`ElseCaseInsteadOfExhaustiveWhen` reported `when (color) { ... else -> ... }` but ignored `when (val c = color) { ... else -> ... }`.

Fix is to check presence of `whenExpression.subjectVariable` and eval its return type in `ElseCaseInsteadOfExhaustiveWhen::checkForElseCaseInsteadOfExhaustiveWhenExpression`.

Found and explored/pinpoint `checkForElseCaseInsteadOfExhaustiveWhenExpression` by myself, used llm to write test cases.