### PR TITLE
Stop using detekt-psi-utils for absolutePath in detekt-core

### DIFF
--- a/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/Analyzer.kt
@@ -14,7 +14,6 @@ import dev.detekt.api.valueOrDefault
 import dev.detekt.core.suppressors.buildSuppressors
 import dev.detekt.core.suppressors.isSuppressedBy
 import dev.detekt.core.util.shouldAnalyzeFile
-import dev.detekt.psi.absolutePath
 import dev.detekt.tooling.api.AnalysisMode
 import org.jetbrains.kotlin.config.LanguageVersionSettings
 import org.jetbrains.kotlin.psi.KtFile

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFileModifier.kt
@@ -5,7 +5,6 @@ import dev.detekt.api.Detektion
 import dev.detekt.api.FileProcessListener
 import dev.detekt.api.Notification
 import dev.detekt.api.modifiedText
-import dev.detekt.psi.absolutePath
 import org.jetbrains.kotlin.psi.KtFile
 import kotlin.io.path.writeText
 

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
@@ -8,7 +8,7 @@ import kotlin.io.path.Path
  * Local copy of `dev.detekt.psi.absolutePath`.
  *
  * `:detekt-psi-utils` exists to support rule authors, so `:detekt-core` should not depend on it
- * (#7279). Copying this one function removes every non-suppressor use core makes of that module;
+ * (#7279).
  * what remains is `AnnotationSuppressor` and `FunctionSuppressor`, which is a separate change.
  *
  * `KtFile.virtualFilePath` is cached, so this is a tiny bit more performant than going through

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
@@ -4,14 +4,4 @@ import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path
 import kotlin.io.path.Path
 
-/**
- * Local copy of `dev.detekt.psi.absolutePath`.
- *
- * `:detekt-psi-utils` exists to support rule authors, so `:detekt-core` should not depend on it
- * (#7279).
- * what remains is `AnnotationSuppressor` and `FunctionSuppressor`, which is a separate change.
- *
- * `KtFile.virtualFilePath` is cached, so this is a tiny bit more performant than going through
- * `virtualFile.path` when called repeatedly for the same file.
- */
 internal fun KtFile.absolutePath(): Path = Path(virtualFilePath)

--- a/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/KtFilePaths.kt
@@ -1,0 +1,17 @@
+package dev.detekt.core
+
+import org.jetbrains.kotlin.psi.KtFile
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+/**
+ * Local copy of `dev.detekt.psi.absolutePath`.
+ *
+ * `:detekt-psi-utils` exists to support rule authors, so `:detekt-core` should not depend on it
+ * (#7279). Copying this one function removes every non-suppressor use core makes of that module;
+ * what remains is `AnnotationSuppressor` and `FunctionSuppressor`, which is a separate change.
+ *
+ * `KtFile.virtualFilePath` is cached, so this is a tiny bit more performant than going through
+ * `virtualFile.path` when called repeatedly for the same file.
+ */
+internal fun KtFile.absolutePath(): Path = Path(virtualFilePath)

--- a/detekt-core/src/main/kotlin/dev/detekt/core/util/ConfigExtensions.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/util/ConfigExtensions.kt
@@ -2,7 +2,7 @@ package dev.detekt.core.util
 
 import dev.detekt.api.Config
 import dev.detekt.api.valueOrDefault
-import dev.detekt.psi.absolutePath
+import dev.detekt.core.absolutePath
 import dev.detekt.utils.PathFilters
 import org.jetbrains.kotlin.psi.KtFile
 import java.nio.file.Path


### PR DESCRIPTION
Progresses #7279. Does **not** close it — see *What is left* below.

This is AI generated 👇

## What

`:detekt-psi-utils` exists to support rule authors, so `:detekt-core` should not depend on it. Core makes five uses of that module across four files:

| File | Uses | Suppressor? |
|---|---|---|
| `Analyzer.kt` | `absolutePath` | no |
| `KtFileModifier.kt` | `absolutePath` | no |
| `util/ConfigExtensions.kt` | `absolutePath` | no |
| `suppressors/AnnotationSuppressor.kt` | `AnnotationExcluder`, `fullyQualifiedNameGlobToRegex` | yes |
| `suppressors/FunctionSuppressor.kt` | `FunctionMatcher` | yes |

This copies `absolutePath` into core, clearing the three non-suppressor uses. All three call sites take a `KtFile`, so only that overload is copied — the `PsiFile` one stays in psi-utils where rules use it.

## What is left

The `implementation(projects.detektPsiUtils)` declaration **stays**, because the two suppressors still need it. That is deliberate: this PR is the trivially-safe half, split out so the interesting half can be discussed on its own.

The remaining half is the one @BraisGabin and @cortinico were discussing on the issue. Worth recording what the code says about it:

- `FunctionMatcher` is used by 6 rule files (complexity, potential-bugs ×2, standard-library, style ×2) plus `FunctionSuppressor`
- `AnnotationExcluder` by `LongParameterList` plus `AnnotationSuppressor`
- `fullyQualifiedNameGlobToRegex` by `UnnecessaryFullyQualifiedName` plus `AnnotationSuppressor`

In every case **the only non-rule consumer is a suppressor**. So @BraisGabin's suggestion — move the suppressors out of core — would leave psi-utils used exclusively by rule modules, with no duplication and no new shared module. That looks like the cleanest of the options raised.

Two things worth deciding there, but not here:

1. It does not require #4932 (extensible suppressors). Moving the implementations out is separable from making them pluggable, and bundling them makes this wait on a 2022 feature request.
2. If the suppressors do become ServiceLoader-loaded, `ignoreAnnotated` and `ignoreFunction` — both documented in `website/docs/introduction/suppressors.mdx` — would silently stop working when the module is absent from the classpath. Today they are guaranteed. Keeping those two as core built-ins and making only *additional* suppressors pluggable would avoid that.

## Verification

- `:detekt-core:compileKotlin`, `:detekt-core:test` — pass
- `:detekt-core:detektMain`, `:detekt-core:detektTest` — pass
- `buildHealth` — pass (no unused-dependency advice, since the suppressors still use it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)