### PR TITLE
Add missing configuration

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -27,6 +27,7 @@ reporting {
                     ":detekt-rules-performance:copyConfigToResources",
                     ":detekt-rules-potential-bugs:copyConfigToResources",
                     ":detekt-rules-ruleauthors:copyConfigToResources",
+                    ":detekt-rules-standard-library:copyConfigToResources",
                     ":detekt-rules-style:copyConfigToResources",
                 )
             }

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     generatedConfig(projects.detektRulesNaming) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesPerformance) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedConfig" }
+    generatedConfig(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesStyle) { targetConfiguration = "generatedConfig" }
     generatedDeprecations(projects.detektRulesComments) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesComplexity) { targetConfiguration = "generatedDeprecations" }
@@ -42,6 +43,7 @@ dependencies {
     generatedDeprecations(projects.detektRulesPerformance) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesRuleauthors) { targetConfiguration = "generatedDeprecations" }
+    generatedDeprecations(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesStyle) { targetConfiguration = "generatedDeprecations" }
 
     testRuntimeOnly(projects.detektRules)

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     generatedDocumentation(projects.detektRulesPerformance) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesRuleauthors) { targetConfiguration = "generatedDocumentation" }
+    generatedDocumentation(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesStyle) { targetConfiguration = "generatedDocumentation" }
 
     testImplementation(projects.detektTestUtils)

--- a/detekt-rules-standard-library/build.gradle.kts
+++ b/detekt-rules-standard-library/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("module")
+    id("generator")
 }
 
 dependencies {
@@ -15,3 +16,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
 }
+
+detektGeneratorConfig.addConfigToResources = false


### PR DESCRIPTION
`main` is broken because of "merge conflicts" between these 2 PRs:

- #9140
- #9143

What would you think about forcing a fresh green CI to merge a PR? And activate the PR queue so if you activate the auto merge on 3 PRs they will be merged at their own pace. Problems like this would be avoided. But it would make us a bit slower.