### PR TITLE
[1/6][autoCorrect] Add marker interface

### DIFF
--- a/detekt-api/api/detekt-api.api
+++ b/detekt-api/api/detekt-api.api
@@ -6,6 +6,9 @@ public abstract interface annotation class dev/detekt/api/Alias : java/lang/anno
 	public abstract fun values ()[Ljava/lang/String;
 }
 
+public abstract interface class dev/detekt/api/AutoCorrectable {
+}
+
 public final class dev/detekt/api/AutocorrectKt {
 	public static final fun getModifiedText (Lorg/jetbrains/kotlin/psi/KtFile;)Ljava/lang/String;
 	public static final fun setModifiedText (Lorg/jetbrains/kotlin/psi/KtFile;Ljava/lang/String;)V

--- a/detekt-api/src/main/kotlin/dev/detekt/api/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/AutoCorrectable.kt
@@ -1,0 +1,6 @@
+package dev.detekt.api
+
+/**
+ * Marks a [Rule] which is able to correct the code it reports on.
+ */
+interface AutoCorrectable


### PR DESCRIPTION
Part 1 of the autoCorrect stack.

Adds the public `AutoCorrectable` marker interface and updates the ABI declaration. This commit does not change runtime behavior.

Testing:
- `./gradlew :detekt-api:checkKotlinAbi`

The next PR migrates the built-in correctable rules to this interface.