### PR TITLE
Fix standard-library generator integration

### DIFF
--- a/code-coverage-report/build.gradle.kts
+++ b/code-coverage-report/build.gradle.kts
@@ -27,6 +27,7 @@ reporting {
                     ":detekt-rules-performance:copyConfigToResources",
                     ":detekt-rules-potential-bugs:copyConfigToResources",
                     ":detekt-rules-ruleauthors:copyConfigToResources",
+                    ":detekt-rules-standard-library:copyConfigToResources",
                     ":detekt-rules-style:copyConfigToResources",
                 )
             }

--- a/detekt-core/build.gradle.kts
+++ b/detekt-core/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     generatedConfig(projects.detektRulesNaming) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesPerformance) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedConfig" }
+    generatedConfig(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedConfig" }
     generatedConfig(projects.detektRulesStyle) { targetConfiguration = "generatedConfig" }
     generatedDeprecations(projects.detektRulesComments) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesComplexity) { targetConfiguration = "generatedDeprecations" }
@@ -42,6 +43,7 @@ dependencies {
     generatedDeprecations(projects.detektRulesPerformance) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesRuleauthors) { targetConfiguration = "generatedDeprecations" }
+    generatedDeprecations(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedDeprecations" }
     generatedDeprecations(projects.detektRulesStyle) { targetConfiguration = "generatedDeprecations" }
 
     testRuntimeOnly(projects.detektRules)

--- a/detekt-generator/build.gradle.kts
+++ b/detekt-generator/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
     generatedDocumentation(projects.detektRulesPerformance) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesPotentialBugs) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesRuleauthors) { targetConfiguration = "generatedDocumentation" }
+    generatedDocumentation(projects.detektRulesStandardLibrary) { targetConfiguration = "generatedDocumentation" }
     generatedDocumentation(projects.detektRulesStyle) { targetConfiguration = "generatedDocumentation" }
 
     testImplementation(projects.detektTestUtils)

--- a/detekt-rules-standard-library/build.gradle.kts
+++ b/detekt-rules-standard-library/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("module")
+    id("generator")
 }
 
 dependencies {
@@ -15,3 +16,5 @@ dependencies {
     testImplementation(projects.detektTestUtils)
     testImplementation(libs.assertj.core)
 }
+
+detektGeneratorConfig.addConfigToResources = false


### PR DESCRIPTION
The standard-library ruleset was merged without being integrated into the generator convention introduced while the PR was open. As a result, generated config omitted the ruleset and config validation caused several workflows on `main` to fail.

This change:

- applies the `generator` convention to `detekt-rules-standard-library`
- includes the ruleset in generated config and deprecation inputs
- includes it in generated documentation
- includes its generated resources in functional-test coverage setup

Verification:

- `./gradlew :detekt-core:generateDefaultDetektConfig :detekt-core:generateDeprecationList :detekt-generator:copyDocumentation --stacktrace`
- `./gradlew :detekt-core:test :detekt-core:verifyGeneratorOutput :detekt-generator:test detektMain detektTest --stacktrace`
- JavaScript and Gradle website generator outputs compared byte-for-byte

This contribution was prepared with assistance from OpenAI Codex and reviewed by the commit author.