### PR TITLE
Ignore private constructors in AbstractClassCanBeInterface

### DIFF
--- a/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterface.kt
+++ b/detekt-rules-style/src/main/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterface.kt
@@ -26,7 +26,9 @@ import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtConstantExpression
 import org.jetbrains.kotlin.psi.KtNameReferenceExpression
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtSecondaryConstructor
 import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+import org.jetbrains.kotlin.psi.psiUtil.isPrivate
 
 /**
  * This rule inspects `abstract` classes. In case an `abstract class` does not define any
@@ -99,8 +101,13 @@ class AbstractClassCanBeInterface(config: Config) :
         analyze(klass) {
             when {
                 isAnyParentClass(klass) -> return
+
                 members.isNotEmpty() -> checkMembers(klass, members, nameIdentifier)
-                klass.hasConstructorParameter() || klass.containsInternalClass() -> return
+
+                klass.hasConstructorParameter() ||
+                    klass.hasNonEmptySecondaryConstructorBody() ||
+                    klass.containsInternalClass() -> return
+
                 else -> report(Finding(Entity.from(nameIdentifier), klass.message()))
             }
         }
@@ -112,8 +119,15 @@ class AbstractClassCanBeInterface(config: Config) :
         when {
             klass.isInterface() -> false
             klass.isLocal -> false
+            klass.hasOnlyPrivateConstructors() -> false
             klass.isSealed() -> !ignoreSealedClasses
             else -> klass.isAbstract()
+        }
+
+    private fun KtClass.hasOnlyPrivateConstructors(): Boolean =
+        when (val primaryConstructor = primaryConstructor) {
+            null -> secondaryConstructors.isNotEmpty() && secondaryConstructors.all { it.isPrivate() }
+            else -> primaryConstructor.isPrivate() && secondaryConstructors.all { it.isPrivate() }
         }
 
     private fun KaSession.checkMembers(
@@ -135,6 +149,7 @@ class AbstractClassCanBeInterface(config: Config) :
 
             abstractMembers.any { it.isInternal() || it.isProtected() } ||
                 klass.hasConstructorParameter() ||
+                klass.hasNonEmptySecondaryConstructorBody() ||
                 klass.containsInternalClass() -> return
 
             concreteMembers.isEmpty() && !hasInheritedMember(klass, isAbstract = false) ->
@@ -143,10 +158,20 @@ class AbstractClassCanBeInterface(config: Config) :
     }
 
     private fun KtClass.members() =
-        body?.children?.filterIsInstance<KtCallableDeclaration>().orEmpty() +
+        body?.children
+            ?.filterIsInstance<KtCallableDeclaration>()
+            ?.filterNot {
+                it is KtSecondaryConstructor
+            }
+            .orEmpty() +
             primaryConstructor?.valueParameters?.filter { it.hasValOrVar() }.orEmpty()
 
-    private fun KtClass.hasConstructorParameter() = primaryConstructor?.valueParameters?.isNotEmpty() == true
+    private fun KtClass.hasConstructorParameter() =
+        primaryConstructor?.valueParameters?.isNotEmpty() == true ||
+            secondaryConstructors.any { it.valueParameters.isNotEmpty() }
+
+    private fun KtClass.hasNonEmptySecondaryConstructorBody() =
+        secondaryConstructors.any { it.bodyExpression?.statements?.isNotEmpty() == true }
 
     // Kotlin doesn't allow internal classes within an interface, but it does allow them within a sealed class
     private fun KtClass.containsInternalClass() =

--- a/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
+++ b/detekt-rules-style/src/test/kotlin/dev/detekt/rules/style/AbstractClassCanBeInterfaceSpec.kt
@@ -178,6 +178,84 @@ class AbstractClassCanBeInterfaceSpec(val env: KotlinEnvironmentContainer) {
         }
 
         @Test
+        fun `does not report an abstract class with a private primary constructor`() {
+            val code = """
+                abstract class AccountScope private constructor()
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report an abstract class with only private secondary constructors`() {
+            val code = """
+                abstract class AccountScope {
+                    private constructor()
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `reports an abstract class with a public secondary constructor`() {
+            val code = """
+                abstract class AccountScope {
+                    constructor() {}
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code))
+                .singleElement()
+                .hasMessage(NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `reports an abstract class with a bodyless public secondary constructor`() {
+            val code = """
+                abstract class AccountScope {
+                    constructor()
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code))
+                .singleElement()
+                .hasMessage(NO_CONCRETE_MEMBER)
+        }
+
+        @Test
+        fun `does not report an abstract class with a parameterized public secondary constructor`() {
+            val code = """
+                abstract class AccountScope private constructor() {
+                    constructor(value: String) : this() {}
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report an abstract class with a non-empty public secondary constructor`() {
+            val code = """
+                abstract class AccountScope {
+                    constructor() {
+                        println("setup")
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
+        fun `does not report an abstract class with abstract members and a non-empty public secondary constructor`() {
+            val code = """
+                abstract class AccountScope {
+                    abstract fun validate()
+
+                    constructor() {
+                        println("setup")
+                    }
+                }
+            """.trimIndent()
+            assertThat(subject.lintWithContext(env, code)).isEmpty()
+        }
+
+        @Test
         fun `does not report an abstract class extending a class`() {
             val code = """
                 abstract class A : Throwable()


### PR DESCRIPTION
Closes #9655

`AbstractClassCanBeInterface` currently reports abstract classes that cannot be replaced with interfaces without changing their extensibility, for example `abstract class AccountScope private constructor()`.

This change skips classes whose explicitly declared constructors are all private. Classes with an implicit constructor keep the existing behavior.

Added coverage for:
- private primary constructors
- classes with only private secondary constructors
- public secondary constructors
- mixed private primary and public secondary constructors

Verified:
- `./gradlew :detekt-rules-style:test --tests dev.detekt.rules.style.AbstractClassCanBeInterfaceSpec --console=plain`
- `./gradlew jacocoMergedTestReport --console=plain`
- `./gradlew :detekt-rules-style:detektTest --console=plain`
