### PR TITLE
Remove shadow warnings on duplicated kotlin_module

### DIFF
--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -71,6 +71,8 @@ tasks {
         filesMatching("META-INF/services/**") {
             duplicatesStrategy = DuplicatesStrategy.INCLUDE
         }
+        @Suppress("DEPRECATION") // This flag will be disabled and removed in the next major version of Shadow.
+        enableKotlinModuleRemapping = false
     }
 
     shadowDistZip {

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -76,6 +76,11 @@ tasks.register("generateWebsite") {
     )
 }
 
+tasks.shadowJar {
+    @Suppress("DEPRECATION") // This flag will be disabled and removed in the next major version of Shadow.
+    enableKotlinModuleRemapping = false
+}
+
 val copyDocumentation = tasks.register<Copy>("copyDocumentation") {
     from(generatedDocumentationFiles)
     into("$rootDir/website/docs/rules")

--- a/detekt-kotlin-analysis-api-standalone/build.gradle.kts
+++ b/detekt-kotlin-analysis-api-standalone/build.gradle.kts
@@ -36,6 +36,8 @@ configurations.apiElements {
 tasks.shadowJar {
     archiveClassifier = ""
     configurations = aaDependencies.map { listOf(it) }
+    @Suppress("DEPRECATION") // This flag will be disabled and removed in the next major version of Shadow.
+    enableKotlinModuleRemapping = false
 }
 
 val sourcesJar = tasks.register<Jar>("sourcesJar") {

--- a/detekt-kotlin-analysis-api/build.gradle.kts
+++ b/detekt-kotlin-analysis-api/build.gradle.kts
@@ -51,6 +51,8 @@ configurations.apiElements {
 tasks.shadowJar {
     archiveClassifier = ""
     configurations = aaDependencies.map { listOf(it) }
+    @Suppress("DEPRECATION") // This flag will be disabled and removed in the next major version of Shadow.
+    enableKotlinModuleRemapping = false
 }
 
 val sourcesJar = tasks.register<Jar>("sourcesJar") {

--- a/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/ktlint-repackage/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
 
 tasks.shadowJar {
     relocate("org.jetbrains.kotlin.com.intellij", "com.intellij")
+    @Suppress("DEPRECATION") // This flag will be disabled and removed in the next major version of Shadow.
+    enableKotlinModuleRemapping = false
 }
 
 java {


### PR DESCRIPTION
Following the recommendation from here: https://github.com/GradleUp/shadow/releases/tag/9.5.0

Avoid all the warnings that we have when running shadow:

> 'META-INF/dev.detekt_detekt-cli.kotlin_module' is matched by com.github.jengelman.gradle.plugins.shadow.transformers.KotlinModuleMetadataTransformer_Decorated but its DuplicatesStrategy is EXCLUDE — duplicates may be silently dropped before the transformer processes them.
> Set it to INCLUDE or WARN to ensure all duplicates are processed by the transformer.
> See https://gradleup.com/shadow/configuration/merging/#handling-duplicates-strategy for more details.
