### PR TITLE
Minimum required Java version is now 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,10 @@ tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
         sarif.required.set(true) // standardized SARIF format (https://sarifweb.azurewebsites.net/) to support integrations with GitHub Code Scanning
         markdown.required.set(true) // simple Markdown format
     }
-    jvmTarget.set("1.8")
+    jvmTarget.set("17")
 }
 tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
-    jvmTarget.set("1.8")
+    jvmTarget.set("17")
 }
 ```
 
@@ -120,10 +120,10 @@ tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
         sarif.required.set(true) // standardized SARIF format (https://sarifweb.azurewebsites.net/) to support integrations with GitHub Code Scanning
         md.required.set(true) // simple Markdown format
     }
-    jvmTarget = "1.8"
+    jvmTarget = "17"
 }
 tasks.withType<io.gitlab.arturbosch.detekt.DetektCreateBaselineTask>().configureEach {
-    jvmTarget = "1.8"
+    jvmTarget = "17"
 }
 ```
 
@@ -142,6 +142,7 @@ The recommended versions together with the other tools recommended versions are:
 
 | Detekt Version  | Gradle   | Kotlin   | AGP      | Java Target Level | JDK Max Version |
 |-----------------|----------|----------|----------|-------------------|-----------------|
+| `2.0.0-alpha.7` | `9.6.1`  | `2.4.10` | `9.3.1`  | `17`              | `25`            |
 | `2.0.0-alpha.6` | `9.6.1`  | `2.4.10` | `9.3.1`  | `1.8`             | `25`            |
 | `2.0.0-alpha.5` | `9.5.1`  | `2.4.0`  | `9.2.1`  | `1.8`             | `25`            |
 | `2.0.0-alpha.3` | `9.3.1`  | `2.3.21` | `9.1.1`  | `1.8`             | `25`            |

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -81,36 +81,9 @@ testing {
     }
 }
 
