### PR TITLE
Add UnnecessaryRun rule

### DIFF
--- a/detekt-core/src/main/resources/default-detekt-config.yml
+++ b/detekt-core/src/main/resources/default-detekt-config.yml
@@ -571,6 +571,8 @@ standard-library:
     active: false
   UnnecessaryReversed:
     active: false
+  UnnecessaryRun:
+    active: false
   UseAnyOrNoneInsteadOfFind:
     active: true
   UseCheckNotNull:

--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/StandardLibraryProvider.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/StandardLibraryProvider.kt
@@ -38,6 +38,7 @@ class StandardLibraryProvider : DefaultRuleSetProvider {
                 ::UnnecessaryFilter,
                 ::UnnecessaryLet,
                 ::UnnecessaryReversed,
+                ::UnnecessaryRun,
                 ::UseAnyOrNoneInsteadOfFind,
                 ::UseCheckNotNull,
                 ::UseCheckOrError,

--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRun.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRun.kt
@@ -55,7 +55,9 @@ class UnnecessaryRun(config: Config) :
         analyze(expression) {
             val call = expression.resolveToCall()?.singleFunctionCallOrNull() ?: return
             if (call.symbol.callableId != RUN_CALLABLE_ID) return
-            if (call.dispatchReceiver != null || call.extensionReceiver != null) return
+            // `RUN_CALLABLE_ID` only matches the top-level `run` and the extension `T.run`, neither of which has a
+            // dispatch receiver, so only the extension receiver needs to be checked here.
+            if (call.extensionReceiver != null) return
 
             report(Finding(Entity.from(expression), "run expression can be omitted"))
         }

--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRun.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRun.kt
@@ -1,0 +1,77 @@
+package dev.detekt.rules.standardlibrary
+
+import dev.detekt.api.Config
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.name.StandardClassIds
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDeclaration
+
+/**
+ * A receiverless `run { ... }` block is used to execute a block and return its result, but if the block only
+ * contains a single expression, the `run` call adds unnecessary visual complexity and can be replaced with that
+ * expression directly.
+ *
+ * This rule only reports the non-extension `run` function, i.e. `run { ... }` without a receiver. `T.run { ... }`
+ * as well as other scope functions such as `with`, `apply` and `let` are out of scope for this rule.
+ *
+ * <noncompliant>
+ * val value = run { calculateValue() }
+ * </noncompliant>
+ *
+ * <compliant>
+ * val value = calculateValue()
+ *
+ * // `run` is kept as it contains more than one statement
+ * val value = run {
+ *     first()
+ *     second()
+ * }
+ *
+ * // `T.run` is out of scope for this rule
+ * val value = receiver.run { calculateValue() }
+ * </compliant>
+ */
+class UnnecessaryRun(config: Config) :
+    Rule(
+        config,
+        "The `run` usage is unnecessary and can be removed."
+    ),
+    RequiresAnalysisApi {
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+
+        if (expression.calleeExpression?.text != "run") return
+        if (!expression.hasSingleExpressionBody()) return
+
+        analyze(expression) {
+            val call = expression.resolveToCall()?.singleFunctionCallOrNull() ?: return
+            if (call.symbol.callableId != RUN_CALLABLE_ID) return
+            if (call.dispatchReceiver != null || call.extensionReceiver != null) return
+
+            report(Finding(Entity.from(expression), "run expression can be omitted"))
+        }
+    }
+
+    /**
+     * Returns whether the lambda body of this call consists of exactly one statement that is an actual
+     * expression (as opposed to a local declaration, which would change meaning if hoisted out of the block).
+     */
+    private fun KtCallExpression.hasSingleExpressionBody(): Boolean {
+        val lambda = lambdaArguments.firstOrNull()?.getLambdaExpression() ?: return false
+        val statement = lambda.bodyExpression?.statements?.singleOrNull() ?: return false
+        return statement !is KtDeclaration
+    }
+
+    companion object {
+        private val RUN_CALLABLE_ID = CallableId(StandardClassIds.BASE_KOTLIN_PACKAGE, Name.identifier("run"))
+    }
+}

