### PR TITLE
Replace unmaintained BreadMoirai GitHub release plugin

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -7,7 +7,8 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.vanniktech.mavenPublish.plugin)
     implementation(libs.semver4j)
-    implementation(libs.breadmoirai.githubRelease.plugin)
+    implementation(libs.github.api)
+    implementation(platform(libs.jackson.bom))
     implementation(libs.dokka.plugin)
 }
 

--- a/build-logic/src/main/kotlin/GithubReleaseTask.kt
+++ b/build-logic/src/main/kotlin/GithubReleaseTask.kt
@@ -1,0 +1,103 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import org.kohsuke.github.GitHub
+import java.io.File
+
+@DisableCachingByDefault(because = "Creates GitHub releases through an external API")
+abstract class GithubReleaseTask : DefaultTask() {
+
+    @get:Internal
+    abstract val token: Property<String>
+
+    @get:Input
+    abstract val owner: Property<String>
+
+    @get:Input
+    abstract val repositoryName: Property<String>
+
+    @get:Input
+    abstract val tagName: Property<String>
+
+    @get:Input
+    abstract val releaseName: Property<String>
+
+    @get:Input
+    abstract val body: Property<String>
+
+    @get:Input
+    abstract val targetCommitish: Property<String>
+
+    @get:Input
+    abstract val prerelease: Property<Boolean>
+
+    @get:InputFiles
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    abstract val releaseAssets: ConfigurableFileCollection
+
+    @TaskAction
+    fun release() {
+        val githubToken = token.get()
+        require(githubToken.isNotBlank()) { "GitHub token must not be blank" }
+
+        val repositoryOwner = owner.get()
+        require(repositoryOwner.isNotBlank()) { "GitHub repository owner must not be blank" }
+        val repository = repositoryName.get()
+        require(repository.isNotBlank()) { "GitHub repository name must not be blank" }
+        val releaseTag = tagName.get()
+        require(releaseTag.isNotBlank()) { "GitHub release tag must not be blank" }
+        val releaseTitle = releaseName.get()
+        require(releaseTitle.isNotBlank()) { "GitHub release name must not be blank" }
+        val releaseBody = body.get()
+        val targetRef = targetCommitish.get()
+        require(targetRef.isNotBlank()) { "GitHub target commitish must not be blank" }
+        val isPrerelease = prerelease.get()
+
+        val assetFiles = releaseAssets.files.sortedBy { it.name }
+        require(assetFiles.isNotEmpty()) { "At least one release asset is required" }
+        val duplicateAssetsByName = assetFiles
+            .groupBy { it.name }
+            .filterValues { files -> files.size > 1 }
+            .toSortedMap()
+        require(duplicateAssetsByName.isEmpty()) {
+            duplicateAssetsByName.entries.joinToString(
+                prefix = "Release asset names must be unique; duplicates: ",
+                separator = "; ",
+            ) { (name, files) -> "$name (${files.joinToString { it.absolutePath }})" }
+        }
+        val assets = assetFiles.map { asset ->
+            require(asset.isFile) { "Release asset does not exist: $asset" }
+            require(asset.length() > 0) { "Release asset is empty: $asset" }
+            asset to asset.contentType()
+        }
+
+        val github = GitHub.connectUsingOAuth(githubToken)
+        val githubRepository = github.getRepository("$repositoryOwner/$repository")
+        githubRepository.getReleaseByTagName(releaseTag)?.delete()
+
+        val release = githubRepository.createRelease(releaseTag)
+            .name(releaseTitle)
+            .body(releaseBody)
+            .commitish(targetRef)
+            .prerelease(isPrerelease)
+            .draft(true)
+            .create()
+
+        assets.forEach { (asset, contentType) -> release.uploadAsset(asset, contentType) }
+        release.update().draft(false).update()
+    }
+
+    private fun File.contentType(): String =
+        when (extension.lowercase()) {
+            "jar" -> "application/java-archive"
+            "zip" -> "application/zip"
+            else -> error("Unsupported release asset type: $name")
+        }
+}

--- a/build-logic/src/main/kotlin/releasing.gradle.kts
+++ b/build-logic/src/main/kotlin/releasing.gradle.kts
@@ -1,24 +1,8 @@
 import org.semver4j.Semver
 
