### PR TITLE
Disable linguist-detectable for website dir

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,9 @@
 *.html          diff=html
 *.md            diff=markdown
 
+# Exclude old docs from being counted as code.
+website/** linguist-detectable=false
+
 *.jar           binary
 *.png           binary
 *.otf           binary


### PR DESCRIPTION
Before:

<img width="600" height="150" alt="image" src="https://github.com/user-attachments/assets/6e130a26-5477-42f7-aacd-4e158cbfe06c" />

After:

<img width="600" height="109" alt="image" src="https://github.com/user-attachments/assets/9e3db1ee-f458-43c7-981f-3c2355a5ea20" />

Detekt is a **Kotlin** project!