--- a/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRunSpec.kt
+++ b/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRunSpec.kt
@@ -407,5 +407,36 @@ class UnnecessaryRunSpec(val env: KotlinEnvironmentContainer) {
                 )
             ).isEmpty()
         }
+
+        @Test
+        fun `does not report a shadowed run variable invoked without a trailing lambda`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            val run = { 1 }
+                            val value = run()
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report an aliased import of run`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        import kotlin.run as runAlias
+
+                        fun f() {
+                            val value = runAlias { 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
     }
 }

--- a/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRunSpec.kt
+++ b/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/UnnecessaryRunSpec.kt
@@ -1,0 +1,411 @@
+package dev.detekt.rules.standardlibrary
+
+import dev.detekt.api.Config
+import dev.detekt.test.assertj.assertThat
+import dev.detekt.test.junit.KotlinCoreEnvironmentTest
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.utils.KotlinEnvironmentContainer
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@KotlinCoreEnvironmentTest
+class UnnecessaryRunSpec(val env: KotlinEnvironmentContainer) {
+
+    val subject = UnnecessaryRun(Config.empty)
+
+    @Nested
+    inner class `receiverless run with a single expression` {
+
+        @Test
+        fun `reports a run used as the initializer of a variable`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun calculateValue(): Int = 42
+
+                    fun f() {
+                        val value = run { calculateValue() }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).singleElement()
+                .hasMessage("run expression can be omitted")
+        }
+
+        @Test
+        fun `reports a run used in a return statement`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f(result: Int): Int {
+                        return run { result }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run used as a function argument`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun foo(value: Int) {}
+
+                    fun f() {
+                        foo(run { 1 })
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run whose single expression spans multiple lines`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = run {
+                            listOf(1, 2, 3)
+                                .filter { it > 1 }
+                                .sum()
+                        }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run whose only statement has a preceding comment`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = run {
+                            // a comment
+                            1
+                        }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run whose single statement is an if expression`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f(flag: Boolean) {
+                        val value = run {
+                            if (flag) 1 else 2
+                        }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run whose single statement is a when expression`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f(flag: Boolean) {
+                        val value = run {
+                            when (flag) {
+                                true -> 1
+                                false -> 2
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run whose single statement is a try expression`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = run {
+                            try {
+                                1
+                            } catch (e: Exception) {
+                                2
+                            }
+                        }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run used inside an elvis operator`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f(nullable: Int?): Int {
+                        return nullable ?: run { 1 }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports a run used as an expression body function`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f(): Int = run { 1 }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `reports each receiverless run in a nested run`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = run { run { 1 } }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(2)
+        }
+
+        @Test
+        fun `reports the fully qualified kotlin run`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = kotlin.run { 1 }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).hasSize(1)
+        }
+
+        @Test
+        fun `points to the run call expression`() {
+            val findings = subject.lintWithContext(
+                env,
+                """
+                    fun f() {
+                        val value = run { 1 }
+                    }
+                """.trimIndent()
+            )
+            assertThat(findings).singleElement()
+                .hasStartSourceLocation(2, 17)
+        }
+    }
+
+    @Nested
+    inner class `compliant usages` {
+
+        @Test
+        fun `does not report an empty run`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            run { }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report a run with multiple statements`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun first() {}
+                        fun second() {}
+
+                        fun f() {
+                            val value = run {
+                                first()
+                                second()
+                            }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report a run with multiple statements separated by semicolons`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            val value = run { 1; 2 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report a run whose only statement is a local declaration`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            run {
+                                val x = 1
+                            }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report run with an explicit receiver`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun calculateValue(): Int = 42
+
+                        fun f() {
+                            val receiver = 1
+                            val value = receiver.run { calculateValue() }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report run with a safe-call receiver`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            val receiver: Int? = 1
+                            val value = receiver?.run { this + 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report run with a parenthesized receiver`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            val value = (1).run { this + 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report with`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        class Receiver {
+                            fun calculateValue(): Int = 1
+                        }
+
+                        fun f(receiver: Receiver) {
+                            val value = with(receiver) { calculateValue() }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report let`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun f() {
+                            val receiver = 1
+                            val value = receiver.let { it + 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report apply`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        class Receiver {
+                            var prop: Int = 0
+                        }
+
+                        fun f(receiver: Receiver) {
+                            receiver.apply { prop = 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report a user-defined run function`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        fun run(block: () -> Int): Int = block()
+
+                        fun f() {
+                            val value = run { 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+
+        @Test
+        fun `does not report a member function named run on a custom receiver`() {
+            assertThat(
+                subject.lintWithContext(
+                    env,
+                    """
+                        class Receiver {
+                            fun run(block: () -> Int): Int = block()
+                        }
+
+                        fun f(receiver: Receiver) {
+                            val value = receiver.run { 1 }
+                        }
+                    """.trimIndent()
+                )
+            ).isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

## What

Adds a new `UnnecessaryRun` rule to the `style` ruleset that reports a receiverless `run { ... }` block whose lambda body consists of a single expression, since the block adds no value over the expression itself:

```kotlin
val value = run { calculateValue() } // can be replaced with `val value = calculateValue()`
```

## Scope (per the discussion on #6112)

The issue title originally proposed detecting `<expr1>?.let { <expr2> } ?: run { <single_line_expr> }`, but the thread converged on a narrower, independent rule (see the final maintainer comments on the issue). This PR implements exactly that agreed scope:

- Only the non-extension `run(block: () -> R): R` overload is reported. `T.run { ... }` (the extension overload, called with an explicit, safe-call, or parenthesized receiver, or implicitly via an in-scope receiver) is out of scope and is not reported.
- Other scope functions (`with`, `apply`, `let`) are out of scope.
- A `run` block with more than one statement (including semicolon-separated statements) is not reported.
- An empty `run { }` is not reported.
- A single statement that is a local declaration (e.g. `run { val x = 1 }`) is not reported, since it isn't an "expression" that can be simplified by dropping `run`.

## Implementation notes

- The rule requires the Analysis API (`RequiresAnalysisApi`) to resolve the call. This is necessary (not just convenient) because `run` has two stdlib overloads sharing the same `CallableId` (`kotlin.run`) — the plain one and the `T.run` extension — so a purely syntactic check (e.g. "is this call preceded by a dot?") cannot reliably tell them apart. For example, `kotlin.run { ... }` (fully-qualified) is syntactically dot-prefixed but should still be reported, while an unqualified `run { ... }` could in principle resolve to `T.run` through an implicit receiver. The rule resolves the call and only reports when both `dispatchReceiver` and `extensionReceiver` are null.
- Because there is no receiver at all in scope, there's no need for the "is the receiver's scope used inside the body" analysis that `UnnecessaryApply`/`UnnecessaryLet` require — that concern doesn't apply here, which keeps this rule considerably simpler than those.
- The single-statement check is done syntactically before entering the analysis block, to avoid the cost of a resolve on the (presumably common) multi-statement/empty case.
- No configuration options were added, per the contribution guide's guidance against unnecessary configuration.
- Registered in `StyleGuideProvider`; added to `default-detekt-config.yml` via `./gradlew generateDefaultDetektConfig` (not hand-edited). The rule is `active: false` by default, consistent with the guide's default for new rules.

## Testing

Added `UnnecessaryRunSpec` covering: the basic non-compliant case, `return`, function-argument position, multiline bodies, comments, `if`/`when`/`try` as the single expression, the elvis operator, expression-body functions, nested `run`, the fully-qualified `kotlin.run` form, finding count/message/location, an explicit receiver, a safe-call receiver, a parenthesized receiver, `with`/`let`/`apply`, an empty block, multiple statements (including semicolon-separated), a local declaration as the sole statement, and a user-defined `run` function/member (to guard against false positives on shadowing declarations).

## Verification performed

- `./gradlew publishToMavenLocal` — successful
- `./gradlew :detekt-rules-style:test --tests "dev.detekt.rules.style.UnnecessaryRunSpec"` — 25/25 passed
- `./gradlew :detekt-rules-style:test` (full module) — successful
- `./gradlew generateDefaultDetektConfig` — successful, config entry verified
- `./gradlew detektMain detektTest` — successful
- `./gradlew build -x dokkaGenerate` — successful

Closes #6112
