### PR TITLE
Use Tapmoc to maintain our compat versions

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `kotlin-dsl`
+    id("com.gradleup.tapmoc") version "0.4.2"
 }
 
 dependencies {
@@ -9,13 +10,15 @@ dependencies {
     implementation(libs.semver4j)
     implementation(libs.breadmoirai.githubRelease.plugin)
     implementation(libs.dokka.plugin)
+    implementation(libs.tapmoc.plugin)
 }
 
 kotlin {
-    @Suppress("MagicNumber")
-    jvmToolchain(17)
-
     compilerOptions {
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
     }
+}
+
+tapmoc {
+    gradle(gradle.gradleVersion)
 }

--- a/build-logic/src/main/kotlin/module.gradle.kts
+++ b/build-logic/src/main/kotlin/module.gradle.kts
@@ -2,13 +2,12 @@ import com.gradle.develocity.agent.gradle.test.DevelocityTestConfiguration
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 import org.jetbrains.kotlin.gradle.dsl.JvmDefaultMode
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.UsesKotlinJavaToolchain
 
 plugins {
     id("packaging")
     kotlin("jvm")
     id("jacoco")
+    id("com.gradleup.tapmoc")
 }
 
 val versionCatalog = versionCatalogs.named("libs")
@@ -56,12 +55,8 @@ tasks.withType<Test>().configureEach {
     }
 }
 
-val jvmTargetVersion = versionCatalog.findVersion("jvm-target").get().requiredVersion
-val jvmMajorVersion = jvmTargetVersion.toIntOrNull() ?: 8
-
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
         extraWarnings = true
         allWarningsAsErrors = providers.gradleProperty("warningsAsErrors").orNull.toBoolean()
         if (project.name != "detekt-gradle-plugin") {
@@ -78,20 +73,6 @@ kotlin {
     }
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
-    compilerOptions {
-        jvmTarget = JvmTarget.fromTarget(jvmTargetVersion)
-    }
-}
-
-val javaLauncher = javaToolchains.launcherFor {
-    languageVersion = JavaLanguageVersion.of(versionCatalog.findVersion("java-compile-toolchain").get().requiredVersion)
-}
-
-project.tasks.withType<UsesKotlinJavaToolchain>().configureEach {
-    kotlinJavaToolchain.toolchain.use(javaLauncher)
-}
-
 testing {
     suites {
         withType<JvmTestSuite> {
@@ -99,6 +80,8 @@ testing {
         }
     }
 }
+
+val jvmMajorVersion = 8
 
 // Pretend AGP API, JUnit and detekt-rules-ktlint-wrapper target JVM 8. Required while detekt itself targets JVM 8 and these dependencies target newer JVM versions.
 dependencies {
@@ -126,10 +109,12 @@ dependencies {
     }
 }
 
+tapmoc {
+    java(jvmMajorVersion)
+}
+
 java {
     withSourcesJar()
-    sourceCompatibility = JavaVersion.toVersion(jvmTargetVersion)
-    targetCompatibility = JavaVersion.toVersion(jvmTargetVersion)
     if (project.name !in setOf("detekt-gradle-plugin", "detekt-test-junit")) {
         // DGP uses different versions of kotlin-gradle-api in test runtime and compile time
         consistentResolution {

--- a/detekt-rules-ktlint-wrapper/build.gradle.kts
+++ b/detekt-rules-ktlint-wrapper/build.gradle.kts
@@ -52,21 +52,9 @@ tasks.jar {
     )
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
-    }
-}
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
+tapmoc {
+    @Suppress("MagicNumber")
+    java(17)
 }
 
 tasks.named("generateConfig") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,9 +7,6 @@ kotlin = "2.4.10"
 ktlint = "1.8.0"
 slf4j = "2.0.18"
 
-jvm-target = "1.8"
-java-compile-toolchain = "17"
-
 [libraries]
 # This version of AGP is used for testing and should be updated when new AGP versions are released to ensure detekt's
 # Gradle plugin remains compatible.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.grad
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 vanniktech-mavenPublish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.37.0" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+tapmoc-plugin = { module = "com.gradleup.tapmoc:com.gradleup.tapmoc.gradle.plugin", version = "0.4.2" }
 
 # This represents the oldest AGP 9 version that is supported by detekt.
 # This should only be updated when updating the minimum version supported by detekt's Gradle plugin.


### PR DESCRIPTION
This is a prerequisit for #9672

This plugin help us to Maintain the compat versions of java, kotlin and gradle.

The idea is to don't use the toolchain. They are a bad idea:
- https://jakewharton.com/gradle-toolchains-are-rarely-a-good-idea/
- https://youtu.be/2Vp2QeBZkfo?si=iBwbHzYvobqH1kYq&t=117

But with this we have a problem: Each of us (CI included) will compile with a different JVM and we will get a lot of miss to the remote cache.

I'm going to open a new PR for that using auto provisioned Daemon JVM. And there we can set the newest and shiniest versions of JVM without losing any compatibilty. (Done: #9681)