### PR TITLE
Fix CouldBeSequence to suggest splitToSequence for String.split chains

### DIFF
--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
@@ -99,12 +99,11 @@ class CouldBeSequence(config: Config) :
     private fun KtCallExpression.isStringSplitCall(): Boolean {
         if (getCallNameExpression()?.getReferencedName() != SPLIT) return false
         return analyze(this) {
-            val callableId = resolveToCall()
+            resolveToCall()
                 ?.singleCallOrNull<KaCallableMemberCall<*, *>>()
                 ?.symbol
                 ?.callableId
-            callableId?.packageName == StandardClassIds.BASE_TEXT_PACKAGE &&
-                callableId.callableName.asString() == SPLIT
+                ?.packageName == StandardClassIds.BASE_TEXT_PACKAGE
         }
     }
 

--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
@@ -15,8 +15,10 @@ import org.jetbrains.kotlin.analysis.api.types.symbol
 import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtQualifiedExpression
 import org.jetbrains.kotlin.psi.psiUtil.getCallNameExpression
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForReceiver
+import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelector
 import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
 
 /**
@@ -24,12 +26,16 @@ import org.jetbrains.kotlin.psi.psiUtil.getQualifiedExpressionForSelectorOrThis
  *
  * <noncompliant>
  * listOf(1, 2, 3, 4).map { it*2 }.filter { it < 4 }.map { it*it }
+ *
+ * "a, b, c".split(",").dropWhile { it.isEmpty() }.drop(1).takeWhile { it.isNotBlank() }
  * </noncompliant>
  *
  * <compliant>
  * listOf(1, 2, 3, 4).asSequence().map { it*2 }.filter { it < 4 }.map { it*it }.toList()
  *
  * listOf(1, 2, 3, 4).map { it*2 }
+ *
+ * "a, b, c".splitToSequence(",").dropWhile { it.isEmpty() }.drop(1).takeWhile { it.isNotBlank() }
  * </compliant>
  */
 class CouldBeSequence(config: Config) :
@@ -64,8 +70,14 @@ class CouldBeSequence(config: Config) :
         }
 
         if (counter > allowedOperations) {
-            val message = "${expression.text} could be .asSequence().${expression.text}"
-            report(Finding(Entity.from(expression), message))
+            val splitCall = expression.previousChainedCall()?.takeIf { it.isStringSplitCall() }
+            if (splitCall != null) {
+                val message = "${splitCall.text} could be ${splitCall.text.replaceFirst(SPLIT, SPLIT_TO_SEQUENCE)}"
+                report(Finding(Entity.from(splitCall), message))
+            } else {
+                val message = "${expression.text} could be .asSequence().${expression.text}"
+                report(Finding(Entity.from(expression), message))
+            }
         }
     }
 
@@ -84,13 +96,36 @@ class CouldBeSequence(config: Config) :
         }
     }
 
+    private fun KtCallExpression.isStringSplitCall(): Boolean {
+        if (getCallNameExpression()?.getReferencedName() != SPLIT) return false
+        return analyze(this) {
+            val callableId = resolveToCall()
+                ?.singleCallOrNull<KaCallableMemberCall<*, *>>()
+                ?.symbol
+                ?.callableId
+            callableId?.packageName == StandardClassIds.BASE_TEXT_PACKAGE &&
+                callableId.callableName.asString() == SPLIT
+        }
+    }
+
     private fun KtExpression.nextChainedCall(): KtExpression? {
         val expression = this.getQualifiedExpressionForSelectorOrThis()
         return expression.getQualifiedExpressionForReceiver()?.selectorExpression
     }
 
+    private fun KtExpression.previousChainedCall(): KtCallExpression? {
+        val qualified = getQualifiedExpressionForSelector() ?: return null
+        return when (val receiver = qualified.receiverExpression) {
+            is KtCallExpression -> receiver
+            is KtQualifiedExpression -> receiver.selectorExpression as? KtCallExpression
+            else -> null
+        }
+    }
+
     companion object {
         private const val SEQUENCE_CLASS_STR = "kotlin.sequences.Sequence"
+        private const val SPLIT = "split"
+        private const val SPLIT_TO_SEQUENCE = "splitToSequence"
         private val listOfAllowedFunFromCollections = listOf("asSequence")
     }
 }

--- a/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
+++ b/detekt-rules-standard-library/src/main/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequence.kt
@@ -7,11 +7,14 @@ import dev.detekt.api.Finding
 import dev.detekt.api.RequiresAnalysisApi
 import dev.detekt.api.Rule
 import dev.detekt.api.config
+import dev.detekt.psi.isCalling
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.resolution.KaCallableMemberCall
 import org.jetbrains.kotlin.analysis.api.resolution.singleCallOrNull
 import org.jetbrains.kotlin.analysis.api.resolution.symbol
 import org.jetbrains.kotlin.analysis.api.types.symbol
