### PR TITLE
[5/6][autoCorrect] Stop pinning correction per rule

### DIFF
--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/Rule.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/Rule.kt
@@ -9,7 +9,6 @@ data class Rule(
     var aliases: List<String>,
     val parent: String,
     val configurations: List<Configuration> = emptyList(),
-    val autoCorrect: Boolean = false,
     val requiresFullAnalysis: Boolean = false,
     val deprecationMessage: String? = null,
 ) {

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/RuleVisitor.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/collection/RuleVisitor.kt
@@ -2,7 +2,6 @@ package dev.detekt.generator.collection
 
 import dev.detekt.api.ActiveByDefault
 import dev.detekt.api.Alias
-import dev.detekt.api.AutoCorrectable
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.generator.collection.exception.InvalidDocumentationException
 import org.jetbrains.kotlin.psi.KtClass
@@ -20,14 +19,12 @@ internal class RuleVisitor : KtTreeVisitorVoid() {
     private var name = ""
     private val documentationCollector = DocumentationCollector()
     private var defaultActivationStatus: DefaultActivationStatus = Inactive
-    private var autoCorrect = false
     private var requiresFullAnalysis = false
     private var aliases: List<String> = emptyList()
     private var parent = ""
     private val configurationCollector = ConfigurationCollector()
     private val classesMap = mutableMapOf<String, Boolean>()
     private var deprecationMessage: String? = null
-    private val autoCorrectableInterface = AutoCorrectable::class.simpleName
     private val fullAnalysisInterface = RequiresAnalysisApi::class.simpleName
 
     fun getRule(): Rule {
@@ -46,7 +43,6 @@ internal class RuleVisitor : KtTreeVisitorVoid() {
             aliases = aliases,
             parent = parent,
             configurations = configurationsByAnnotation,
-            autoCorrect = autoCorrect,
             deprecationMessage = deprecationMessage,
             requiresFullAnalysis = requiresFullAnalysis
         )
@@ -95,8 +91,6 @@ internal class RuleVisitor : KtTreeVisitorVoid() {
             defaultActivationStatus = Active(since = activeByDefaultSinceValue)
         }
 
-        autoCorrect = classOrObject.superTypeListEntries
-            .any { it.text.substringAfterLast(".") == autoCorrectableInterface }
         requiresFullAnalysis = classOrObject.superTypeListEntries
             .any { it.text.substringAfterLast(".") == fullAnalysisInterface }
         deprecationMessage = classOrObject.firstAnnotationParameterOrNull(Deprecated::class)

--- a/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
+++ b/detekt-generator/src/main/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinter.kt
@@ -38,9 +38,6 @@ internal fun YamlNode.printRule(rule: Rule) {
         if (rule.aliases.isNotEmpty()) {
             keyValue { Config.ALIASES_KEY to "[${rule.aliases.joinToString(separator = ", ") { "'$it'" }}]" }
         }
-        if (rule.autoCorrect) {
-            keyValue { Config.AUTO_CORRECT_KEY to "true" }
-        }
         val ruleExclusion = exclusions.singleOrNull { it.isExcluded(rule) }
         if (ruleExclusion != null) {
             keyValue { Config.EXCLUDES_KEY to ruleExclusion.pattern }

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/collection/RuleCollectorSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/collection/RuleCollectorSpec.kt
@@ -140,19 +140,6 @@ class RuleCollectorSpec {
     }
 
     @Test
-    fun `is auto-correctable`() {
-        val code = """
-            /**
-             * description
-             *
-             */
-            class SomeRandomClass : Rule, AutoCorrectable
-        """.trimIndent()
-        val items = subject.run(code)
-        assertThat(items[0].autoCorrect).isTrue()
-    }
-
-    @Test
     fun `collects the issue property`() {
         val code = """
             /**

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/ConfigPrinterSpec.kt
@@ -34,7 +34,6 @@ class ConfigPrinterSpec {
                 active: false
               NoUnitKeyword:
                 active: true
-                autoCorrect: true
 
         """.trimIndent()
 

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/printer/defaultconfig/RuleSetConfigPrinterTest.kt
@@ -104,24 +104,6 @@ internal class RuleSetConfigPrinterTest {
         }
 
         @Nested
-        inner class AutoCorrect {
-
-            @Test
-            fun `has auto correct property`() {
-                val rule = ruleTemplate.copy(autoCorrect = true)
-                val actual = yaml { printRule(rule) }
-                assertThat(actual.lines()).contains("  autoCorrect: true")
-            }
-
-            @Test
-            fun `omits auto correct property if false`() {
-                val rule = ruleTemplate.copy(autoCorrect = false)
-                val actual = yaml { printRule(rule) }
-                assertThat(actual).doesNotContain(Config.AUTO_CORRECT_KEY)
-            }
-        }
-
-        @Nested
         inner class Exclusion {
 
             @Test

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/util/RuleSetPageCreator.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/util/RuleSetPageCreator.kt
@@ -93,7 +93,6 @@ internal fun createRules(): List<Rule> {
         aliases = emptyList(),
         parent = "",
         configurations = emptyList(),
-        autoCorrect = true,
         requiresFullAnalysis = true
     )
     val rule4 = Rule(

--- a/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
+++ b/detekt-rules-ktlint-wrapper/src/main/resources/config/config.yml
@@ -5,14 +5,11 @@ ktlint:
   autoCorrect: true
   AnnotationOnSeparateLine:
     active: true
-    autoCorrect: true
     indentSize: 4
   AnnotationSpacing:
     active: true
-    autoCorrect: true
   ArgumentListWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     ignoreRuleParameterThreshold: 8
@@ -20,134 +17,105 @@ ktlint:
     active: true
   BinaryExpressionWrapping:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     indentSize: 4
   BlankLineBeforeDeclaration:
     active: false
-    autoCorrect: true
   BlankLineBetweenWhenConditions:
     active: true
-    autoCorrect: true
     lineBreakAfterWhenEntries: true
   BlockCommentInitialStarAlignment:
     active: true
-    autoCorrect: true
   ChainMethodContinuation:
     active: false
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     forceMultilineWhenChainOperatorCountGreaterOrEqualThan: 4
   ChainWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   ClassName:
     active: false
   ClassSignature:
     active: true
-    autoCorrect: true
     forceMultilineWhenParameterCountGreaterOrEqualThan: 'unset'
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   CommentSpacing:
     active: true
-    autoCorrect: true
   CommentWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   ConditionWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   ContextReceiverListWrapping:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     indentSize: 4
   ContextReceiverMapping:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     indentSize: 4
   EnumEntryNameCase:
     active: true
     aliases: ['EnumEntryName']
-    autoCorrect: true
     enumEntryNameCasing: 'upper_or_camel_cases'
   EnumWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   ExpressionOperandWrapping:
     active: false
-    autoCorrect: true
     indentSize: 4
   Filename:
     active: true
   FinalNewline:
     active: true
-    autoCorrect: true
     insertFinalNewLine: true
   FunKeywordSpacing:
     active: true
-    autoCorrect: true
   FunctionExpressionBody:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   FunctionLiteral:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   FunctionName:
     active: false
   FunctionReturnTypeSpacing:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   FunctionSignature:
     active: true
-    autoCorrect: true
     forceMultilineWhenParameterCountGreaterOrEqualThan: 2147483647
     functionBodyExpressionWrapping: 'default'
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     indentSize: 4
   FunctionStartOfBodySpacing:
     active: true
-    autoCorrect: true
   FunctionTypeModifierSpacing:
     active: true
-    autoCorrect: true
   FunctionTypeReferenceSpacing:
     active: true
-    autoCorrect: true
   IfElseBracing:
     active: false
-    autoCorrect: true
     indentSize: 4
   IfElseWrapping:
     active: false
-    autoCorrect: true
     indentSize: 4
   ImportOrdering:
     active: true
-    autoCorrect: true
     # layout: If the 'code_style' ruleset property is set to 'android', the default is '*', otherwise '*,java.**,javax.**,kotlin.**,^'.
   Indentation:
     active: true
-    autoCorrect: true
     indentSize: 4
     indentWhenArrowOnNewLine: false
   Kdoc:
     active: true
   KdocWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   MaximumLineLength:
     active: true
@@ -158,95 +126,71 @@ ktlint:
     active: true
   ModifierListSpacing:
     active: true
-    autoCorrect: true
     indentSize: 4
   ModifierOrdering:
     active: true
-    autoCorrect: true
   MultiLineIfElse:
     active: true
-    autoCorrect: true
     indentSize: 4
   MultilineExpressionWrapping:
     active: false
-    autoCorrect: true
     indentSize: 4
     functionBodyExpressionWrapping: 'multiline'
   MultilineLoop:
     active: true
-    autoCorrect: true
     indentSize: 4
   NoBlankLineBeforeRbrace:
     active: true
-    autoCorrect: true
   NoBlankLineInList:
     active: false
-    autoCorrect: true
   NoBlankLinesInChainedMethodCalls:
     active: true
-    autoCorrect: true
   NoConsecutiveBlankLines:
     active: true
-    autoCorrect: true
   NoConsecutiveComments:
     active: false
   NoEmptyClassBody:
     active: true
-    autoCorrect: true
   NoEmptyFile:
     active: true
   NoEmptyFirstLineInClassBody:
     active: false
-    autoCorrect: true
     indentSize: 4
   NoEmptyFirstLineInMethodBlock:
     active: true
-    autoCorrect: true
   NoLineBreakAfterElse:
     active: true
-    autoCorrect: true
   NoLineBreakBeforeAssignment:
     active: true
-    autoCorrect: true
   NoMultipleSpaces:
     active: true
-    autoCorrect: true
   NoSemicolons:
     active: true
-    autoCorrect: true
   NoSingleLineBlockComment:
     active: false
-    autoCorrect: true
     indentSize: 4
   NoTrailingSpaces:
     active: true
-    autoCorrect: true
   NoUnitReturn:
     active: true
-    autoCorrect: true
   NoUnusedImports:
     active: true
-    autoCorrect: true
   NoWildcardImports:
     active: true
     packagesToUseImportOnDemandProperty: 'java.util.*,kotlinx.android.synthetic.**'
   NullableTypeSpacing:
     active: true
-    autoCorrect: true
   PackageName:
     active: true
   ParameterListSpacing:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   ParameterListWrapping:
     active: true
-    autoCorrect: true
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
     indentSize: 4
   ParameterWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   PropertyName:
@@ -254,106 +198,78 @@ ktlint:
     constantNamingStyle: 'screaming_snake_case'
   PropertyWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.
   SpacingAroundAngleBrackets:
     active: true
-    autoCorrect: true
   SpacingAroundColon:
     active: true
-    autoCorrect: true
   SpacingAroundComma:
     active: true
-    autoCorrect: true
   SpacingAroundCurly:
     active: true
-    autoCorrect: true
     indentSize: 4
   SpacingAroundDot:
     active: true
-    autoCorrect: true
   SpacingAroundDoubleColon:
     active: true
-    autoCorrect: true
   SpacingAroundKeyword:
     active: true
-    autoCorrect: true
   SpacingAroundOperators:
     active: true
-    autoCorrect: true
   SpacingAroundParens:
     active: true
-    autoCorrect: true
   SpacingAroundRangeOperator:
     active: true
-    autoCorrect: true
   SpacingAroundSquareBrackets:
     active: true
-    autoCorrect: true
   SpacingAroundUnaryOperator:
     active: true
-    autoCorrect: true
   SpacingBetweenDeclarationsWithAnnotations:
     active: true
-    autoCorrect: true
   SpacingBetweenDeclarationsWithComments:
     active: true
-    autoCorrect: true
   SpacingBetweenFunctionNameAndOpeningParenthesis:
     active: true
-    autoCorrect: true
   StatementWrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
   StringTemplate:
     active: true
-    autoCorrect: true
   StringTemplateIndent:
     active: false
-    autoCorrect: true
     indentSize: 4
   ThenSpacing:
     active: true
-    autoCorrect: true
   TrailingCommaOnCallSite:
     active: true
-    autoCorrect: true
     # useTrailingCommaOnCallSite: If the 'code_style' ruleset property is set to 'android', the default is 'false', otherwise 'true'.
   TrailingCommaOnDeclarationSite:
     active: true
-    autoCorrect: true
     # useTrailingCommaOnDeclarationSite: If the 'code_style' ruleset property is set to 'android', the default is 'false', otherwise 'true'.
   TryCatchFinallySpacing:
     active: false
-    autoCorrect: true
     indentSize: 4
   TypeArgumentComment:
     active: true
   TypeArgumentListSpacing:
     active: true
-    autoCorrect: true
     indentSize: 4
   TypeParameterComment:
     active: true
   TypeParameterListSpacing:
     active: true
-    autoCorrect: true
     indentSize: 4
   UnnecessaryParenthesesBeforeTrailingLambda:
     active: true
-    autoCorrect: true
   ValueArgumentComment:
     active: true
   ValueParameterComment:
     active: true
   WhenEntryBracing:
     active: false
-    autoCorrect: true
     indentSize: 4
   Wrapping:
     active: true
-    autoCorrect: true
     indentSize: 4
     # maxLineLength: If the 'code_style' ruleset property is set to 'android', the default is '100', otherwise '120'.

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/DefaultConfigSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/DefaultConfigSpec.kt
@@ -1,0 +1,27 @@
+package dev.detekt.rules.ktlintwrapper
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DefaultConfigSpec {
+
+    private val defaultConfig =
+        checkNotNull(KtlintWrapperProvider::class.java.getResource("/config/config.yml")) {
+            "The bundled default config is missing"
+        }.readText()
+
+    /**
+     * Declaring `autoCorrect` on every single rule makes it impossible to turn correction off for a
+     * whole rule set: once the user config is merged with the default one, the rule level values win
+     * and the user's `ktlint: autoCorrect: false` is unreachable. See #1466.
+     *
+     * Which rules are able to correct is decided at runtime by [dev.detekt.api.AutoCorrectable]
+     * instead, so the default config only carries the rule set level switch.
+     */
+    @Test
+    fun `declares autoCorrect only at the rule set level`() {
+        val declarations = defaultConfig.lines().filter { "autoCorrect:" in it }
+
+        assertThat(declarations).containsExactly("  autoCorrect: true")
+    }
+}

--- a/website/docs/introduction/configurations.mdx
+++ b/website/docs/introduction/configurations.mdx
@@ -98,6 +98,35 @@ The severity will be computed in the priority order:
 - Severity of the parent ruleset if exists
 - Default severity: error
 
+### Auto correction
+
+Some rules are able to correct the code they report on. Correction is off unless you run _detekt_ with
+`--auto-correct` (or set `autoCorrect` on the Gradle extension or task) - that flag is the master switch and
+nothing in the config file can turn correction on without it.
+
+With the flag on, you may narrow down which rules correct by setting `autoCorrect` at the rule or ruleset level:
+
+```yaml
+ktlint:
+    active: true
+    autoCorrect: false
+    ImportOrdering:
+        active: true
+        autoCorrect: true
+```
+
+Whether a rule corrects will be computed in the priority order:
+
+- `autoCorrect` of the rule if exists
+- `autoCorrect` of the parent ruleset if exists
+- Default: `false`
+
+The example above therefore corrects import ordering and nothing else. Note that the rule level value wins, so a
+ruleset level `autoCorrect: false` acts as a default for the ruleset rather than a veto over it.
+
+Rules which are not able to correct anything are never affected by this setting. Setting `autoCorrect` on such a
+rule has no effect, and _detekt_ will warn you about it rather than silently ignoring it.
+
 ### Aliases
 
 Each rule can have a list of aliases. Those aliases will be used as new identifiers for that rule so they can be used


### PR DESCRIPTION
Part 5 of the autoCorrect stack.

Depends on #9687.

Stops the default-config generator from emitting `autoCorrect: true` on every capable rule. Those generated rule-level values override a user-defined ruleset value after configuration merging, making a ruleset-level `false` ineffective.

Capability is now determined at runtime through `AutoCorrectable`, so the bundled configuration only needs the ruleset-level switch. This completes the configuration precedence fix for #1466 while retaining a default of `false` when no value exists.

Testing:
- Generator tests
- Bundled default-config regression test
- ktlint wrapper precedence tests

The final PR separately changes the unconfigured fallback.

Fixes #1466