### PR TITLE
[4/6][autoCorrect] Prefer rule configuration over rule set

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Rule.kt
@@ -28,10 +28,19 @@ open class Rule(val config: Config, val description: String, val url: URI? = nul
 
     protected lateinit var languageVersionSettings: LanguageVersionSettings
 
+    /**
+     * Whether this rule should correct the code it reports on.
+     *
+     * Only rules implementing [AutoCorrectable] can correct anything. For capable rules, an
+     * `autoCorrect` value on the rule takes precedence over the value on its parent rule set.
+     */
     val autoCorrect: Boolean
         get() = this is AutoCorrectable &&
-            config.valueOrDefault(Config.AUTO_CORRECT_KEY, false) &&
-            (config.parent?.valueOrDefault(Config.AUTO_CORRECT_KEY, true) != false)
+            (
+                config.valueOrNull<Boolean>(Config.AUTO_CORRECT_KEY)
+                    ?: config.parent?.valueOrNull<Boolean>(Config.AUTO_CORRECT_KEY)
+                    ?: false
+                )
 
     private val findings: MutableList<Finding> = mutableListOf()
 

--- a/detekt-api/src/test/kotlin/dev/detekt/api/RuleSpec.kt
+++ b/detekt-api/src/test/kotlin/dev/detekt/api/RuleSpec.kt
@@ -13,14 +13,14 @@ class RuleSpec {
         "undefined, undefined, false",
         "undefined, true,      true",
         "undefined, false,     false",
-        "true,      undefined, false",
+        "true,      undefined, true",
         "true,      true,      true",
         "true,      false,     false",
         "false,     undefined, false",
-        "false,     true,      false",
+        "false,     true,      true",
         "false,     false,     false",
     )
-    fun `preserves autoCorrect configuration behavior for a capable rule`(
+    fun `resolves autoCorrect preferring the rule level over the rule set level`(
         ruleSetLevel: String,
         ruleLevel: String,
         expected: Boolean,

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
@@ -21,11 +21,11 @@ class AutoCorrectLevelSpec {
         "Undefined, Undefined, false",
         "Undefined, True,      true",
         "Undefined, False,     false",
-        "True,      Undefined, false",
+        "True,      Undefined, true",
         "True,      True,      true",
         "True,      False,     false",
         "False,     Undefined, false",
-        "False,     True,      false",
+        "False,     True,      true",
         "False,     False,     false",
     )
     fun autoCorrect(ruleSet: AutoCorrectConfig, rule: AutoCorrectConfig, wasFormatted: Boolean) {


### PR DESCRIPTION
Part 4 of the autoCorrect stack.

Depends on #9686.

Resolves `autoCorrect` in this order for capable rules:

1. Rule-level value
2. Ruleset-level value
3. `false`

This allows a rule-level opt-in to override a ruleset-level `false`. The fallback intentionally remains `false` here so the separate default behavior can be reviewed in the final PR.

Testing:
- API precedence truth table
- ktlint wrapper precedence truth table

The next PR removes generated rule-level values that currently mask this precedence.