### PR TITLE
Report unused constructor parameters from UnusedParameter

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
@@ -1,5 +1,6 @@
 package dev.detekt.rules.style
 
+import com.intellij.psi.PsiElement
 import dev.detekt.api.ActiveByDefault
 import dev.detekt.api.Alias
 import dev.detekt.api.Config
@@ -7,6 +8,7 @@ import dev.detekt.api.Configuration
 import dev.detekt.api.DetektVisitor
 import dev.detekt.api.Entity
 import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
 import dev.detekt.psi.isAbstract
@@ -17,15 +19,17 @@ import dev.detekt.psi.isMainFunction
 import dev.detekt.psi.isOpen
 import dev.detekt.psi.isOperator
 import dev.detekt.psi.isOverride
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.symbols.KaValueParameterSymbol
+import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
 import org.jetbrains.kotlin.psi.KtConstructor
-import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
-import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtValueArgumentName
@@ -50,27 +54,35 @@ import org.jetbrains.kotlin.psi.psiUtil.isProtected
  */
 @ActiveByDefault(since = "1.23.0")
 @Alias("UNUSED_PARAMETER", "unused")
-class UnusedParameter(config: Config) : Rule(config, "Function parameter is unused and should be removed.") {
+class UnusedParameter(config: Config) :
+    Rule(config, "Function parameter is unused and should be removed."),
+    RequiresAnalysisApi {
 
     @Configuration("unused parameter names matching this regex are ignored")
     private val allowedNames: Regex by config("ignored|expected", String::toRegex)
 
     override fun visit(root: KtFile) {
         super.visit(root)
-        val visitor = UnusedParameterVisitor(allowedNames)
-        root.accept(visitor)
-        visitor.getUnusedReports().forEach { report(it) }
+
+        // Declaration and usage need different traversals. Collection stops at declarations that are
+        // allowed to have unused parameters, while a reference to a parameter can sit anywhere in the
+        // file, including inside those same declarations.
+        val declarations = ParameterDeclarationVisitor(allowedNames)
+        root.accept(declarations)
+        val usages = ParameterUsageVisitor()
+        root.accept(usages)
+
+        declarations.candidates
+            .filterNot { it in usages.usedParameters }
+            .forEach {
+                report(Finding(Entity.atName(it), "Function parameter `${it.nameAsSafeName.identifier}` is unused."))
+            }
     }
 }
 
-private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVisitor() {
+private class ParameterDeclarationVisitor(private val allowedNames: Regex) : DetektVisitor() {
 
-    private val unusedParameters: MutableSet<KtParameter> = mutableSetOf()
-
-    fun getUnusedReports(): List<Finding> =
-        unusedParameters.map {
-            Finding(Entity.atName(it), "Function parameter `${it.nameAsSafeName.identifier}` is unused.")
-        }
+    val candidates: MutableSet<KtParameter> = mutableSetOf()
 
     override fun visitClassOrObject(klassOrObject: KtClassOrObject) {
         if (klassOrObject.isExpect()) return
@@ -90,7 +102,7 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
             return
         }
 
-        collectParameters(function.valueParameters, function)
+        collectParameters(function.valueParameters)
 
         super.visitNamedFunction(function)
     }
@@ -98,10 +110,7 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
         if (constructor.isRelevant()) {
             // A parameter declared with `val` or `var` is a property, so UnusedPrivateProperty owns it.
-            collectParameters(
-                constructor.valueParameters.filterNot { it.isPropertyParameter() },
-                constructor.getContainingClassOrObject(),
-            )
+            collectParameters(constructor.valueParameters.filterNot { it.isPropertyParameter() })
         }
 
         super.visitPrimaryConstructor(constructor)
@@ -109,39 +118,16 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
 
     override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
         if (constructor.isRelevant()) {
-            collectParameters(constructor.valueParameters, constructor)
+            collectParameters(constructor.valueParameters)
         }
 
         super.visitSecondaryConstructor(constructor)
     }
 
-    private fun collectParameters(candidates: List<KtParameter>, scope: KtElement) {
-        val parameters = mutableMapOf<String, KtParameter>()
-        candidates.forEach { parameter ->
-            val name = parameter.nameAsSafeName.identifier
-            if (!allowedNames.matches(name)) {
-                parameters[name] = parameter
-            }
-        }
-
-        scope.accept(object : DetektVisitor() {
-            override fun visitProperty(property: KtProperty) {
-                if (property.isLocal) {
-                    val name = property.nameAsSafeName.identifier
-                    parameters.remove(name)
-                }
-                super.visitProperty(property)
-            }
-
-            override fun visitReferenceExpression(expression: KtReferenceExpression) {
-                if (expression.parent !is KtValueArgumentName) {
-                    parameters.remove(expression.text.removeSurrounding("`"))
-                }
-                super.visitReferenceExpression(expression)
-            }
-        })
-
-        unusedParameters.addAll(parameters.values)
+    private fun collectParameters(parameters: List<KtParameter>) {
+        parameters
+            .filterNot { allowedNames.matches(it.nameAsSafeName.identifier) }
+            .forEach { candidates.add(it) }
     }
 
     private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
@@ -164,4 +150,22 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
             isExpect() ||
             isActual() ||
             isProtected()
+}
+
+private class ParameterUsageVisitor : DetektVisitor() {
+
+    val usedParameters: MutableSet<PsiElement> = mutableSetOf()
+
+    override fun visitReferenceExpression(expression: KtReferenceExpression) {
+        super.visitReferenceExpression(expression)
+
+        if (expression !is KtNameReferenceExpression) return
+        // `foo(bar = 1)` names the callee's parameter, it does not read it.
+        if (expression.parent is KtValueArgumentName) return
+
+        analyze(expression) {
+            val symbol = expression.mainReference.resolveToSymbol() as? KaValueParameterSymbol ?: return
+            symbol.psi?.let { usedParameters.add(it) }
+        }
+    }
 }

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
@@ -90,16 +90,18 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
             return
         }
 