-val jvmMajorVersion = 8
-
-// Pretend AGP API, JUnit and detekt-rules-ktlint-wrapper target JVM 8. Required while detekt itself targets JVM 8 and these dependencies target newer JVM versions.
-dependencies {
-    components {
-        setOf(
-            "com.android.tools.build:gradle-api",
-            "com.android.tools.build:gradle-common-api",
-            "org.junit.jupiter:junit-jupiter",
-            "org.junit.jupiter:junit-jupiter-api",
-            "org.junit.jupiter:junit-jupiter-engine",
-            "org.junit.jupiter:junit-jupiter-params",
-            "org.junit.platform:junit-platform-commons",
-            "org.junit.platform:junit-platform-engine",
-            "org.junit.platform:junit-platform-launcher",
-            "dev.detekt:detekt-rules-ktlint-wrapper",
-        ).forEach {
-            withModule(it) {
-                allVariants {
-                    attributes {
-                        attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, jvmMajorVersion)
-                    }
-                }
-            }
-        }
-    }
-}
-
 tapmoc {
-    java(jvmMajorVersion)
+    @Suppress("MagicNumber")
+    java(17)
 }
 
 java {

--- a/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
+++ b/detekt-cli/src/main/kotlin/dev/detekt/cli/CliArgs.kt
@@ -220,7 +220,7 @@ class CliArgs {
         description = "Target version of the generated JVM bytecode that was generated during " +
             "compilation and is now being used for type resolution"
     )
-    var jvmTarget: JvmTarget = JvmTarget.DEFAULT
+    var jvmTarget: JvmTarget = JvmTarget.JVM_17
 
     @Parameter(
         names = ["--jdk-home"],

--- a/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
+++ b/detekt-core/src/main/kotlin/dev/detekt/core/settings/EnvironmentAware.kt
@@ -75,7 +75,7 @@ internal class EnvironmentFacade(projectSpec: ProjectSpec, compilerSpec: Compile
 
             buildKtModuleProvider {
                 val targetPlatform =
-                    JvmPlatforms.jvmPlatformByTargetVersion(configuration.jvmTarget ?: JvmTarget.DEFAULT)
+                    JvmPlatforms.jvmPlatformByTargetVersion(configuration.jvmTarget ?: JvmTarget.JVM_17)
                 platform = targetPlatform
 
                 val jdk = configuration.jdkHome?.let { jdkHome ->

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -52,11 +52,6 @@ tasks.jar {
     )
 }
 
-tapmoc {
-    @Suppress("MagicNumber")
-    java(17)
-}
-
 tasks.named("generateConfig") {
     val ktlintVersion = libs.versions.ktlint
     inputs.property("ktlintVersion", ktlintVersion)

--- a/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/CompilerSpecBuilder.kt
+++ b/detekt-tooling/src/main/kotlin/dev/detekt/tooling/dsl/CompilerSpecBuilder.kt
@@ -6,7 +6,7 @@ import java.nio.file.Path
 @ProcessingModelDsl
 class CompilerSpecBuilder : Builder<CompilerSpec> {
 
-    var jvmTarget: String = "1.8"
+    var jvmTarget: String = "17"
     var languageVersion: String? = null
     var apiVersion: String? = null
     var classpath: List<Path> = emptyList()

--- a/website/docs/gettingstarted/gradle.mdx
+++ b/website/docs/gettingstarted/gradle.mdx
@@ -358,11 +358,11 @@ More information on type resolution are available on the [type resolution](type-
 
 ```groovy
 tasks.withType(dev.detekt.gradle.Detekt).configureEach {
-    jvmTarget = '1.8'
+    jvmTarget = '17'
     jdkHome.set(file('path/to/jdkHome'))
 }
 tasks.withType(dev.detekt.gradle.DetektCreateBaselineTask).configureEach {
-    jvmTarget = '1.8'
+    jvmTarget = '17'
     jdkHome.set(file('path/to/jdkHome'))
 }
 ```
@@ -371,11 +371,11 @@ tasks.withType(dev.detekt.gradle.DetektCreateBaselineTask).configureEach {
 
 ```kotlin
 tasks.withType<dev.detekt.gradle.Detekt>().configureEach {
-    jvmTarget.set("1.8")
+    jvmTarget.set("17")
     jdkHome.set(file("path/to/jdkHome"))
 }
 tasks.withType<dev.detekt.gradle.DetektCreateBaselineTask>().configureEach {
-    jvmTarget.set("1.8")
+    jvmTarget.set("17")
     jdkHome.set(file("path/to/jdkHome"))
 }
 ```

--- a/website/scripts/generate-docs.mjs
+++ b/website/scripts/generate-docs.mjs
@@ -1000,6 +1000,7 @@ function generateCliOptionsFile() {
     else if (/AnalysisMode\.(\w+)/.test(defaultExpr)) defaultValue = defaultExpr.match(/AnalysisMode\.(\w+)/)[1];
     else if (/FailureSeverity\.(\w+)/.test(defaultExpr)) defaultValue = defaultExpr.match(/FailureSeverity\.(\w+)/)[1];
     else if (/JvmTarget\.DEFAULT/.test(defaultExpr)) defaultValue = '1.8';
+    else if (/JvmTarget\.JVM_17/.test(defaultExpr)) defaultValue = '17';
 
     const possibleValues = POSSIBLE_VALUES[converter] ?? POSSIBLE_VALUES[fieldType] ?? null;
     const primaryName = names.find(n => n.startsWith('--')) ?? names[0];


### PR DESCRIPTION
Close #9634

I have some open questions on this PR. I'm opening it to make it easier to talk about it.

I'm using `tapmoc` to configure the java version. I used it in sarif4k and I think it is *really* good.

And I'm wondering if this change make us move our minimum supported gradle version to 9.0.0. The functional tests keep working so I'm not completely sure.