### PR TITLE
Remove dependency from root build task to DGP build task

### DIFF
--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -70,6 +70,9 @@ jobs:
       - name: Build detekt
         run: ./gradlew build -x detekt
 
+      - name: Build detekt-gradle-plugin
+        run: ./gradlew -pdetekt-gradle-plugin build -x detekt
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: heap-dump

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,4 +89,9 @@ setOf(
     }
 }
 
-tasks.build { dependsOn(gradle.includedBuild("detekt-gradle-plugin").task(":build")) }
+tasks.build {
+    logger.warn(
+        "Executing `build` task from root build will not build the Gradle plugin. " +
+            "Use `/gradlew -pdetekt-gradle-plugin check`"
+    )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,6 @@ setOf(
 tasks.build {
     logger.warn(
         "Executing `build` task from root build will not build the Gradle plugin. " +
-            "Use `/gradlew -pdetekt-gradle-plugin check`"
+            "Use `./gradlew -pdetekt-gradle-plugin build`"
     )
 }

--- a/detekt-gradle-plugin/gradle.properties
+++ b/detekt-gradle-plugin/gradle.properties
@@ -1,4 +1,7 @@
 kotlin.stdlib.default.dependency=false
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.kotlin.dsl.allWarningsAsErrors=true
 org.gradle.warning.mode=fail
 dependency.analysis.print.build.health=true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,7 @@
 set -e
 gradle publishToMavenLocal
 gradle build
+gradle -pdetekt-gradle-plugin build
 # Uploads artifacts to Central Portal. After all steps complete, release manually at
 # https://central.sonatype.com/publishing — or replace with publishAndReleaseToMavenCentral to release automatically.
 # --no-configuration-cache is required due to a vanniktech bug with MavenCentralBuildService serialization:


### PR DESCRIPTION
I also enabled the parallelization and configuration cache on `:detekt-gradle-plugin` because now that we execute with `-p` it matters.

#9694 talks about a warning but I'm not sure were to put it.

Close #9694