-plugins {
-    id("com.github.breadmoirai.github-release")
-}
-
 val releaseArtifacts = configurations.dependencyScope("releaseArtifacts")
 val releaseAssetFiles = configurations.resolvable("releaseAssetFiles") {
     extendsFrom(releaseArtifacts)
-}
-
-githubRelease {
-    token(providers.gradleProperty("github.token"))
-    owner = "detekt"
-    repo = "detekt"
-    overwrite = true
-    dryRun = false
-    prerelease = true
-    targetCommitish = "main"
-    body = "Detekt Release Body"
-    releaseAssets.setFrom(releaseAssetFiles)
 }
 
 dependencies {
@@ -43,6 +27,23 @@ dependencies {
         targetConfiguration = Dependency.DEFAULT_CONFIGURATION
         isTransitive = false
     }
+}
+
+val releaseTag = providers.provider { "v${project.version}" }
+
+tasks.register<GithubReleaseTask>("githubRelease") {
+    group = "publishing"
+    description = "Creates the GitHub release"
+
+    token.set(providers.gradleProperty("github.token"))
+    owner.set("detekt")
+    repositoryName.set("detekt")
+    tagName.set(releaseTag)
+    releaseName.set(releaseTag)
+    targetCommitish.set("main")
+    body.set("Detekt Release Body")
+    prerelease.set(true)
+    releaseAssets.from(releaseAssetFiles)
 }
 
 fun updateVersion(increment: (Semver) -> Semver) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ java-compile-toolchain = "17"
 # Gradle plugin remains compatible.
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 android-gradle-builtInKotlin-plugin = { module = "com.android.built-in-kotlin:com.android.built-in-kotlin.gradle.plugin", version.ref = "agp" }
-breadmoirai-githubRelease-plugin = { module = "com.github.breadmoirai:github-release", version = "2.5.2" }
 develocity-plugin = { module = "com.gradle.develocity:com.gradle.develocity.gradle.plugin", version = "4.5.0" }
 dokka-plugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version = "2.2.0" }
 vanniktech-mavenPublish-plugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.37.0" }
@@ -31,6 +30,8 @@ android-gradleApi = { module = "com.android.tools.build:gradle-api", version = "
 # This should be set to the oldest Gradle version supported by KGP, but 8.14.3 is the earliest published Gradle API, so
 # we need to be on a newer version until KGP minimum version gets bumped higher (https://youtrack.jetbrains.com/issue/KT-84114)
 gradle-publicApi = { module = "org.gradle.experimental:gradle-public-api", version = "8.14.3" }
+github-api = { module = "org.kohsuke:github-api", version = "1.330" }
+jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version = "2.22.2" }
 
 # This represents the oldest JUnit version supported by detekt-test-junit.
 # This should only be updated when updating the minimum version supported by detekt-test-junit.


### PR DESCRIPTION
Closes #9668 

BreadMoirai provides the `githubRelease` task called by `scripts/release.sh`, so removing the dependency alone would break the release script. This replaces it with a Gradle task using hub4j. The implementation for the task is in `GithubReleaseTask.kt` while the same release configuration as before this change remains in `releasing.gradle.kts`.

Detekt already uses hub4j 1.330 in its milestone report script. hub4j pulls in Jackson 2.20.0, which is affected by [GHSA-wjgm-6hv5-3cvf](https://github.com/FasterXML/jackson-databind/security/advisories/GHSA-wjgm-6hv5-3cvf), so I used Jackson 2.22.2 BOM instead.

## Testing

I tried to do a local simulation of `githubRelease`, a script that replaced the github action with local checks:

```
> Task :githubRelease
repository=detekt/detekt
tag=v2.0.0-alpha.6
target=main
prerelease=true
assets=6
- detekt-cli-2.0.0-alpha.6-all.jar
- detekt-cli-2.0.0-alpha.6.zip
- detekt-generator-2.0.0-alpha.6-all.jar
- detekt-rules-ktlint-wrapper-2.0.0-alpha.6.jar
- detekt-rules-libraries-2.0.0-alpha.6.jar
- detekt-rules-ruleauthors-2.0.0-alpha.6.jar

BUILD SUCCESSFUL in 25s
110 actionable tasks: 1 executed, 109 up-to-date
```

It checked that all six files existed, weren't empty, had unique names, and used `.jar` or `.zip`. 

Also passed:
- confirmed `BreadMoirai` dependency was removed
- `publishToMavenLocal`
- `build -x dokkaGenerate`
- `detektMain` `detektTest` `detektFunctionalTest`  `detektTestFixtures`