### PR TITLE
Pass only friend paths that exist

### DIFF
--- a/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
+++ b/detekt-gradle-plugin/src/main/kotlin/dev/detekt/gradle/invoke/CliArgument.kt
@@ -115,12 +115,15 @@ internal data class FreeArgs(val args: List<String>) : CliArgument {
 }
 
 internal data class FriendPathArgs(val fileCollection: FileCollection) : CliArgument {
-    override fun toArgument() =
-        if (!fileCollection.isEmpty) {
-            listOf(FRIEND_PATHS_PARAMETER, fileCollection.joinToString(",") { it.absolutePath })
-        } else {
+    override fun toArgument(): List<String> {
+        // a module with a disabled jar task still contributes its jar, so an entry can be absent
+        val existing = fileCollection.files.filter(File::exists)
+        return if (existing.isEmpty()) {
             emptyList()
+        } else {
+            listOf(FRIEND_PATHS_PARAMETER, existing.joinToString(",") { it.absolutePath })
         }
+    }
 }
 
 internal data class BasePathArgument(val basePath: String?) : CliArgument {

--- a/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/invoke/FriendPathArgsSpec.kt
+++ b/detekt-gradle-plugin/src/test/kotlin/dev/detekt/gradle/invoke/FriendPathArgsSpec.kt
@@ -1,0 +1,49 @@
+package dev.detekt.gradle.invoke
+
+import org.assertj.core.api.Assertions.assertThat
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class FriendPathArgsSpec {
+    @Test
+    fun `passes the paths that exist`(@TempDir tempDir: File) {
+        val existing = File(tempDir, "main.jar").apply { createNewFile() }
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+
+        val actual = FriendPathArgs(project.files(existing)).toArgument()
+
+        assertThat(actual).containsExactly("-Xfriend-paths", existing.absolutePath)
+    }
+
+    @Test
+    fun `drops a path that does not exist`(@TempDir tempDir: File) {
+        val existing = File(tempDir, "main.jar").apply { createNewFile() }
+        val missing = File(tempDir, "disabled.jar")
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+
+        val actual = FriendPathArgs(project.files(existing, missing)).toArgument()
+
+        assertThat(actual).containsExactly("-Xfriend-paths", existing.absolutePath)
+    }
+
+    @Test
+    fun `passes nothing when no path exists`(@TempDir tempDir: File) {
+        val missing = File(tempDir, "disabled.jar")
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+
+        val actual = FriendPathArgs(project.files(missing)).toArgument()
+
+        assertThat(actual).isEmpty()
+    }
+
+    @Test
+    fun `passes nothing when the collection is empty`(@TempDir tempDir: File) {
+        val project = ProjectBuilder.builder().withProjectDir(tempDir).build()
+
+        val actual = FriendPathArgs(project.files()).toArgument()
+
+        assertThat(actual).isEmpty()
+    }
+}


### PR DESCRIPTION
Fixes #9623.

`FriendPathArgs` passed every entry it was given, while `ClasspathArgument` in the same file already filters by `File::exists`. The Kotlin Gradle plugin puts the main jar on the test compilation friend paths, so a module whose `jar` task is disabled makes every `detektTest` run log a `NoSuchFileException` and a full `ZipHandler` stack trace. This filters the missing entries and omits the argument altogether when none of them exist.