### PR TITLE
Remove redundant assignment

### DIFF
--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/Spec.kt
@@ -60,7 +60,6 @@ internal fun CliArgs.createSpec(output: Appendable, error: Appendable): Processi
         }
 
         extensions {
-            disableDefaultRuleSets = args.disableDefaultRuleSets
             fromPaths { args.plugins }
         }
 


### PR DESCRIPTION
This line is there since 2020 but it does nothing. `args == this` so it does nothing at all.