### PR TITLE
Fix outdated analysis projects script reference

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,8 +36,7 @@ In short: use AI as a tool, not as a replacement for human context, care, and re
 When implementing a new rule, do not forget to perform the following steps:
 - Add the new rule to a `RuleSetProvider` (such as `StyleGuideProvider`).
 - Test the new rule and/or add tests for any changes made to a rule. Run detekt on itself and other
-  Kotlin projects with the `--run-rule RuleSet:RuleId` option to test your rule in isolation. Make use of
-  the `scripts/get_analysis_projects.kts` script to automatically establish a set of analysis projects.
+  Kotlin projects with the `--run-rule RuleSet:RuleId` option to test your rule in isolation.
 - Run `./gradlew generateDefaultDetektConfig` to add your rule and its config options to the `default-detekt-config.yml`.
 - Run `./gradlew build`. This will execute tests locally.
 


### PR DESCRIPTION
## Summary

- Remove the outdated `scripts/get_analysis_projects.kts` reference from the contributor guide.
- Keep the existing `--run-rule RuleSet:RuleId` guidance, which remains supported by the CLI.
- PR #8698 removed the script because it no longer worked and was not being used or maintained; no replacement workflow was introduced there.

## Verification

- Confirmed the script is absent from the repository.
- Confirmed `--run-rule` remains implemented and covered by CLI tests.
- `git diff --check`
- `./gradlew detektMain detektTest --no-daemon --max-workers=2`
- No production code changed.

Closes #9629