### PR TITLE
Update test to avoid relying on ktlint rule set

### DIFF
--- a/detekt-cli/src/test/kotlin/dev/detekt/cli/runners/ElementPrinterSpec.kt
+++ b/detekt-cli/src/test/kotlin/dev/detekt/cli/runners/ElementPrinterSpec.kt
@@ -25,16 +25,31 @@ private val expected = """
         1: KtImportList
         3: KtClass
           3: KtClassBody
-            5: KtProperty
-              5: KtTypeReference
-              5: KtUserType
-              5: KtNameReferenceExpression
-              5: KtStringTemplateExpression
-              5: KtLiteralStringTemplateEntry
-            6: KtNamedFunction
-              6: KtParameterList
-              6: KtStringTemplateExpression
-              6: KtLiteralStringTemplateEntry
-              6: KtSimpleNameStringTemplateEntry
+            5: KtNamedFunction
+            6: KtParameterList
+              6: KtParameter
+                6: KtTypeReference
+                6: KtUserType
+                6: KtNameReferenceExpression
+              6: KtTypeReference
+              6: KtUserType
               6: KtNameReferenceExpression
+              6: KtBlockExpression
+              7: KtWhenExpression
+                7: KtNameReferenceExpression
+              8: KtWhenEntry
+                8: KtWhenConditionWithExpression
+                8: KtConstantExpression
+                8: KtReturnExpression
+                  8: KtConstantExpression
+              9: KtWhenEntry
+                9: KtWhenConditionWithExpression
+                9: KtConstantExpression
+                9: KtReturnExpression
+                  9: KtConstantExpression
+              10: KtWhenEntry
+                10: KtWhenConditionWithExpression
+                10: KtConstantExpression
+                10: KtReturnExpression
+                  10: KtConstantExpression
 """.trimIndent()

--- a/detekt-cli/src/test/resources/cases/Poko.kt
+++ b/detekt-cli/src/test/resources/cases/Poko.kt
@@ -2,8 +2,12 @@ package cases
 
 class Poko {
 
-    val name: String = "Poko"
-    fun hello() = "Hello, $name"
-
-
+    // Reports MagicNumber
+    fun test(x: Int): Int {
+        when (x) {
+            5 -> return 5
+            4 -> return 4
+            3 -> return 3
+        }
+    }
 }


### PR DESCRIPTION
Update rule to trigger MagicNumber instead of a ktlint rule. detekt-cli tests should rely only on first party rules to pass.

<!-- A similar PR may already be submitted! -->
<!-- Please search among the [Pull requests](https://github.com/detekt/detekt/pulls) before creating one. -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. Link to relevant issues if possible. -->

<!-- For more information, see the [CONTRIBUTING guide](https://github.com/detekt/detekt/blob/main/.github/CONTRIBUTING.md). -->
