### PR TITLE
Tasks to run the tests in different JVMs

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -40,13 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest ]
-        jdk: [ 17, 21, 25 ]
-        include:
-          - os: windows-latest
-            jdk: 25
-          - os: macos-latest
-            jdk: 25
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repo
@@ -55,7 +49,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6
         with:
-          java-version: ${{ matrix.jdk }}
+          java-version: 25
           distribution: 'temurin'
           verify-signature: true
 

--- a/build-logic/src/main/kotlin/dev/detekt/buildlogic/Utils.kt
+++ b/build-logic/src/main/kotlin/dev/detekt/buildlogic/Utils.kt
@@ -1,7 +1,15 @@
 package dev.detekt.buildlogic
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.testing.Test
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.register
+import org.gradle.language.base.plugins.LifecycleBasePlugin
 
 private val operativeSystem: String = when {
     Os.isFamily(Os.FAMILY_WINDOWS) -> Os.FAMILY_WINDOWS
@@ -12,4 +20,48 @@ private val operativeSystem: String = when {
 
 fun Task.osDependent() {
     inputs.property("os.name", operativeSystem)
+}
+
+fun Project.testInMultipleJvms(testName: String, @Suppress("MagicNumber") jvms: List<Int> = listOf(17, 21, 25)) {
+    if (jvms.isEmpty()) return
+
+    val testSourceSet = extensions.getByType<SourceSetContainer>().getByName(testName)
+    val isCiBuild = providers.environmentVariable("CI")
+
+    jvms.dropLast(1).forEach { jvm ->
+        val testTask = tasks.register<Test>("${testName}Jvm$jvm") {
+            description = "Runs the test suite (JVM $jvm)."
+            group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+            testClassesDirs = testSourceSet.output.classesDirs
+            classpath = testSourceSet.runtimeClasspath
+
+            useJUnitPlatform()
+
+            configureJavaLauncher(jvm)
+        }
+
+        if (isCiBuild.isPresent) {
+            tasks.named("check") { dependsOn(testTask) }
+        }
+    }
+
+    val jvm = jvms.last()
+
+    val defaultTestTask = tasks.named(testName, Test::class.java) {
+        configureJavaLauncher(jvm)
+    }
+    tasks.register("${testName}Jvm$jvm") {
+        description = "Runs the test suite (JVM $jvm) — alias of $testName."
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+
+        dependsOn(defaultTestTask)
+    }
+}
+
+private fun Test.configureJavaLauncher(jvmVersion: Int) {
+    javaLauncher.set(
+        project.extensions.getByType<JavaToolchainService>()
+            .launcherFor { languageVersion.set(JavaLanguageVersion.of(jvmVersion)) }
+    )
 }

--- a/detekt-cli/build.gradle.kts
+++ b/detekt-cli/build.gradle.kts
@@ -86,17 +86,33 @@ tasks {
         args = listOf("--help")
     }
 
-    val runWithArgsFile = register<JavaExec>("runWithArgsFile") {
-        // The task generating these jar files run first.
-        inputs.files(pluginsJarFiles)
-        doNotTrackState("The entire root directory is read as the input source.")
-        classpath = files(shadowJar)
-        workingDir = rootDir
-        args = listOf(
-            "@./config/detekt/argsfile",
-            "-p",
-            pluginsJarFiles.get().files.joinToString(File.pathSeparator) { it.path },
-        )
+    val isCiBuild = providers.environmentVariable("CI")
+    val jvms = listOf(null, 17, 21, 25)
+
+    jvms.forEach { jvm ->
+        val runWithArgsFile = register<JavaExec>(if (jvm == null) "runWithArgsFile" else "runWithArgsFileJvm$jvm") {
+            // The task generating these jar files run first.
+            inputs.files(pluginsJarFiles)
+            doNotTrackState("The entire root directory is read as the input source.")
+            classpath = files(shadowJar)
+            workingDir = rootDir
+            args = listOf(
+                "@./config/detekt/argsfile",
+                "-p",
+                pluginsJarFiles.get().files.joinToString(File.pathSeparator) { it.path },
+            )
+            if (jvm != null) {
+                javaLauncher.set(
+                    project.extensions.getByType<JavaToolchainService>().launcherFor {
+                        languageVersion.set(JavaLanguageVersion.of(jvm))
+                    }
+                )
+            }
+        }
+
+        if ((jvm == null) xor isCiBuild.isPresent) {
+            check { dependsOn(runWithArgsFile) }
+        }
     }
 
     withType<Jar>().configureEach {
@@ -106,9 +122,7 @@ tasks {
         }
     }
 
-    check {
-        dependsOn(runWithHelpFlag, runWithArgsFile)
-    }
+    check { dependsOn(runWithHelpFlag) }
 }
 
 val shadowDist = configurations.consumable("shadowDist")

--- a/detekt-gradle-plugin/build.gradle.kts
+++ b/detekt-gradle-plugin/build.gradle.kts
@@ -3,6 +3,7 @@
 @file:Suppress("StringLiteralDuplication")
 
 import dev.detekt.buildlogic.osDependent
+import dev.detekt.buildlogic.testInMultipleJvms
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.DetektCreateBaselineTask
 import org.gradle.plugin.compatibility.compatibility
@@ -305,3 +306,6 @@ dependencyAnalysis {
         }
     }
 }
+
+testInMultipleJvms("functionalTest")
+testInMultipleJvms("functionalTestMinSupportedGradle")


### PR DESCRIPTION
I used tasks instead of test suites (as recommended by @3flex [here](https://github.com/detekt/detekt/pull/9681#issuecomment-5478669240)) because it looks easier. If test suites are better I can change it.

This PR also makes 4 variants of `runWithArgsFile` oen that uses the local jvm and other 3 that uses the ones that we use in CI.

In both cases I only link to `check` the 3 jvm tasks when we are in CI.

This way we don't need the jvm matrix anymore in our pre-merge workflow.

