### PR TITLE
fix(core): allow autoCorrect PSI edits on Analysis API files

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
@@ -15,6 +15,11 @@ class KtFileModifier : FileProcessListener {
 
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         var finalResult = result
+        files.forEach { ktFile ->
+            if (ktFile.modifiedText == null && ktFile.modificationStamp > 0) {
+                ktFile.modifiedText = ktFile.node.text
+            }
+        }
         files.filter { it.modifiedText != null }
             .forEach { ktFile ->
                 val path = ktFile.absolutePath()

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
@@ -16,8 +16,10 @@ class KtFileModifier : FileProcessListener {
     override fun onFinish(files: List<KtFile>, result: Detektion): Detektion {
         var finalResult = result
         files.forEach { ktFile ->
-            if (ktFile.modifiedText == null && ktFile.modificationStamp > 0) {
-                ktFile.modifiedText = ktFile.node.text
+            // Live PSI edits bump modificationStamp. Prefer that over a ktlint modifiedText
+            // buffer for the same file when both ran.
+            if (ktFile.modificationStamp > 0) {
+                ktFile.modifiedText = ktFile.text
             }
         }
         files.filter { it.modifiedText != null }

--- a/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/ProcessingSettings.kt
@@ -51,7 +51,12 @@ class ProcessingSettings private constructor(
         spec,
         config,
         monitor,
-        EnvironmentFacade(spec.projectSpec, spec.compilerSpec, spec.loggingSpec),
+        EnvironmentFacade(
+            spec.projectSpec,
+            spec.compilerSpec,
+            spec.loggingSpec,
+            spec.rulesSpec.autoCorrect,
+        ),
     )
 
     override fun close() {

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -1,9 +1,14 @@
 package dev.detekt.core.settings
 
+import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.text.StringUtilRt
+import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.pom.PomModel
 import com.intellij.pom.tree.TreeAspect
+import com.intellij.psi.impl.source.tree.TreeCopyHandler
+import com.intellij.testFramework.LightVirtualFile
 import dev.detekt.core.parser.createCompilerConfiguration
 import dev.detekt.parser.DetektPomModel
 import dev.detekt.tooling.api.spec.CompilerSpec
@@ -29,15 +34,23 @@ import org.jetbrains.kotlin.platform.jvm.JvmPlatforms
 import org.jetbrains.kotlin.psi.KtFile
 import java.io.OutputStream
 import java.io.PrintStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
 import kotlin.io.path.Path
+import kotlin.io.path.name
+import kotlin.io.path.readText
 
 interface EnvironmentAware {
     val languageVersionSettings: LanguageVersionSettings
     val ktFiles: List<KtFile>
 }
 
-internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: CompilerSpec, loggingSpec: LoggingSpec) :
-    AutoCloseable,
+internal class EnvironmentFacade(
+    projectSpec: ProjectSpec,
+    compilerSpec: CompilerSpec,
+    loggingSpec: LoggingSpec,
+    private val autoCorrect: Boolean,
+) : AutoCloseable,
     EnvironmentAware {
 
     private val printStream = if (loggingSpec.debug) loggingSpec.errorChannel.asPrintStream() else NullPrintStream
@@ -70,6 +83,16 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
             // Required for autocorrect support
             registerProjectService(TreeAspect::class.java)
             registerProjectService(PomModel::class.java, DetektPomModel(project))
+            if (autoCorrect) {
+                val area = application.extensionArea
+                if (!area.hasExtensionPoint(TreeCopyHandler.EP_NAME)) {
+                    CoreApplicationEnvironment.registerExtensionPoint(
+                        area,
+                        TreeCopyHandler.EP_NAME,
+                        TreeCopyHandler::class.java,
+                    )
+                }
+            }
 
             configuration.putIfAbsent(CommonConfigurationKeys.MODULE_NAME, "<no module name provided>")
 
@@ -102,7 +125,12 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
                 }
 
                 sourceModule = buildKtSourceModule {
-                    addSourceRoots(configuration.kotlinSourceRoots.map { Path(it.path) })
+                    val sourcePaths = configuration.kotlinSourceRoots.map { Path(it.path) }
+                    if (autoCorrect) {
+                        addSourceVirtualFiles(sourcePaths.map { it.toWritableKotlinVirtualFile() })
+                    } else {
+                        addSourceRoots(sourcePaths)
+                    }
                     platform = targetPlatform
                     moduleName = "source"
 
@@ -124,6 +152,28 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
 
     override fun close() {
         Disposer.dispose(disposable)
+    }
+}
+
+/**
+ * Standalone Analysis API source roots use the core VFS, which reports files as read-only.
+ * Auto-correct rules need a writable PSI tree while still resolving to the original path on disk.
+ */
+private fun Path.toWritableKotlinVirtualFile(): VirtualFile {
+    val originalPath = toAbsolutePath().normalize().toString()
+    val rawText = readText()
+    val lineSeparator = when {
+        "\r\n" in rawText -> "\r\n"
+        "\r" in rawText -> "\r"
+        else -> "\n"
+    }
+    return object : LightVirtualFile(name, StringUtilRt.convertLineSeparators(rawText)) {
+        init {
+            charset = StandardCharsets.UTF_8
+            detectedLineSeparator = lineSeparator
+        }
+
+        override fun getPath(): String = originalPath
     }
 }
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -3,6 +3,7 @@ package dev.detekt.core.settings
 import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.util.Disposer
+import com.intellij.openapi.util.io.FileUtil
 import com.intellij.openapi.util.text.StringUtilRt
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.pom.PomModel
@@ -127,6 +128,7 @@ internal class EnvironmentFacade(
                 sourceModule = buildKtSourceModule {
                     val sourcePaths = configuration.kotlinSourceRoots.map { Path(it.path) }
                     if (autoCorrect) {
+                        // Writable lights require in-memory content; large projects pay a full read of every source.
                         addSourceVirtualFiles(sourcePaths.map { it.toWritableKotlinVirtualFile() })
                     } else {
                         addSourceRoots(sourcePaths)
@@ -160,7 +162,7 @@ internal class EnvironmentFacade(
  * Auto-correct rules need a writable PSI tree while still resolving to the original path on disk.
  */
 private fun Path.toWritableKotlinVirtualFile(): VirtualFile {
-    val originalPath = toAbsolutePath().normalize().toString()
+    val originalPath = FileUtil.toSystemIndependentName(toAbsolutePath().normalize().toString())
     val rawText = readText()
     val lineSeparator = when {
         "\r\n" in rawText -> "\r\n"

--- a/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -2,11 +2,14 @@ package dev.detekt.core
 
 import dev.detekt.api.Config
 import dev.detekt.api.Detektion
+import dev.detekt.api.Entity
 import dev.detekt.api.FileProcessListener
+import dev.detekt.api.Finding
 import dev.detekt.api.Rule
 import dev.detekt.api.RuleSet
 import dev.detekt.api.RuleSetId
 import dev.detekt.api.RuleSetProvider
+import dev.detekt.api.internal.AutoCorrectable
 import dev.detekt.core.tooling.AnalysisFacade
 import dev.detekt.core.tooling.Lifecycle
 import dev.detekt.test.utils.NullPrintStream
@@ -14,10 +17,17 @@ import dev.detekt.test.utils.readResourceContent
 import dev.detekt.test.utils.resourceAsPath
 import dev.detekt.test.utils.resourceUrl
 import dev.detekt.tooling.api.spec.ProcessingSpec
+import dev.detekt.tooling.api.spec.RulesSpec
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.kotlin.psi.KtAnnotation
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtPsiFactory
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.io.path.writeText
 
 class TopLevelAutoCorrectSpec {
 
@@ -62,6 +72,48 @@ class TopLevelAutoCorrectSpec {
 
         assertThat(readResourceContent("cases/Test.kt")).isEqualTo(fileContentBeforeAutoCorrect)
     }
+
+    @Test
+    fun `autoCorrect PSI mutations on analysis API source files do not crash and are written to disc`(
+        @TempDir tempDir: Path,
+    ) {
+        val fileUnderTest = tempDir.resolve("Foo.kt")
+        val originalContent = """
+            class Foo {
+            }
+
+        """.trimIndent()
+        fileUnderTest.writeText(originalContent)
+
+        val spec = ProcessingSpec {
+            project {
+                inputPaths = listOf(fileUnderTest)
+                basePath = tempDir
+            }
+            config {
+                resources = listOf(resourceUrl("configs/minimal-auto-correct.yaml"))
+            }
+            rules {
+                autoCorrect = true
+                failurePolicy = RulesSpec.FailurePolicy.NeverFail
+            }
+            logging {
+                outputChannel = NullPrintStream()
+                errorChannel = NullPrintStream()
+            }
+        }
+
+        val result = AnalysisFacade(spec).runAnalysis { settings ->
+            Lifecycle(
+                settings.config,
+                settings,
+                ruleSetsProvider = { listOf(MinimalAutoCorrectProvider()) }
+            )
+        }
+
+        assertThat(result.error).isNull()
+        assertThat(fileUnderTest.readText()).contains("// autoCorrect")
+    }
 }
 
 private class DeleteAnnotationsRule(config: Config) : Rule(config, "") {
@@ -73,4 +125,23 @@ private class DeleteAnnotationsRule(config: Config) : Rule(config, "") {
 private class TopLevelAutoCorrectProvider : RuleSetProvider {
     override val ruleSetId = RuleSetId("test-rule-set")
     override fun instance() = RuleSet(ruleSetId, listOf(::DeleteAnnotationsRule))
+}
+
+@AutoCorrectable(since = "2.0.0")
+private class MinimalAutoCorrectRule(config: Config) : Rule(config, "Triggers PSI modification via auto-correct.") {
+    override fun visitClass(klass: KtClass) {
+        super.visitClass(klass)
+        report(Finding(Entity.atName(klass), "Found a class: ${klass.name}"))
+        if (autoCorrect) {
+            val factory = KtPsiFactory(klass.project)
+            val body = klass.body ?: return
+            body.addBefore(factory.createWhiteSpace(" "), body.firstChild)
+            body.addBefore(factory.createComment("// autoCorrect"), body.rBrace)
+        }
+    }
+}
+
+private class MinimalAutoCorrectProvider : RuleSetProvider {
+    override val ruleSetId = RuleSetId("test-rule-set")
+    override fun instance() = RuleSet(ruleSetId, listOf(::MinimalAutoCorrectRule))
 }

--- a/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -78,16 +78,20 @@ class TopLevelAutoCorrectSpec {
         @TempDir tempDir: Path,
     ) {
         val fileUnderTest = tempDir.resolve("Foo.kt")
+        val untouched = tempDir.resolve("Bar.kt")
         val originalContent = """
             class Foo {
             }
 
-        """.trimIndent()
+        """.trimIndent() + "\n"
+        val untouchedContent = "fun unused() = Unit\n"
         fileUnderTest.writeText(originalContent)
+        untouched.writeText(untouchedContent)
+        val untouchedModified = java.nio.file.Files.getLastModifiedTime(untouched)
 
         val spec = ProcessingSpec {
             project {
-                inputPaths = listOf(fileUnderTest)
+                inputPaths = listOf(fileUnderTest, untouched)
                 basePath = tempDir
             }
             config {
@@ -112,7 +116,9 @@ class TopLevelAutoCorrectSpec {
         }
 
         assertThat(result.error).isNull()
-        assertThat(fileUnderTest.readText()).contains("// autoCorrect")
+        assertThat(fileUnderTest.readText()).isEqualTo("class Foo {\n// autoCorrect}\n\n")
+        assertThat(untouched.readText()).isEqualTo(untouchedContent)
+        assertThat(java.nio.file.Files.getLastModifiedTime(untouched)).isEqualTo(untouchedModified)
     }
 }
 

--- a/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
+++ b/detekt-core/src/test/kotlin/dev/detekt/core/TopLevelAutoCorrectSpec.kt
@@ -115,8 +115,13 @@ class TopLevelAutoCorrectSpec {
             )
         }
 
+        val expectedContent = """
+            class Foo {
+            // autoCorrect}
+
+        """.trimIndent() + "\n"
         assertThat(result.error).isNull()
-        assertThat(fileUnderTest.readText()).isEqualTo("class Foo {\n// autoCorrect}\n\n")
+        assertThat(fileUnderTest.readText()).isEqualTo(expectedContent)
         assertThat(untouched.readText()).isEqualTo(untouchedContent)
         assertThat(java.nio.file.Files.getLastModifiedTime(untouched)).isEqualTo(untouchedModified)
     }

--- a/detekt-core/src/test/resources/configs/minimal-auto-correct.yaml
+++ b/detekt-core/src/test/resources/configs/minimal-auto-correct.yaml
@@ -1,0 +1,5 @@
+test-rule-set:
+  autoCorrect: true
+  MinimalAutoCorrectRule:
+    active: true
+    autoCorrect: true


### PR DESCRIPTION
<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

Fixes #9332

## Summary
- Standalone Analysis API source files are loaded through the core VFS, which reports them as read-only. `@AutoCorrectable` rules that mutate PSI (`addBefore`, `delete`, `KtPsiFactory`, etc.) then crash in `CheckUtil.checkWritable` with `Cannot modify a read-only file`.
- When `autoCorrect` is enabled, open Kotlin sources as writable in-memory files that still resolve to the original disk path (`FileUtil.toSystemIndependentName`, matching `CoreLocalVirtualFile`), and register the `treeCopyHandler` extension point needed to copy generated PSI into the tree.
- After analysis, persist live PSI mutations (`modificationStamp > 0`) through `KtFileModifier` using `ktFile.text`, even if a ktlint `modifiedText` buffer was already set for the same file.

This is independent of open #9383 (ktlint-wrapper parsing). The issue timeline's cross-reference to `intellij-community#3495` is a Jewel migration PR, not a covering fix here.

## Test plan
- [x] Reproduced on `main` HEAD (`2.0.0-alpha.6-SNAPSHOT`, JDK 21): a minimal `@AutoCorrectable` rule using `KtPsiFactory` + `addBefore` crashed with `Cannot modify a read-only file` from `CheckUtil.checkWritable`.
- [x] `./gradlew :detekt-core:test --tests "dev.detekt.core.TopLevelAutoCorrectSpec"` — exact corrected content written; sibling input not touched (JDK 21, macOS).
- [x] `./gradlew :detekt-core:test --tests "dev.detekt.core.CorrectableRulesFirstSpec" --tests "dev.detekt.core.AnalyzerSpec"`
- [x] `./gradlew :detekt-core:detektMain :detekt-core:detektTest`

## AI assistance
Drafted with Cursor Composer 2.5; human-reviewed by arimu1 before submission. No `Co-authored-by: Cursor` trailer.