### PR TITLE
[6/6][autoCorrect] Enable capable rules by default

### DIFF
--- a/detekt-api/src/main/kotlin/dev/detekt/api/AutoCorrectable.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/AutoCorrectable.kt
@@ -2,5 +2,10 @@ package dev.detekt.api
 
 /**
  * Marks a [Rule] which is able to correct the code it reports on.
+ *
+ * Only rules implementing this interface can be auto-corrected: for every other rule
+ * [Rule.autoCorrect] is always `false`, regardless of configuration. This allows detekt to
+ * tell apart "this rule was asked to correct" from "this rule is able to correct", and to
+ * warn about configuration which would otherwise silently do nothing.
  */
 interface AutoCorrectable

--- a/detekt-api/src/main/kotlin/dev/detekt/api/Rule.kt
+++ b/detekt-api/src/main/kotlin/dev/detekt/api/Rule.kt
@@ -31,15 +31,21 @@ open class Rule(val config: Config, val description: String, val url: URI? = nul
     /**
      * Whether this rule should correct the code it reports on.
      *
-     * Only rules implementing [AutoCorrectable] can correct anything. For capable rules, an
-     * `autoCorrect` value on the rule takes precedence over the value on its parent rule set.
+     * Only rules implementing [AutoCorrectable] can correct anything, so for every other rule this
+     * is always `false`. For those that can, the value is resolved in priority order:
+     * - the `autoCorrect` property of the rule
+     * - the `autoCorrect` property of the parent rule set
+     * - `true`, as a rule which is able to correct is expected to do so
+     *
+     * The `--auto-correct` CLI flag (and its Gradle counterpart) remains the master switch: when it
+     * is off, detekt forces `autoCorrect` to `false` for every rule regardless of configuration.
      */
     val autoCorrect: Boolean
         get() = this is AutoCorrectable &&
             (
                 config.valueOrNull<Boolean>(Config.AUTO_CORRECT_KEY)
                     ?: config.parent?.valueOrNull<Boolean>(Config.AUTO_CORRECT_KEY)
-                    ?: false
+                    ?: true
                 )
 
     private val findings: MutableList<Finding> = mutableListOf()

--- a/detekt-api/src/test/kotlin/dev/detekt/api/RuleSpec.kt
+++ b/detekt-api/src/test/kotlin/dev/detekt/api/RuleSpec.kt
@@ -10,7 +10,7 @@ class RuleSpec {
 
     @ParameterizedTest(name = "rule set: {0}, rule: {1} -> {2}")
     @CsvSource(
-        "undefined, undefined, false",
+        "undefined, undefined, true",
         "undefined, true,      true",
         "undefined, false,     false",
         "true,      undefined, true",

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/AutoCorrectLevelSpec.kt
@@ -18,7 +18,7 @@ class AutoCorrectLevelSpec {
 
     @ParameterizedTest
     @CsvSource(
-        "Undefined, Undefined, false",
+        "Undefined, Undefined, true",
         "Undefined, True,      true",
         "Undefined, False,     false",
         "True,      Undefined, true",

--- a/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/NoUnusedImportsSpec.kt
+++ b/detekt-rules-ktlint-wrapper/src/test/kotlin/dev/detekt/rules/ktlintwrapper/NoUnusedImportsSpec.kt
@@ -2,6 +2,7 @@ package dev.detekt.rules.ktlintwrapper
 
 import dev.detekt.api.Config
 import dev.detekt.rules.ktlintwrapper.wrappers.NoUnusedImports
+import dev.detekt.test.TestConfig
 import dev.detekt.test.assertj.assertThat
 import dev.detekt.test.lint
 import org.junit.jupiter.api.Test
@@ -27,7 +28,8 @@ class NoUnusedImportsSpec {
             fun f() = 5
         """.trimIndent()
 
-        val findings = NoUnusedImports(Config.empty).lint(code)
+        // autoCorrect is off so that the reported locations are not shifted by the correction itself
+        val findings = NoUnusedImports(TestConfig(Config.AUTO_CORRECT_KEY to false)).lint(code)
 
         assertThat(findings).satisfiesExactlyInAnyOrder(
             { assertThat(it).hasStartSourceLocation(3, 1) },

--- a/website/docs/introduction/configurations.mdx
+++ b/website/docs/introduction/configurations.mdx
@@ -119,7 +119,7 @@ Whether a rule corrects will be computed in the priority order:
 
 - `autoCorrect` of the rule if exists
 - `autoCorrect` of the parent ruleset if exists
-- Default: `false`
+- Default: `true`
 
 The example above therefore corrects import ordering and nothing else. Note that the rule level value wins, so a
 ruleset level `autoCorrect: false` acts as a default for the ruleset rather than a veto over it.


### PR DESCRIPTION
Part 6 of the autoCorrect stack.

Depends on #9688.

Changes the fallback for a capable rule with no rule-level or ruleset-level `autoCorrect` value from `false` to `true`. The CLI or Gradle auto-correct option remains the master switch, so configuration cannot enable correction unless that global option is active.

This allows correction to work without building upon the default configuration and addresses #7333. Keeping this change separate makes the `unset` behavior independently reviewable from the #1466 precedence fix.

Testing:
- API precedence truth table
- ktlint wrapper precedence truth table
- Updated correction-sensitive regression test
- Relevant API, core, generator, and ktlint-wrapper test suites

Fixes #7333