-        collectParameters(function.valueParameterList?.parameters.orEmpty(), function)
+        collectParameters(function.valueParameters, function)
 
         super.visitNamedFunction(function)
     }
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
-        val klass = constructor.containingClassOrObject
-        if (constructor.isRelevant() && klass != null) {
+        if (constructor.isRelevant()) {
             // A parameter declared with `val` or `var` is a property, so UnusedPrivateProperty owns it.
-            collectParameters(constructor.valueParameters.filterNot { it.isPropertyParameter() }, klass)
+            collectParameters(
+                constructor.valueParameters.filterNot { it.isPropertyParameter() },
+                constructor.getContainingClassOrObject(),
+            )
         }
 
         super.visitPrimaryConstructor(constructor)
@@ -144,10 +146,12 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
 
     private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
 
-    private fun KtConstructor<*>.isRelevant(): Boolean {
-        if (isExpect() || isActual()) return false
+    private fun KtConstructor<*>.isRelevant() = !isAllowedToHaveUnusedParameters()
+
+    private fun KtConstructor<*>.isAllowedToHaveUnusedParameters(): Boolean {
+        if (isActual()) return true
         val klass = containingClassOrObject as? KtClass ?: return false
-        return !klass.isExpect() && !klass.isData() && !klass.isValue() && !klass.isInline()
+        return klass.isData() || klass.isValue() || klass.isInline()
     }
 
     private fun KtNamedFunction.isAllowedToHaveUnusedParameters() =

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedParameter.kt
@@ -19,12 +19,18 @@ import dev.detekt.psi.isOperator
 import dev.detekt.psi.isOverride
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtConstructor
+import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtValueArgumentName
+import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
+import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 import org.jetbrains.kotlin.psi.psiUtil.isProtected
 
 /**
@@ -84,21 +90,39 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
             return
         }
 
-        collectParameters(function)
+        collectParameters(function.valueParameterList?.parameters.orEmpty(), function)
 
         super.visitNamedFunction(function)
     }
 
-    private fun collectParameters(function: KtNamedFunction) {
+    override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
+        val klass = constructor.containingClassOrObject
+        if (constructor.isRelevant() && klass != null) {
+            // A parameter declared with `val` or `var` is a property, so UnusedPrivateProperty owns it.
+            collectParameters(constructor.valueParameters.filterNot { it.isPropertyParameter() }, klass)
+        }
+
+        super.visitPrimaryConstructor(constructor)
+    }
+
+    override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
+        if (constructor.isRelevant()) {
+            collectParameters(constructor.valueParameters, constructor)
+        }
+
+        super.visitSecondaryConstructor(constructor)
+    }
+
+    private fun collectParameters(candidates: List<KtParameter>, scope: KtElement) {
         val parameters = mutableMapOf<String, KtParameter>()
-        function.valueParameterList?.parameters?.forEach { parameter ->
+        candidates.forEach { parameter ->
             val name = parameter.nameAsSafeName.identifier
             if (!allowedNames.matches(name)) {
                 parameters[name] = parameter
             }
         }
 
-        function.accept(object : DetektVisitor() {
+        scope.accept(object : DetektVisitor() {
             override fun visitProperty(property: KtProperty) {
                 if (property.isLocal) {
                     val name = property.nameAsSafeName.identifier
@@ -119,6 +143,12 @@ private class UnusedParameterVisitor(private val allowedNames: Regex) : DetektVi
     }
 
     private fun KtNamedFunction.isRelevant() = !isAllowedToHaveUnusedParameters()
+
+    private fun KtConstructor<*>.isRelevant(): Boolean {
+        if (isExpect() || isActual()) return false
+        val klass = containingClassOrObject as? KtClass ?: return false
+        return !klass.isExpect() && !klass.isData() && !klass.isValue() && !klass.isInline()
+    }
 
     private fun KtNamedFunction.isAllowedToHaveUnusedParameters() =
         isAbstract() ||

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
@@ -134,8 +134,8 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
 
         constructor.valueParameters
             .filter {
-                it.isPrivate() &&
-                    it.isPropertyParameter() &&
+                it.isPropertyParameter() &&
+                    it.isPrivate() &&
                     !constructor.isExpectClassConstructor() &&
                     !constructor.isDataOrValueClassConstructor()
             }

--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/UnusedPrivateProperty.kt
@@ -33,7 +33,6 @@ import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.KtReferenceExpression
-import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.psi.psiUtil.containingClassOrObject
 import org.jetbrains.kotlin.psi.psiUtil.getChildrenOfType
@@ -44,8 +43,8 @@ import org.jetbrains.kotlin.psi.psiUtil.isPropertyParameter
 /**
  * An unused private property can be removed to simplify the source file.
  *
- * This rule also detects unused constructor parameters since these can become
- * properties of the class when they are declared with `val` or `var`.
+ * This rule also detects unused constructor properties, which are the parameters declared with `val` or `var`.
+ * Constructor parameters that are not properties are reported by `UnusedParameter`.
  *
  * <noncompliant>
  * class Foo {
@@ -95,9 +94,6 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
     private val classProperties = hashSetOf<KtNamedDeclaration>()
     private val usedClassProperties = hashSetOf<PsiElement>()
 
-    private val constructorParameters = hashSetOf<KtNamedDeclaration>()
-    private val usedConstructorParameters = hashSetOf<PsiElement>()
-
     fun getUnusedReports(): List<Finding> {
         val propertiesReport = classProperties
             .filter { it.psiOrParent !in usedClassProperties }
@@ -106,16 +102,6 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
                 Finding(
                     entity = Entity.atName(it),
                     message = "Private property `${it.nameAsSafeName.identifier}` is unused."
-                )
-            }
-
-        val constructorParametersReport = constructorParameters
-            .filter { it.psiOrParent !in usedConstructorParameters }
-            .filter { !allowedNames.matches(it.nameAsSafeName.identifier) }
-            .map {
-                Finding(
-                    entity = Entity.atName(it),
-                    message = "Constructor parameter `${it.nameAsSafeName.identifier}` is unused.",
                 )
             }
 
@@ -129,7 +115,7 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
                 )
             }
 
-        return propertiesReport + constructorParametersReport + topLevelPropertyReport
+        return propertiesReport + topLevelPropertyReport
     }
 
     override fun visitPrimaryConstructor(constructor: KtPrimaryConstructor) {
@@ -137,22 +123,12 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
 
         constructor.valueParameters
             .filter {
-                (it.isPrivate() || !it.isPropertyParameter()) &&
+                it.isPrivate() &&
+                    it.isPropertyParameter() &&
                     !constructor.isExpectClassConstructor() &&
                     !constructor.isDataOrValueClassConstructor()
             }
-            .forEach { valueParameter ->
-                if (valueParameter.isPropertyParameter()) {
-                    classProperties.add(valueParameter)
-                } else {
-                    constructorParameters.add(valueParameter)
-                }
-            }
-    }
-
-    override fun visitSecondaryConstructor(constructor: KtSecondaryConstructor) {
-        super.visitSecondaryConstructor(constructor)
-        constructorParameters += constructor.valueParameters
+            .forEach { classProperties.add(it) }
     }
 
     override fun visitProperty(property: KtProperty) {
@@ -197,8 +173,6 @@ private class UnusedPrivatePropertyVisitor(private val allowedNames: Regex) : De
                                 usedClassProperties.add(psi)
                             }
                         }
-
-                        else -> usedConstructorParameters.add(psi)
                     }
                 }
         }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
@@ -2,11 +2,14 @@ package dev.detekt.rules.style
 
 import dev.detekt.api.Config
 import dev.detekt.test.assertj.assertThat
-import dev.detekt.test.lint
+import dev.detekt.test.junit.KotlinCoreEnvironmentTest
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.utils.KotlinEnvironmentContainer
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
-class UnusedParameterSpec {
+@KotlinCoreEnvironmentTest
+class UnusedParameterSpec(val env: KotlinEnvironmentContainer) {
     val subject = UnusedParameter(Config.empty)
 
     @Nested
@@ -19,7 +22,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -30,7 +33,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -41,7 +44,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -52,7 +55,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -63,7 +66,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -78,7 +81,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -98,7 +101,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -113,7 +116,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -128,7 +131,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -143,7 +146,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -158,7 +161,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -174,7 +177,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -186,7 +189,7 @@ class UnusedParameterSpec {
                 fun foo(@Suppress("UnusedParameter") unused: String){}
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -195,7 +198,7 @@ class UnusedParameterSpec {
                 fun foo(@Suppress("UnusedParameter") unused: String, unusedWithoutAnnotation: String){}
             """.trimIndent()
 
-            val lint = subject.lint(code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint).singleElement()
                 .hasMessage("Function parameter `unusedWithoutAnnotation` is unused.")
@@ -208,7 +211,7 @@ class UnusedParameterSpec {
                 fun foo(unused: String, otherUnused: String){}
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -221,7 +224,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -233,7 +236,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -249,7 +252,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -261,7 +264,7 @@ class UnusedParameterSpec {
                 fun foo(unused: Int){}
             """.trimIndent()
 
-            val lint = subject.lint(code)
+            val lint = subject.lintWithContext(env, code)
 
             assertThat(lint).singleElement()
                 .hasMessage("Function parameter `unused` is unused.")
@@ -282,7 +285,7 @@ class UnusedParameterSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -292,7 +295,7 @@ class UnusedParameterSpec {
                     println("b")
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -303,7 +306,7 @@ class UnusedParameterSpec {
             val code = """
                 fun test(`foo bar`: Int) = `foo bar`
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -322,7 +325,7 @@ class UnusedParameterSpec {
                     ) = 1
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).singleElement()
+            assertThat(subject.lintWithContext(env, code)).singleElement()
                 .hasStartSourceLocation(6, 9)
         }
     }
@@ -340,7 +343,7 @@ class UnusedParameterSpec {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).singleElement()
+            assertThat(subject.lintWithContext(env, code)).singleElement()
                 .hasStartSourceLocation(1, 9)
         }
 
@@ -355,7 +358,18 @@ class UnusedParameterSpec {
                     println(modifier)
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `reports a parameter only named in a recursive call`() {
+            val code = """
+                fun foo(unused: Int) {
+                    if (false) foo(unused = 1)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
     }
 
@@ -367,7 +381,7 @@ class UnusedParameterSpec {
                 class A(unused: String)
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -378,7 +392,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -389,7 +403,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -397,7 +411,7 @@ class UnusedParameterSpec {
             val code = """
                 class Test(unused: Any)
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(1)
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
         @Test
@@ -409,7 +423,7 @@ class UnusedParameterSpec {
                     }
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -419,7 +433,7 @@ class UnusedParameterSpec {
                     val usedString = used.toString()
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -433,7 +447,7 @@ class UnusedParameterSpec {
                     constructor(used: Any)
                 }
             """.trimIndent()
-            assertThat(subject.lint(code)).hasSize(2)
+            assertThat(subject.lintWithContext(env, code)).hasSize(2)
         }
 
         @Test
@@ -442,7 +456,7 @@ class UnusedParameterSpec {
                class Test(vararg unused: Any)
             """.trimIndent()
 
-            assertThat(subject.lint(code))
+            assertThat(subject.lintWithContext(env, code))
                 .hasSize(1)
         }
 
@@ -458,7 +472,7 @@ class UnusedParameterSpec {
                }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isNotEmpty()
+            assertThat(subject.lintWithContext(env, code)).isNotEmpty()
         }
 
         @Test
@@ -469,7 +483,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
         @Test
@@ -481,7 +495,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, allowCompilationErrors = true)).isEmpty()
         }
 
         @Test
@@ -492,7 +506,7 @@ class UnusedParameterSpec {
                 }
             """.trimIndent()
 
-            assertThat(subject.lint(code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, allowCompilationErrors = true)).isEmpty()
         }
 
         @Test
@@ -501,7 +515,7 @@ class UnusedParameterSpec {
                 class A(val unused: String)
             """.trimIndent()
 
-            assertThat(subject.lint(code)).isEmpty()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 
@@ -516,7 +530,7 @@ class UnusedParameterSpec {
                     actual fun baz(i: Int, s: String) {}
                 }
             """.trimIndent()
-            assertThat(subject.lint(code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, allowCompilationErrors = true)).isEmpty()
         }
 
         @Test
@@ -524,7 +538,51 @@ class UnusedParameterSpec {
             val code = """
                 actual class Foo actual constructor(bar: String) {}
             """.trimIndent()
-            assertThat(subject.lint(code, compile = false)).isEmpty()
+            assertThat(subject.lintWithContext(env, code, allowCompilationErrors = true)).isEmpty()
+        }
+    }
+
+    @Nested
+    inner class `references are resolved, not matched by name` {
+        @Test
+        fun `reports a parameter whose name is also a property on another receiver`() {
+            val code = """
+                class Other { val unused = 1 }
+                class A {
+                    fun foo(unused: Int) {
+                        println(Other().unused)
+                    }
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports a parameter shadowed by a local variable of the same name`() {
+            val code = """
+                fun foo(unused: Int) {
+                    val unused = 5
+                    println(unused)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a parameter used inside an anonymous object`() {
+            val code = """
+                abstract class Base { abstract fun foo() }
+                fun outer(used: Int) {
+                    val obj = object : Base() {
+                        override fun foo() { println(used) }
+                    }
+                    println(obj)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
     }
 }

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
@@ -462,6 +462,40 @@ class UnusedParameterSpec {
         }
 
         @Test
+        fun `does not report unused parameters of a data class secondary constructor`() {
+            val code = """
+                data class A(val x: Int) {
+                    constructor(x: Int, unused: Int) : this(x)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report unused parameters of a value class constructor`() {
+            val code = """
+                @JvmInline
+                value class A(private val x: Int) {
+                    constructor(x: Int, unused: Int) : this(x)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lint(code, compile = false)).isEmpty()
+        }
+
+        @Test
+        fun `does not report unused parameters of an inline class constructor`() {
+            val code = """
+                inline class A(private val x: Int) {
+                    constructor(x: Int, unused: Int) : this(x)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lint(code, compile = false)).isEmpty()
+        }
+
+        @Test
         fun `does not report a constructor property`() {
             val code = """
                 class A(val unused: String)

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedParameterSpec.kt
@@ -360,6 +360,118 @@ class UnusedParameterSpec {
     }
 
     @Nested
+    inner class `constructor parameters` {
+        @Test
+        fun `reports unused parameter of a primary constructor`() {
+            val code = """
+                class A(unused: String)
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `reports unused parameter of a secondary constructor`() {
+            val code = """
+                class A {
+                    constructor(unused: String)
+                }
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report a used parameter of a primary constructor`() {
+            val code = """
+                class A(used: String) {
+                    val length = used.length
+                }
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `reports unused parameter`() {
+            val code = """
+                class Test(unused: Any)
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(1)
+        }
+
+        @Test
+        fun `does not report used parameter in init block`() {
+            val code = """
+                class Test(used: Any) {
+                    init {
+                        used.toString()
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report used parameter to initialize property`() {
+            val code = """
+                class Test(used: Any) {
+                    val usedString = used.toString()
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).isEmpty()
+        }
+
+        @Test
+        fun `report unused parameters in secondary constructors`() {
+            val code = """
+                private class ClassWithSecondaryConstructor {
+                    constructor(used: Any, unused: Any) {
+                        used.toString()
+                    }
+                
+                    constructor(used: Any)
+                }
+            """.trimIndent()
+            assertThat(subject.lint(code)).hasSize(2)
+        }
+
+        @Test
+        fun `reports unused vararg parameter`() {
+            val code = """
+               class Test(vararg unused: Any)
+            """.trimIndent()
+
+            assertThat(subject.lint(code))
+                .hasSize(1)
+        }
+
+        @Test
+        fun `reports for multiple classes with same properties name in the same file`() {
+            val code = """
+                class C(initial:Int = 0){
+                
+                constructor(c:Float, d:Float):this(c.toInt()){
+                   println(c)
+                }
+                  
+               }
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isNotEmpty()
+        }
+
+        @Test
+        fun `does not report a constructor property`() {
+            val code = """
+                class A(val unused: String)
+            """.trimIndent()
+
+            assertThat(subject.lint(code)).isEmpty()
+        }
+    }
+
+    @Nested
     inner class `actual functions and classes` {
 
         @Test

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/UnusedPrivatePropertySpec.kt
@@ -628,16 +628,7 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
     @Nested
     inner class `properties in primary constructors` {
 
-        @Test
-        fun `reports unused vararg parameter`() {
-            val code = """
-               class Test(vararg unused: Any)
-            """.trimIndent()
-
-            assertThat(subject.lintWithContext(env, code))
-                .hasSize(1)
-        }
-
+        
         @Test
         fun `not reports used vararg parameter`() {
             val code = """
@@ -680,21 +671,7 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
             assertThat(subject.lintWithContext(env, code)).hasSize(1)
         }
 
-        @Test
-        fun `reports for multiple classes with same properties name in the same file`() {
-            val code = """
-                class C(initial:Int = 0){
-                
-                constructor(c:Float, d:Float):this(c.toInt()){
-                   println(c)
-                }
-                  
-               }
-            """.trimIndent()
-
-            assertThat(subject.lintWithContext(env, code)).isNotEmpty()
-        }
-
+        
         @Test
         fun `does not report public property`() {
             val code = """
@@ -864,14 +841,7 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `parameters in primary constructors` {
-        @Test
-        fun `reports unused parameter`() {
-            val code = """
-                class Test(unused: Any)
-            """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(1)
-        }
-
+        
         @Test
         fun `does not report used parameter for calling super`() {
             val code = """
@@ -881,28 +851,8 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
             assertThat(subject.lintWithContext(env, code)).isEmpty()
         }
 
-        @Test
-        fun `does not report used parameter in init block`() {
-            val code = """
-                class Test(used: Any) {
-                    init {
-                        used.toString()
-                    }
-                }
-            """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
-        }
-
-        @Test
-        fun `does not report used parameter to initialize property`() {
-            val code = """
-                class Test(used: Any) {
-                    val usedString = used.toString()
-                }
-            """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).isEmpty()
-        }
-
+        
+        
         @Test
         fun `reports parameter used for delegation`() {
             val code = """
@@ -918,18 +868,5 @@ class UnusedPrivatePropertySpec(val env: KotlinEnvironmentContainer) {
 
     @Nested
     inner class `secondary parameters` {
-        @Test
-        fun `report unused parameters in secondary constructors`() {
-            val code = """
-                private class ClassWithSecondaryConstructor {
-                    constructor(used: Any, unused: Any) {
-                        used.toString()
-                    }
-                
-                    constructor(used: Any)
-                }
-            """.trimIndent()
-            assertThat(subject.lintWithContext(env, code)).hasSize(2)
-        }
-    }
+            }
 }


### PR DESCRIPTION
Fixes #9633

`UnusedPrivateProperty` collected primary constructor parameters that are not properties,
and every secondary constructor parameter, and reported them as
`Constructor parameter ... is unused`. Those are parameters rather than properties, so
`UnusedParameter` now owns them and `UnusedPrivateProperty` keeps only the parameters
declared with `val` or `var`.

`UnusedParameter` visits primary and secondary constructors. The exclusions move across as
well, so `expect` and `actual` constructors and the constructors of `data`, `value`, and
`inline` classes are left alone.

`UnusedParameter` is now a `RequiresAnalysisApi` rule and resolves references instead of
removing them by name. Two cases it used to miss now report: a parameter whose name is also
a property on another receiver, and a parameter shadowed by a local variable of the same
name.

Declaration and usage need different traversals, so they run as two passes. Collection stops
at declarations that are allowed to have unused parameters, while a reference to a parameter
can sit anywhere in the file, including inside those same declarations. A single visitor
would report `used` below, because `foo` is an override and collection stops there before
reaching the reference:

```kotlin
fun outer(used: Int) {
    val obj = object : Base() {
        override fun foo() { println(used) }
    }
}
```

Six tests moved from `UnusedPrivatePropertySpec` to `UnusedParameterSpec`, and four new ones
cover the constructor cases. `UnusedParameterSpec` now runs on `lintWithContext`, with four
more tests, 44 in total.

This was written with AI assistance (Claude), which is credited as a commit co-author. I
reviewed the change and ran the tests.