+import org.jetbrains.kotlin.name.CallableId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.name.StandardClassIds
 import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtExpression
@@ -96,16 +99,7 @@ class CouldBeSequence(config: Config) :
         }
     }
 
-    private fun KtCallExpression.isStringSplitCall(): Boolean {
-        if (getCallNameExpression()?.getReferencedName() != SPLIT) return false
-        return analyze(this) {
-            resolveToCall()
-                ?.singleCallOrNull<KaCallableMemberCall<*, *>>()
-                ?.symbol
-                ?.callableId
-                ?.packageName == StandardClassIds.BASE_TEXT_PACKAGE
-        }
-    }
+    private fun KtCallExpression.isStringSplitCall(): Boolean = isCalling(splitCallableId)
 
     private fun KtExpression.nextChainedCall(): KtExpression? {
         val expression = this.getQualifiedExpressionForSelectorOrThis()
@@ -125,6 +119,7 @@ class CouldBeSequence(config: Config) :
         private const val SEQUENCE_CLASS_STR = "kotlin.sequences.Sequence"
         private const val SPLIT = "split"
         private const val SPLIT_TO_SEQUENCE = "splitToSequence"
+        private val splitCallableId = CallableId(StandardClassIds.BASE_TEXT_PACKAGE, Name.identifier(SPLIT))
         private val listOfAllowedFunFromCollections = listOf("asSequence")
     }
 }

--- a/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequenceSpec.kt
+++ b/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequenceSpec.kt
@@ -225,4 +225,46 @@ class CouldBeSequenceSpec(val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `String split chain should suggest splitToSequence - #9720`() {
+        val code = """
+            val text = "a, b, c"
+            val processed = text
+                .split(",")
+                .dropWhile { it.isEmpty() }
+                .drop(1)
+                .takeWhile { it.isNotBlank() }
+                .joinToString(",")
+                .trim()
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("splitToSequence")
+        assertThat(findings[0].message).doesNotContain("asSequence")
+    }
+
+    @Test
+    fun `String splitToSequence chain should not trigger rule - #9720`() {
+        val code = """
+            val text = "a, b, c"
+            val processed = text
+                .splitToSequence(",")
+                .dropWhile { it.isEmpty() }
+                .drop(1)
+                .takeWhile { it.isNotBlank() }
+                .joinToString(",")
+                .trim()
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
+
+    @Test
+    fun `String split with only allowed operations should not trigger rule`() {
+        val code = """
+            val text = "a, b, c"
+            val processed = text.split(",").map { it.trim() }.filter { it.isNotEmpty() }
+        """.trimIndent()
+        assertThat(subject.lintWithContext(env, code)).isEmpty()
+    }
 }

--- a/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequenceSpec.kt
+++ b/detekt-rules-standard-library/src/test/kotlin/dev/detekt/rules/standardlibrary/CouldBeSequenceSpec.kt
@@ -267,4 +267,55 @@ class CouldBeSequenceSpec(val env: KotlinEnvironmentContainer) {
         """.trimIndent()
         assertThat(subject.lintWithContext(env, code)).isEmpty()
     }
+
+    @Test
+    fun `custom split before long chain should suggest asSequence`() {
+        val code = """
+            class TextHolder(private val value: String) {
+                fun split(delimiter: String): List<String> = value.split(delimiter)
+            }
+
+            val processed = TextHolder("a, b, c")
+                .split(",")
+                .dropWhile { it.isEmpty() }
+                .drop(1)
+                .takeWhile { it.isNotBlank() }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("asSequence")
+        assertThat(findings[0].message).doesNotContain("splitToSequence")
+    }
+
+    @Test
+    fun `long chain after property access should suggest asSequence`() {
+        val code = """
+            class Box(val items: List<Int>)
+
+            val processed = Box(listOf(1, 2, 3, 4, 5))
+                .items
+                .map { it * 2 }
+                .filter { it > 2 }
+                .map { it + 1 }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("asSequence")
+    }
+
+    @Test
+    fun `long chain with implicit receiver has no previous qualified call`() {
+        // First `map` is the receiver of `map.filter`, not a selector, so
+        // previousChainedCall() hits getQualifiedExpressionForSelector() == null.
+        val code = """
+            val processed = listOf(1, 2, 3, 4, 5).run {
+                map { it * 2 }
+                    .filter { it > 2 }
+                    .map { it + 1 }
+            }
+        """.trimIndent()
+        val findings = subject.lintWithContext(env, code)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].message).contains("asSequence")
+    }
 }


### PR DESCRIPTION
## Summary
- Fixes #9720: when a long collection chain starts from `CharSequence.split`, `CouldBeSequence` now suggests `splitToSequence` instead of inserting `.asSequence()`.
- Updates rule docs with `split` / `splitToSequence` examples and adds regression tests.