### PR TITLE
Assert usage text for -h and --help flags

### DIFF
--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/CliArgsSpec.kt
@@ -332,10 +332,13 @@ internal class CliArgsSpec {
             }
         }
 
-        @Test
-        fun `throws HelpRequest on --help`() {
-            assertThatExceptionOfType(HelpRequest::class.java)
-                .isThrownBy { parseArguments(arrayOf("--help")) }
+        @ParameterizedTest
+        @ValueSource(strings = ["-h", "--help"])
+        fun `throws HelpRequest on help flag`(helpFlag: String) {
+            assertThatThrownBy { parseArguments(arrayOf(helpFlag)) }
+                .isInstanceOf(HelpRequest::class.java)
+                .extracting { (it as HelpRequest).usageText.trim() }
+                .isEqualTo(expectedHelp)
         }
     }
 
@@ -534,3 +537,114 @@ internal class CliArgsSpec {
 }
 
 private fun CliArgs.toSpec() = createSpec(NullPrintStream(), NullPrintStream())
+
+private val currentWorkingDir = System.getProperty("user.dir")
+
+private val expectedHelp = """
+    |Usage: detekt [options] Options to pass to the Kotlin compiler.
+    |  Options:
+    |    --all-rules
+    |      Activates all available (even unstable) rules.
+    |      Default: false
+    |    --analysis-mode
+    |      Analysis mode used by detekt. 'full' analysis mode is comprehensive but 
+    |      requires the correct compiler options to be provided. 'light' analysis 
+    |      cannot utilise compiler information and some rules cannot be run in this 
+    |      mode. 
+    |      Default: light
+    |      Possible Values: [full, light]
+    |    --api-version
+    |      Kotlin API version used by the code under analysis. Some rules use this 
+    |      information to provide more specific rule violation messages.
+    |    --auto-correct, -ac
+    |      Allow rules to auto correct code if they support it. The default rule 
+    |      sets do NOT support auto correcting and won't change any line in the 
+    |      users code base. However custom rules can be written to support auto 
+    |      correcting. The additional 'ktlint' rule set, added with '--plugins', 
+    |      does support it and needs this flag.
+    |      Default: false
+    |    --base-path, -bp
+    |      Specifies a directory as the base path.Currently it impacts all file 
+    |      paths in the formatted reports. File paths in console output are not 
+    |      affected and remain as absolute paths.
+    |      Default: $currentWorkingDir
+    |    --baseline, -b
+    |      If a baseline xml file is passed in, only new findings not in the 
+    |      baseline are printed in the console.
+    |    --build-upon-default-config
+    |      Preconfigures detekt with a bunch of rules and some opinionated defaults 
+    |      for you. Allows additional provided configurations to override the 
+    |      defaults. 
+    |      Default: false
+    |    --classpath, -cp
+    |      Paths where to find user class files and depending jar files. Used for 
+    |      type resolution.
+    |      Default: []
+    |    --config, -c
+    |      Path to the config file (path/to/config.yml). Multiple configuration 
+    |      files can be specified with ':' on *nix or ';' on Windows as separator.
+    |      Default: []
+    |    --config-resource, -cr
+    |      Path to the config resource on detekt's classpath (path/to/config.yml).
+    |      Default: []
+    |    --create-baseline, -cb
+    |      Treats current analysis findings as a smell baseline for future detekt 
+    |      runs. 
+    |      Default: false
+    |    --debug
+    |      Prints extra information about configurations and extensions.
+    |      Default: false
+    |    --disable-default-rulesets, -dd
+    |      Disables default rule sets.
+    |      Default: false
+    |    --excludes, -ex
+    |      Globbing patterns describing paths to exclude from the analysis.
+    |      Default: []
+    |    --fail-on-severity
+    |      Specifies the minimum severity that causes the build to fail. When the 
+    |      value is set to 'Never' detekt will not fail regardless of the number of 
+    |      issues and their severities.
+    |      Default: Error
+    |      Possible Values: [Error, Warning, Info, Never]
+    |    --generate-config, -gc
+    |      Export default config to the provided path.
+    |    --help, -h
+    |      Shows the usage.
+    |    --includes, -in
+    |      Globbing patterns describing paths to include in the analysis. Useful in 
+    |      combination with 'excludes' patterns.
+    |      Default: []
+    |    --input, -i
+    |      Input paths to analyze. Multiple paths are separated by ':' on *nix or 
+    |      ';' on Windows. If not specified the current working directory is used.
+    |      Default: [$currentWorkingDir]
+    |    --jdk-home
+    |      Use a custom JDK home directory to include into the classpath
+    |    --jvm-target
+    |      Target version of the generated JVM bytecode that was generated during 
+    |      compilation and is now being used for type resolution
+    |      Default: 1.8
+    |      Possible Values: [1.6, 1.8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26]
+    |    --language-version
+    |      Compatibility mode for Kotlin language version X.Y, reports errors for 
+    |      all language features that came out later
+    |      Possible Values: [1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0, 2.1, 2.2, 2.3, 2.4, 2.5]
+    |    --parallel
+    |      Enables parallel compilation and analysis of source files. Do some 
+    |      benchmarks first before enabling this flag. Heuristics show performance 
+    |      benefits starting from 2000 lines of Kotlin code.
+    |      Default: false
+    |    --plugins, -p
+    |      Extra paths to plugin jars separated by ':' on *nix or ';' on Windows.
+    |      Default: []
+    |    --report, -r
+    |      Generates a report for given 'report-id' and stores it on given 'path'. 
+    |      Entry should consist of: [report-id:path]. Available 'report-id' values: 
+    |      'checkstyle', 'html', 'md', 'sarif'. These can also be used in 
+    |      combination with each other e.g. '-r html:reports/detekt.html -r 
+    |      checkstyle:reports/detekt.xml' 
+    |      Default: []
+    |    --version
+    |      Prints the detekt CLI version.
+    |      Default: false
+""".trimMargin()

--- a/detekt-generator/src/test/kotlin/dev/detekt/generator/GeneratorArgsSpec.kt
+++ b/detekt-generator/src/test/kotlin/dev/detekt/generator/GeneratorArgsSpec.kt
@@ -1,0 +1,40 @@
+package dev.detekt.generator
+
+import com.beust.jcommander.JCommander
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class GeneratorArgsSpec {
+
+    @ParameterizedTest
+    @ValueSource(strings = ["-h", "--help"])
+    fun `parses help flag and outputs usage text`(helpFlag: String) {
+        val args = GeneratorArgs()
+        val parser = JCommander(args)
+        parser.parse(helpFlag)
+        assertThat(args.help).isTrue()
+
+        val usage = StringBuilder()
+        parser.usageFormatter.usage(usage)
+        assertThat(usage.toString().trim()).isEqualTo(expectedHelp)
+    }
+}
+
+private val expectedHelp = """
+    |Usage: <main class> [options]
+    |  Options:
+    |    --config, -c
+    |      Output path for generated detekt config.
+    |    --documentation, -d
+    |      Output path for generated documentation.
+    |    --generate-custom-rule-config, -gcrc
+    |      Generate config for user-defined rules. Path to user rules can be 
+    |      specified with --input option
+    |      Default: false
+    |    --help, -h
+    |      Shows the usage.
+    |  * --input, -i
+    |      Input paths to analyze.
+    |      Default: []
+""".trimMargin()


### PR DESCRIPTION
Helps follow-up PRs to migrate from JCommander to Clikt and verifies the full behavior of the CLIs.

Refs #9718.