### PR TITLE
Use tapmoc in :detekt-gradle-plugin

### DIFF
--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -40,8 +40,6 @@ detekt {
 
 dokka {
     dokkaSourceSets.configureEach {
-        apiVersion = "1.4"
-
         externalDocumentationLinks {
             create("gradle") {
                 url("https://docs.gradle.org/current/javadoc/")
@@ -100,14 +98,7 @@ testing {
 }
 
 kotlin {
-    @OptIn(ExperimentalBuildToolsApi::class, ExperimentalKotlinGradlePluginApi::class)
-    compilerVersion = "2.1.21"
-
     compilerOptions {
-        // The apiVersion Gradle property cannot be used here, so set api version using free compiler args.
-        // https://youtrack.jetbrains.com/issue/KT-72247/KGP-Cannot-use-unsupported-API-version-with-compilerVersion-that-supports-it#focus=Comments-27-11050897.0-0
-        freeCompilerArgs.addAll("-language-version", "1.8")
-        freeCompilerArgs.addAll("-api-version", "1.7")
         // Suppress warning about deprecated API version. When DGP compiles with Kotlin 2.4 change this to suppress DEPRECATED_LANGUAGE_VERSION diagnostic (see KT-83765)
         freeCompilerArgs.add("-Xsuppress-version-warnings")
     }
@@ -286,6 +277,12 @@ tasks {
 with(components["java"] as AdhocComponentWithVariants) {
     withVariantsFromConfiguration(configurations["testFixturesApiElements"]) { skip() }
     withVariantsFromConfiguration(configurations["testFixturesRuntimeElements"]) { skip() }
+}
+
+tapmoc {
+    gradle(libs.gradle.publicApi.get().version!!)
+
+    checkDependencies()
 }
 
 dependencyAnalysis {


### PR DESCRIPTION
This breaks for multiple places right now so I'm going to keep this as a draft for now. I'll retake this job later and see how to fix it. Probably as soon as we drop support for gradle 8.x