### PR TITLE
Drop the unused detekt-psi-utils dependency from :detekt-report-complexity

### DIFF
--- a/detekt-report-complexity/build.gradle.kts
+++ b/detekt-report-complexity/build.gradle.kts
@@ -4,10 +4,8 @@ plugins {
 
 dependencies {
     compileOnly(projects.detektApi)
-    compileOnly(projects.detektPsiUtils)
     compileOnly(projects.detektMetrics)
 
-    testRuntimeOnly(projects.detektPsiUtils)
     testRuntimeOnly(projects.detektApi)
     testRuntimeOnly(projects.detektMetrics)
     testImplementation(projects.detektTest)


### PR DESCRIPTION
This is AI generated 👇

## What

`:detekt-report-complexity` declares `:detekt-psi-utils` twice — `compileOnly` and `testRuntimeOnly` — but never uses it. No source file in the module references `dev.detekt.psi` or any symbol from it (`AnnotationExcluder`, `FunctionMatcher`, `absolutePath`, `fullyQualifiedNameGlobToRegex`).

Both lines were in the build file from the moment the module was created in #9215 and were never needed.

`buildHealth` does not flag this: dependency-analysis does not report unused `compileOnly` declarations.

## Why it is worth a PR

Noticed while auditing psi-utils consumers for #7279.

#9347 (rename `detekt-psi-utils` to something clearer) is blocked on #7279, on the stated premise that *"detekt-core is the only module that has a dependency on detekt-psi-utils that shouldn't. Otherwise, only detekt-rules-* depend on it as expected."*

That premise had a second exception: this module. Removing it means the remaining consumers really are just the rule modules, which is the condition #9347 wants before renaming.

## Verification

- `:detekt-report-complexity:test` — 20 tests pass
- `:detekt-report-complexity:detektMain`, `:detekt-report-complexity:detektTest` — pass
- `buildHealth` — clean
- `psi-utils` confirmed absent from both `compileClasspath` and `testRuntimeClasspath` afterwards
- End-to-end through a built CLI, the complexity report still renders:

```
Complexity Report:
	- 6 lines of code (loc)
	- 4 source lines of code (sloc)
	- 2 logical lines of code (lloc)
	...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)